### PR TITLE
ci: add typecheck + lint workflow, PR template, fix CORP

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,15 @@
+## Summary
+
+<!-- 1-3 bullets of what changed and why. -->
+
+## Test plan
+
+<!-- How you verified it works. Delete what doesn't apply. -->
+
+- [ ] `bun run typecheck` passes
+- [ ] Manually exercised the affected flow in the browser
+- [ ] No new console errors / network errors
+
+## Notes
+
+<!-- Anything reviewers should pay attention to: migrations, env-var changes, breaking changes, follow-ups. Delete if none. -->

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,44 @@
+name: ci
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  typecheck:
+    name: typecheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Typecheck
+        run: bun run typecheck
+
+  lint:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Lint
+        run: bun run lint

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -23,7 +23,16 @@ const ctx = await buildContext()
 const app = new Hono<HonoEnv>()
 
 app.use('*', logger())
-app.use('*', secureHeaders())
+app.use(
+  '*',
+  secureHeaders({
+    // CORP/COEP block legitimate cross-origin loads (the web app pulling images and JSON from
+    // this API). Cross-origin access control is enforced by the CORS middleware below; turning
+    // these off avoids browser-level blocks on `<img src="https://api.../api/m/...">`.
+    crossOriginResourcePolicy: false,
+    crossOriginEmbedderPolicy: false,
+  }),
+)
 app.use(
   '*',
   cors({
@@ -71,10 +80,6 @@ app.get('/api/m/*', async (c) => {
     key,
     expiresInSeconds: 60 * 60,
   })
-  // secureHeaders() defaults to `Cross-Origin-Resource-Policy: same-origin`, which makes the
-  // browser refuse to load the redirect from a different origin (`<img>` on the web app).
-  // Override here — this endpoint is intentionally cross-origin.
-  c.header('Cross-Origin-Resource-Policy', 'cross-origin')
   // Signing is microseconds; keep the redirect cache short so a bad deploy doesn't poison
   // browser caches for ages, but long enough to skip re-signing during a single page paint.
   c.header('Cache-Control', 'public, max-age=30')


### PR DESCRIPTION
## Summary

- Adds a GitHub Actions workflow (`.github/workflows/ci.yml`) that runs `bun run typecheck` and `bun run lint` on every PR to `main` and on direct pushes. Concurrency groups cancel superseded runs so only the latest commit's checks matter.
- Adds a PR template (`.github/pull_request_template.md`) with summary / test plan / notes sections so PR descriptions stay reviewable.
- Disables `Cross-Origin-Resource-Policy` and `Cross-Origin-Embedder-Policy` in `secureHeaders()` on the API. The defaults (`same-origin`) were causing `ERR_BLOCKED_BY_RESPONSE.NotSameOrigin` when the web app loaded images via the `/api/m/*` signing proxy. Cross-origin access is still gated by the CORS middleware on JSON routes.

## Test plan

- [ ] CI runs both jobs successfully on this PR
- [ ] After merge: web app images load (no more CORP errors)
- [ ] JSON API requests from the web app still work (CORS unchanged)

## Notes

After merging, enable required status checks in GitHub → Settings → Branches → rule for `main` → check `typecheck` and `lint` so future PRs can't merge red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)