### PR TITLE
Add DM message requests, admin verified-badge mgmt, and block/mute lists

### DIFF
--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -52,6 +52,7 @@ adminRoute.get('/users', async (c) => {
     banReason: u.banReason,
     banExpires: u.banExpires?.toISOString() ?? null,
     shadowBannedAt: u.shadowBannedAt?.toISOString() ?? null,
+    isVerified: u.isVerified,
     deletedAt: u.deletedAt?.toISOString() ?? null,
     createdAt: u.createdAt.toISOString(),
   }))
@@ -108,6 +109,7 @@ adminRoute.get('/users/:id', async (c) => {
       banReason: user.banReason,
       banExpires: user.banExpires?.toISOString() ?? null,
       shadowBannedAt: user.shadowBannedAt?.toISOString() ?? null,
+      isVerified: user.isVerified,
       deletedAt: user.deletedAt?.toISOString() ?? null,
       createdAt: user.createdAt.toISOString(),
     },
@@ -338,6 +340,51 @@ adminRoute.patch('/reports/:id', async (c) => {
       resolvedAt: new Date(),
     })
     .where(eq(schema.reports.id, id))
+  return c.json({ ok: true })
+})
+
+const verifySchema = z.object({
+  reason: z.string().trim().min(1).max(500).optional(),
+})
+
+// Grant a verified badge. Idempotent — re-running on an already-verified user just records
+// another audit entry. Uses the existing `warn` mod action with a privateNote so we don't
+// have to extend the mod_action enum (and its DB migration) for a one-bit flag toggle.
+adminRoute.post('/users/:id/verify', async (c) => {
+  const session = c.get('session')!
+  const { db } = c.get('ctx')
+  const id = c.req.param('id')
+  const body = verifySchema.parse(await c.req.json().catch(() => ({})))
+
+  await db.transaction(async (tx) => {
+    await tx.update(schema.users).set({ isVerified: true }).where(eq(schema.users.id, id))
+    await tx.insert(schema.moderationActions).values({
+      moderatorId: session.user.id,
+      subjectType: 'user',
+      subjectId: id,
+      action: 'warn',
+      privateNote: `verify_grant${body.reason ? `: ${body.reason}` : ''}`,
+    })
+  })
+  return c.json({ ok: true })
+})
+
+adminRoute.post('/users/:id/unverify', async (c) => {
+  const session = c.get('session')!
+  const { db } = c.get('ctx')
+  const id = c.req.param('id')
+  const body = verifySchema.parse(await c.req.json().catch(() => ({})))
+
+  await db.transaction(async (tx) => {
+    await tx.update(schema.users).set({ isVerified: false }).where(eq(schema.users.id, id))
+    await tx.insert(schema.moderationActions).values({
+      moderatorId: session.user.id,
+      subjectType: 'user',
+      subjectId: id,
+      action: 'warn',
+      privateNote: `verify_revoke${body.reason ? `: ${body.reason}` : ''}`,
+    })
+  })
   return c.json({ ok: true })
 })
 

--- a/apps/api/src/routes/dms.ts
+++ b/apps/api/src/routes/dms.ts
@@ -1,7 +1,7 @@
 import { Hono } from 'hono'
 import { streamSSE } from 'hono/streaming'
 import { z } from 'zod'
-import { and, desc, eq, inArray, isNull, lt, or, sql } from '@workspace/db'
+import { and, desc, eq, inArray, isNull, lt, ne, or, sql } from '@workspace/db'
 import { schema, type Database } from '@workspace/db'
 import { assetUrl } from '@workspace/media/s3'
 import { requireAuth, type HonoEnv } from '../middleware/session.ts'
@@ -91,10 +91,34 @@ dmsRoute.get('/stream', async (c) => {
 })
 
 // List my conversations with last-message preview, other-member info (1:1), and unread count.
+// `folder` selects between the main inbox (`requestState in ('none','accepted')`) and pending
+// message requests (`requestState='pending'`). Default is `inbox` so legacy clients don't get
+// requests mixed in. `requestCount` is always returned so the UI can render the tab badge
+// without a second round-trip.
 dmsRoute.get('/', async (c) => {
   const session = c.get('session')!
   const { db, mediaEnv } = c.get('ctx')
   const me = session.user.id
+  const folder = c.req.query('folder') === 'requests' ? 'requests' : 'inbox'
+
+  const folderFilter =
+    folder === 'requests'
+      ? eq(schema.conversationMembers.requestState, 'pending')
+      : inArray(schema.conversationMembers.requestState, ['none', 'accepted'])
+
+  // Pending requests count is always shown on the inbox tab so users can see new requests
+  // without polling /requests; one cheap aggregate is fine.
+  const [pendingRow] = await db
+    .select({ n: sql<number>`count(*)::int` })
+    .from(schema.conversationMembers)
+    .where(
+      and(
+        eq(schema.conversationMembers.userId, me),
+        isNull(schema.conversationMembers.leftAt),
+        eq(schema.conversationMembers.requestState, 'pending'),
+      ),
+    )
+  const requestCount = pendingRow?.n ?? 0
 
   const myConvs = await db
     .select({
@@ -110,12 +134,13 @@ dmsRoute.get('/', async (c) => {
       and(
         eq(schema.conversationMembers.userId, me),
         isNull(schema.conversationMembers.leftAt),
+        folderFilter,
       ),
     )
     .orderBy(desc(schema.conversations.lastMessageAt))
     .limit(50)
 
-  if (myConvs.length === 0) return c.json({ conversations: [] })
+  if (myConvs.length === 0) return c.json({ conversations: [], requestCount, folder })
 
   const convIds = myConvs.map((r) => r.conv.id)
   // postgres-js sends a JS array as one bound param; using `= ANY($1)` makes Postgres try to
@@ -199,6 +224,7 @@ dmsRoute.get('/', async (c) => {
       lastMessageAt: r.conv.lastMessageAt?.toISOString() ?? null,
       unreadCount: unreadByConv.get(r.conv.id) ?? 0,
       members: others,
+      requestState: r.member.requestState,
       lastMessage: latest
         ? {
             id: latest.id,
@@ -211,10 +237,13 @@ dmsRoute.get('/', async (c) => {
     }
   })
 
-  return c.json({ conversations })
+  return c.json({ conversations, requestCount, folder })
 })
 
-// Total unread across all my conversations. Used by sidebar badge.
+// Total unread across my non-pending conversations + a separate count of pending requests.
+// Pending-request messages are intentionally excluded from `count` so the sidebar badge
+// reflects messages the user has chosen to receive; `requestCount` lets the UI surface
+// pending requests with a distinct affordance.
 dmsRoute.get('/unread-count', async (c) => {
   const session = c.get('session')!
   const { db } = c.get('ctx')
@@ -227,13 +256,24 @@ dmsRoute.get('/unread-count', async (c) => {
     WHERE m.sender_id <> ${me}
       AND m.deleted_at IS NULL
       AND cm.left_at IS NULL
+      AND cm.request_state IN ('none', 'accepted')
       AND (
         cm.last_read_message_id IS NULL OR
         m.created_at > (SELECT created_at FROM ${schema.messages} WHERE id = cm.last_read_message_id)
       )
   `)
+  const [pendingRow] = await db
+    .select({ n: sql<number>`count(*)::int` })
+    .from(schema.conversationMembers)
+    .where(
+      and(
+        eq(schema.conversationMembers.userId, me),
+        isNull(schema.conversationMembers.leftAt),
+        eq(schema.conversationMembers.requestState, 'pending'),
+      ),
+    )
   const row = (result as unknown as Array<{ n: number }>)[0]
-  return c.json({ count: row?.n ?? 0 })
+  return c.json({ count: row?.n ?? 0, requestCount: pendingRow?.n ?? 0 })
 })
 
 // Start a conversation. With one peer (userId or userIds[0]) it find-or-creates the canonical
@@ -284,6 +324,29 @@ dmsRoute.post('/', async (c) => {
 
   const kind = peerIds.length >= 2 ? 'group' : 'dm'
 
+  // A peer's row starts as 'pending' (i.e. a message request) unless we're already mutuals
+  // — either I follow them, or they follow me. Mutuals get 'accepted' so the convo lands
+  // straight in their main inbox. Group convos opt out: joining a group is an explicit invite
+  // flow, not a cold DM, so all peers go in as 'accepted'.
+  const acceptedPeerIds = new Set<string>()
+  if (kind === 'dm') {
+    const edges = await db
+      .select({
+        followerId: schema.follows.followerId,
+        followeeId: schema.follows.followeeId,
+      })
+      .from(schema.follows)
+      .where(
+        or(
+          and(eq(schema.follows.followerId, me), inArray(schema.follows.followeeId, peerIds)),
+          and(eq(schema.follows.followeeId, me), inArray(schema.follows.followerId, peerIds)),
+        ),
+      )
+    for (const e of edges) acceptedPeerIds.add(e.followerId === me ? e.followeeId : e.followerId)
+  } else {
+    for (const id of peerIds) acceptedPeerIds.add(id)
+  }
+
   const id = await db.transaction(async (tx) => {
     const [created] = await tx
       .insert(schema.conversations)
@@ -291,17 +354,74 @@ dmsRoute.post('/', async (c) => {
       .returning({ id: schema.conversations.id })
     if (!created) throw new Error('failed_to_create_conversation')
     await tx.insert(schema.conversationMembers).values([
-      { conversationId: created.id, userId: me, role: 'admin' },
+      { conversationId: created.id, userId: me, role: 'admin', requestState: 'accepted' },
       ...peerIds.map((userId) => ({
         conversationId: created.id,
         userId,
         role: 'member' as const,
+        requestState: acceptedPeerIds.has(userId) ? ('accepted' as const) : ('pending' as const),
       })),
     ])
     return created.id
   })
 
   return c.json({ id, created: true })
+})
+
+// Accept a pending message request. Idempotent — a second call on an already-accepted
+// conversation just returns ok. Republishes a membership event so the sender sees nothing
+// special; from their side the convo was always accepted.
+dmsRoute.post('/:id/accept', async (c) => {
+  const session = c.get('session')!
+  const { db, pubsub, cache } = c.get('ctx')
+  const me = session.user.id
+  const conversationId = c.req.param('id')
+
+  const membership = await loadMembership(db, conversationId, me)
+  if (!membership) return c.json({ error: 'not_a_member' }, 403)
+  if (membership.requestState === 'declined') return c.json({ error: 'declined' }, 410)
+
+  await db
+    .update(schema.conversationMembers)
+    .set({ requestState: 'accepted' })
+    .where(
+      and(
+        eq(schema.conversationMembers.conversationId, conversationId),
+        eq(schema.conversationMembers.userId, me),
+      ),
+    )
+  // Accepting moves any messages from the requester out of the 'pending' bucket and into
+  // the unread count, so blow the cached count for this user.
+  await invalidateUnreadCounts(cache, [me])
+  await pubsub.publish(dmChannel(me), { type: 'membership', conversationId })
+  return c.json({ ok: true })
+})
+
+// Decline a pending message request. Soft-leaves the conversation so it disappears from the
+// receiver's listings and they stop accruing unread on it. Sender is not notified — declines
+// are intentionally silent. The conversation row is preserved (in case the same user later
+// gets a follow-from / accepts) but the receiver won't see further messages.
+dmsRoute.post('/:id/decline', async (c) => {
+  const session = c.get('session')!
+  const { db, pubsub, cache } = c.get('ctx')
+  const me = session.user.id
+  const conversationId = c.req.param('id')
+
+  const membership = await loadMembership(db, conversationId, me)
+  if (!membership) return c.json({ error: 'not_a_member' }, 403)
+
+  await db
+    .update(schema.conversationMembers)
+    .set({ requestState: 'declined', leftAt: new Date() })
+    .where(
+      and(
+        eq(schema.conversationMembers.conversationId, conversationId),
+        eq(schema.conversationMembers.userId, me),
+      ),
+    )
+  await invalidateUnreadCounts(cache, [me])
+  await pubsub.publish(dmChannel(me), { type: 'membership', conversationId })
+  return c.json({ ok: true })
 })
 
 // Group-only operations below. Schema enforces `kind in ('dm','group')`; we additionally guard
@@ -591,6 +711,7 @@ dmsRoute.get('/:id', async (c) => {
       title: conv.title,
       createdAt: conv.createdAt.toISOString(),
       myRole: membership.role,
+      myRequestState: membership.requestState,
       members: memberRows.map((r) => ({
         id: r.user.id,
         handle: r.user.handle,
@@ -693,6 +814,9 @@ dmsRoute.post('/:id/messages', async (c) => {
 
   const membership = await loadMembership(db, conversationId, me)
   if (!membership) return c.json({ error: 'not_a_member' }, 403)
+  // Pending requests can be previewed but not replied to — the receiver must accept first,
+  // and a declined member's row is soft-left (membership would be null above).
+  if (membership.requestState === 'pending') return c.json({ error: 'request_pending' }, 403)
 
   // Verify the media belongs to me before attaching — stops mediaId enumeration / theft.
   if (body.mediaId) {
@@ -742,9 +866,14 @@ dmsRoute.post('/:id/messages', async (c) => {
         ),
       )
 
-    // Notify everyone else still in the conversation.
+    // Notify everyone else still in the conversation. Members in 'pending' (an unaccepted
+    // message request) are skipped so cold DMs don't ring their notification bell — the
+    // request itself is surfaced via the inbox tab badge instead.
     const others = await tx
-      .select({ userId: schema.conversationMembers.userId })
+      .select({
+        userId: schema.conversationMembers.userId,
+        requestState: schema.conversationMembers.requestState,
+      })
       .from(schema.conversationMembers)
       .where(
         and(
@@ -753,10 +882,11 @@ dmsRoute.post('/:id/messages', async (c) => {
           sql`${schema.conversationMembers.userId} <> ${me}`,
         ),
       )
-    if (others.length > 0) {
+    const notifiable = others.filter((o) => o.requestState !== 'pending')
+    if (notifiable.length > 0) {
       await notify(
         tx,
-        others.map((o) => ({
+        notifiable.map((o) => ({
           userId: o.userId,
           actorId: me,
           kind: 'dm' as const,

--- a/apps/api/src/routes/me.ts
+++ b/apps/api/src/routes/me.ts
@@ -79,6 +79,75 @@ meRoute.post('/handle', async (c) => {
   return c.json({ user: toSelfDto(user, c.get('ctx').mediaEnv) })
 })
 
+// Users I've blocked. Newest first. Used by settings → Privacy so users can audit and
+// unblock without remembering exact handles.
+meRoute.get('/blocks', async (c) => {
+  const session = c.get('session')!
+  const { db, mediaEnv } = c.get('ctx')
+  const limit = Math.min(Number(c.req.query('limit') ?? 50), 100)
+  const cursor = c.req.query('cursor')
+
+  const rows = await db
+    .select({ user: schema.users, block: schema.blocks })
+    .from(schema.blocks)
+    .innerJoin(schema.users, eq(schema.users.id, schema.blocks.blockedId))
+    .where(
+      and(
+        eq(schema.blocks.blockerId, session.user.id),
+        isNull(schema.users.deletedAt),
+        cursor ? lt(schema.blocks.createdAt, new Date(cursor)) : undefined,
+      ),
+    )
+    .orderBy(desc(schema.blocks.createdAt))
+    .limit(limit)
+  const users = rows.map((r) => ({
+    id: r.user.id,
+    handle: r.user.handle,
+    displayName: r.user.displayName,
+    avatarUrl: assetUrl(mediaEnv, r.user.avatarUrl),
+    isVerified: r.user.isVerified,
+    blockedAt: r.block.createdAt.toISOString(),
+  }))
+  const nextCursor =
+    rows.length === limit ? rows[rows.length - 1]!.block.createdAt.toISOString() : null
+  return c.json({ users, nextCursor })
+})
+
+// Users I've muted, with the mute scope so the UI can show whether they're hidden from
+// feed only, notifications only, or both.
+meRoute.get('/mutes', async (c) => {
+  const session = c.get('session')!
+  const { db, mediaEnv } = c.get('ctx')
+  const limit = Math.min(Number(c.req.query('limit') ?? 50), 100)
+  const cursor = c.req.query('cursor')
+
+  const rows = await db
+    .select({ user: schema.users, mute: schema.mutes })
+    .from(schema.mutes)
+    .innerJoin(schema.users, eq(schema.users.id, schema.mutes.mutedId))
+    .where(
+      and(
+        eq(schema.mutes.muterId, session.user.id),
+        isNull(schema.users.deletedAt),
+        cursor ? lt(schema.mutes.createdAt, new Date(cursor)) : undefined,
+      ),
+    )
+    .orderBy(desc(schema.mutes.createdAt))
+    .limit(limit)
+  const users = rows.map((r) => ({
+    id: r.user.id,
+    handle: r.user.handle,
+    displayName: r.user.displayName,
+    avatarUrl: assetUrl(mediaEnv, r.user.avatarUrl),
+    isVerified: r.user.isVerified,
+    mutedAt: r.mute.createdAt.toISOString(),
+    scope: r.mute.scope,
+  }))
+  const nextCursor =
+    rows.length === limit ? rows[rows.length - 1]!.mute.createdAt.toISOString() : null
+  return c.json({ users, nextCursor })
+})
+
 // Viewer's bookmarked posts, newest bookmark first.
 meRoute.get('/bookmarks', async (c) => {
   const session = c.get('session')!

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -69,6 +69,14 @@ export const api = {
       `/api/search?q=${encodeURIComponent(q)}`,
     ),
   bookmarks: (cursor?: string) => request<FeedPage>(`/api/me/bookmarks${qs(cursor)}`),
+  blocks: (cursor?: string) =>
+    request<{ users: Array<BlockedUser>; nextCursor: string | null }>(
+      `/api/me/blocks${qs(cursor)}`,
+    ),
+  mutes: (cursor?: string) =>
+    request<{ users: Array<MutedUser>; nextCursor: string | null }>(
+      `/api/me/mutes${qs(cursor)}`,
+    ),
 
   notifications: (cursor?: string, unreadOnly = false) => {
     const tail = unreadOnly ? (cursor ? "&unread=1" : "?unread=1") : ""
@@ -88,11 +96,20 @@ export const api = {
   analyticsOverview: (days = 28) =>
     request<AnalyticsOverview>(`/api/analytics/overview?days=${days}`),
 
-  dmConversations: () =>
-    request<{ conversations: Array<DmConversation> }>("/api/dms"),
+  dmConversations: (folder: "inbox" | "requests" = "inbox") =>
+    request<{
+      conversations: Array<DmConversation>
+      requestCount: number
+      folder: "inbox" | "requests"
+    }>(`/api/dms?folder=${folder}`),
   dmConversation: (conversationId: string) =>
     request<{ conversation: DmConversationDetail }>(`/api/dms/${conversationId}`),
-  dmUnreadCount: () => request<{ count: number }>("/api/dms/unread-count"),
+  dmUnreadCount: () =>
+    request<{ count: number; requestCount: number }>("/api/dms/unread-count"),
+  dmAcceptRequest: (conversationId: string) =>
+    request<{ ok: true }>(`/api/dms/${conversationId}/accept`, { method: "POST" }),
+  dmDeclineRequest: (conversationId: string) =>
+    request<{ ok: true }>(`/api/dms/${conversationId}/decline`, { method: "POST" }),
   dmStart: (userId: string) =>
     request<{ id: string; created: boolean }>("/api/dms", {
       method: "POST",
@@ -268,6 +285,16 @@ export const api = {
       method: "POST",
       body: JSON.stringify({ role }),
     }),
+  adminVerify: (id: string, reason?: string) =>
+    request<{ ok: true }>(`/api/admin/users/${id}/verify`, {
+      method: "POST",
+      body: JSON.stringify(reason ? { reason } : {}),
+    }),
+  adminUnverify: (id: string, reason?: string) =>
+    request<{ ok: true }>(`/api/admin/users/${id}/unverify`, {
+      method: "POST",
+      body: JSON.stringify(reason ? { reason } : {}),
+    }),
   adminReports: (status?: ReportStatus, cursor?: string) => {
     const params = new URLSearchParams()
     if (status) params.set("status", status)
@@ -415,6 +442,25 @@ export interface UserListPage {
   nextCursor: string | null
 }
 
+export interface BlockedUser {
+  id: string
+  handle: string | null
+  displayName: string | null
+  avatarUrl: string | null
+  isVerified: boolean
+  blockedAt: string
+}
+
+export interface MutedUser {
+  id: string
+  handle: string | null
+  displayName: string | null
+  avatarUrl: string | null
+  isVerified: boolean
+  mutedAt: string
+  scope: "feed" | "notifications" | "both"
+}
+
 export interface SelfUser {
   id: string
   email: string
@@ -523,6 +569,8 @@ export interface DmMember {
   isVerified: boolean
 }
 
+export type DmRequestState = "none" | "pending" | "accepted" | "declined"
+
 export interface DmConversation {
   id: string
   kind: "dm" | "group"
@@ -531,6 +579,7 @@ export interface DmConversation {
   lastMessageAt: string | null
   unreadCount: number
   members: Array<DmMember>
+  requestState: DmRequestState
   lastMessage: {
     id: string
     senderId: string
@@ -546,6 +595,7 @@ export interface DmConversationDetail {
   title: string | null
   createdAt: string
   myRole: "member" | "admin"
+  myRequestState: DmRequestState
   members: Array<
     DmMember & { role: "member" | "admin"; lastReadMessageId: string | null }
   >
@@ -608,6 +658,7 @@ export interface AdminUser {
   banReason: string | null
   banExpires: string | null
   shadowBannedAt: string | null
+  isVerified: boolean
   deletedAt: string | null
   createdAt: string
 }

--- a/apps/web/src/routes/admin.users.tsx
+++ b/apps/web/src/routes/admin.users.tsx
@@ -81,6 +81,17 @@ function AdminUsers() {
     return act(u.id, () => api.adminSetRole(u.id, role as "user" | "admin" | "owner"))
   }
 
+  function toggleVerify(u: AdminUser) {
+    const verb = u.isVerified ? "Revoke verified badge from" : "Grant verified badge to"
+    const reason = window.prompt(`${verb} @${u.handle ?? u.email}? Reason (optional):`, "")
+    if (reason === null) return
+    return act(u.id, () =>
+      u.isVerified
+        ? api.adminUnverify(u.id, reason || undefined)
+        : api.adminVerify(u.id, reason || undefined),
+    )
+  }
+
   return (
     <main>
       <div className="border-b border-border p-4">
@@ -145,6 +156,11 @@ function AdminUsers() {
                   >
                     {status}
                   </span>
+                  {u.isVerified && (
+                    <span className="rounded-full bg-primary/10 px-1.5 text-[10px] font-semibold uppercase tracking-wider text-primary">
+                      verified
+                    </span>
+                  )}
                 </div>
                 <p className="text-xs text-muted-foreground">{u.email}</p>
                 {u.banReason && (
@@ -192,6 +208,14 @@ function AdminUsers() {
                       Shadow
                     </Button>
                   )}
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    disabled={busyId === u.id}
+                    onClick={() => toggleVerify(u)}
+                  >
+                    {u.isVerified ? "Unverify" : "Verify"}
+                  </Button>
                 </div>
                 {me?.role === "owner" && u.id !== me.id && (
                   <Button

--- a/apps/web/src/routes/inbox.$conversationId.tsx
+++ b/apps/web/src/routes/inbox.$conversationId.tsx
@@ -411,6 +411,18 @@ function Thread() {
         />
       )}
 
+      {conversation?.myRequestState === "pending" && (
+        <RequestBanner
+          conversationId={conversationId}
+          onAccepted={() =>
+            setConversation((prev) =>
+              prev ? { ...prev, myRequestState: "accepted" } : prev,
+            )
+          }
+          onDeclined={() => router.navigate({ to: "/inbox" })}
+        />
+      )}
+
       <div ref={scrollerRef} className="flex-1 overflow-y-auto px-4 py-4">
         {error && (
           <p className="mx-auto mb-3 max-w-prose rounded-md border border-destructive/40 bg-destructive/5 p-2 text-center text-xs text-destructive">
@@ -487,47 +499,106 @@ function Thread() {
         </div>
       )}
 
-      <form
-        onSubmit={send}
-        className="flex items-end gap-2 border-t border-border px-3 py-3"
-      >
-        <input
-          ref={fileInputRef}
-          type="file"
-          accept="image/*"
-          className="hidden"
-          onChange={onFileChange}
-        />
-        <Button
-          type="button"
-          variant="ghost"
-          aria-label="attach image"
-          disabled={sending}
-          onClick={() => fileInputRef.current?.click()}
+      {conversation?.myRequestState !== "pending" && (
+        <form
+          onSubmit={send}
+          className="flex items-end gap-2 border-t border-border px-3 py-3"
         >
-          <IconPaperclip size={18} stroke={1.75} />
-        </Button>
-        <textarea
-          ref={textareaRef}
-          value={draft}
-          onChange={(e) => {
-            setDraft(e.target.value)
-            if (e.target.value.length > 0) pingTyping()
-          }}
-          placeholder={pending ? "Add a caption…" : "Message"}
-          rows={1}
-          disabled={sending}
-          onKeyDown={onKeyDown}
-          className="flex-1 resize-none rounded-md border border-border bg-transparent px-3 py-2 text-sm leading-relaxed focus:ring-1 focus:ring-ring focus:outline-none disabled:opacity-60"
-        />
-        <Button
-          type="submit"
-          disabled={sending || (draft.trim().length === 0 && !pending)}
-        >
-          {sending ? "…" : "Send"}
-        </Button>
-      </form>
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept="image/*"
+            className="hidden"
+            onChange={onFileChange}
+          />
+          <Button
+            type="button"
+            variant="ghost"
+            aria-label="attach image"
+            disabled={sending}
+            onClick={() => fileInputRef.current?.click()}
+          >
+            <IconPaperclip size={18} stroke={1.75} />
+          </Button>
+          <textarea
+            ref={textareaRef}
+            value={draft}
+            onChange={(e) => {
+              setDraft(e.target.value)
+              if (e.target.value.length > 0) pingTyping()
+            }}
+            placeholder={pending ? "Add a caption…" : "Message"}
+            rows={1}
+            disabled={sending}
+            onKeyDown={onKeyDown}
+            className="flex-1 resize-none rounded-md border border-border bg-transparent px-3 py-2 text-sm leading-relaxed focus:ring-1 focus:ring-ring focus:outline-none disabled:opacity-60"
+          />
+          <Button
+            type="submit"
+            disabled={sending || (draft.trim().length === 0 && !pending)}
+          >
+            {sending ? "…" : "Send"}
+          </Button>
+        </form>
+      )}
     </main>
+  )
+}
+
+function RequestBanner({
+  conversationId,
+  onAccepted,
+  onDeclined,
+}: {
+  conversationId: string
+  onAccepted: () => void
+  onDeclined: () => void
+}) {
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  async function accept() {
+    setBusy(true)
+    setError(null)
+    try {
+      await api.dmAcceptRequest(conversationId)
+      onAccepted()
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "couldn't accept")
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  async function decline() {
+    if (!window.confirm("Decline this message request? The sender won't be notified.")) return
+    setBusy(true)
+    setError(null)
+    try {
+      await api.dmDeclineRequest(conversationId)
+      onDeclined()
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "couldn't decline")
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-2 border-t border-border bg-muted/30 px-4 py-3 text-xs sm:flex-row sm:items-center sm:justify-between">
+      <p className="text-muted-foreground">
+        This is a message request. Accept to start the conversation or decline to remove it.
+      </p>
+      <div className="flex items-center gap-2">
+        {error && <span className="text-destructive">{error}</span>}
+        <Button size="sm" variant="ghost" disabled={busy} onClick={decline}>
+          Decline
+        </Button>
+        <Button size="sm" disabled={busy} onClick={accept}>
+          Accept
+        </Button>
+      </div>
+    </div>
   )
 }
 

--- a/apps/web/src/routes/inbox.index.tsx
+++ b/apps/web/src/routes/inbox.index.tsx
@@ -10,16 +10,22 @@ import type { DmConversation, DmMember } from "../lib/api"
 
 export const Route = createFileRoute("/inbox/")({ component: InboxList })
 
+type Folder = "inbox" | "requests"
+
 function InboxList() {
+  const [folder, setFolder] = useState<Folder>("inbox")
   const [conversations, setConversations] = useState<Array<DmConversation> | null>(null)
+  const [requestCount, setRequestCount] = useState(0)
   const [error, setError] = useState<string | null>(null)
 
   useEffect(() => {
     let cancel = false
     async function load() {
       try {
-        const { conversations } = await api.dmConversations()
-        if (!cancel) setConversations(conversations)
+        const res = await api.dmConversations(folder)
+        if (cancel) return
+        setConversations(res.conversations)
+        setRequestCount(res.requestCount)
       } catch (e) {
         if (!cancel) setError(e instanceof Error ? e.message : "failed to load")
       }
@@ -35,7 +41,13 @@ function InboxList() {
       clearInterval(iv)
       unsubscribe()
     }
-  }, [])
+  }, [folder])
+
+  // Reset list state when the user switches tabs so the loading skeleton shows briefly
+  // instead of stale content from the other folder.
+  useEffect(() => {
+    setConversations(null)
+  }, [folder])
 
   return (
     <main>
@@ -50,6 +62,20 @@ function InboxList() {
           New
         </Button>
       </header>
+
+      <div className="flex border-b border-border text-sm">
+        <FolderTab
+          active={folder === "inbox"}
+          onClick={() => setFolder("inbox")}
+          label="Inbox"
+        />
+        <FolderTab
+          active={folder === "requests"}
+          onClick={() => setFolder("requests")}
+          label="Requests"
+          badge={requestCount}
+        />
+      </div>
 
       {error && <p className="p-4 text-sm text-destructive">{error}</p>}
       {!conversations && !error && (
@@ -70,10 +96,18 @@ function InboxList() {
       )}
       {conversations && conversations.length === 0 && (
         <div className="px-4 py-16 text-center">
-          <p className="text-sm font-semibold">No conversations yet</p>
+          <p className="text-sm font-semibold">
+            {folder === "requests" ? "No message requests" : "No conversations yet"}
+          </p>
           <p className="mt-1 text-xs text-muted-foreground">
-            Tap <span className="font-medium">New</span> above, or open someone's profile and
-            tap the message icon.
+            {folder === "requests"
+              ? "When someone you don't follow messages you, it'll appear here."
+              : (
+                  <>
+                    Tap <span className="font-medium">New</span> above, or open someone's
+                    profile and tap the message icon.
+                  </>
+                )}
           </p>
         </div>
       )}
@@ -85,6 +119,37 @@ function InboxList() {
         </ul>
       )}
     </main>
+  )
+}
+
+function FolderTab({
+  active,
+  onClick,
+  label,
+  badge,
+}: {
+  active: boolean
+  onClick: () => void
+  label: string
+  badge?: number
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`flex flex-1 items-center justify-center gap-2 px-4 py-3 text-sm transition-colors ${
+        active
+          ? "border-b-2 border-primary font-semibold text-foreground"
+          : "text-muted-foreground hover:text-foreground"
+      }`}
+    >
+      {label}
+      {badge !== undefined && badge > 0 && (
+        <span className="rounded-full bg-primary px-2 py-0.5 text-[10px] font-semibold text-primary-foreground">
+          {badge}
+        </span>
+      )}
+    </button>
   )
 }
 

--- a/apps/web/src/routes/settings.tsx
+++ b/apps/web/src/routes/settings.tsx
@@ -1,4 +1,4 @@
-import { createFileRoute, useRouter } from "@tanstack/react-router"
+import { Link, createFileRoute, useRouter } from "@tanstack/react-router"
 import { useEffect, useState } from "react"
 import { Button } from "@workspace/ui/components/button"
 import { Input } from "@workspace/ui/components/input"
@@ -10,6 +10,8 @@ import { useMe } from "../lib/me"
 import { ClaimHandle } from "../components/claim-handle"
 import { AvatarUpload } from "../components/avatar-upload"
 import { BannerUpload } from "../components/banner-upload"
+import { Avatar } from "../components/avatar"
+import type { BlockedUser, MutedUser } from "../lib/api"
 
 export const Route = createFileRoute("/settings")({ component: Settings })
 
@@ -115,6 +117,7 @@ function Settings() {
 
       <AccountSection email={me.email} />
       <SessionsSection currentSessionId={session?.session.id ?? null} />
+      <PrivacySection />
       <DangerZone onDeleted={() => router.navigate({ to: "/" })} />
 
       <form onSubmit={onSave} className="space-y-3">
@@ -351,6 +354,179 @@ function SessionsSection({ currentSessionId }: { currentSessionId: string | null
         </ul>
       )}
     </section>
+  )
+}
+
+function PrivacySection() {
+  const [tab, setTab] = useState<"blocks" | "mutes">("blocks")
+  const [blocks, setBlocks] = useState<Array<BlockedUser> | null>(null)
+  const [mutes, setMutes] = useState<Array<MutedUser> | null>(null)
+  const [busyId, setBusyId] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  async function loadBlocks() {
+    setError(null)
+    try {
+      const { users } = await api.blocks()
+      setBlocks(users)
+    } catch (e) {
+      setError(e instanceof ApiError ? e.message : "couldn't load blocks")
+    }
+  }
+
+  async function loadMutes() {
+    setError(null)
+    try {
+      const { users } = await api.mutes()
+      setMutes(users)
+    } catch (e) {
+      setError(e instanceof ApiError ? e.message : "couldn't load mutes")
+    }
+  }
+
+  useEffect(() => {
+    if (tab === "blocks" && blocks === null) loadBlocks()
+    if (tab === "mutes" && mutes === null) loadMutes()
+  }, [tab, blocks, mutes])
+
+  async function unblock(handle: string, id: string) {
+    setBusyId(id)
+    try {
+      await api.unblock(handle)
+      setBlocks((prev) => (prev ? prev.filter((u) => u.id !== id) : prev))
+    } finally {
+      setBusyId(null)
+    }
+  }
+
+  async function unmute(handle: string, id: string) {
+    setBusyId(id)
+    try {
+      await api.unmute(handle)
+      setMutes((prev) => (prev ? prev.filter((u) => u.id !== id) : prev))
+    } finally {
+      setBusyId(null)
+    }
+  }
+
+  return (
+    <section className="space-y-3 border-t border-border pt-6">
+      <h2 className="text-sm font-semibold">Privacy</h2>
+      <div className="flex gap-1">
+        <Button
+          size="sm"
+          variant={tab === "blocks" ? "default" : "ghost"}
+          onClick={() => setTab("blocks")}
+        >
+          Blocked
+          {blocks !== null && blocks.length > 0 && (
+            <span className="ml-1.5 text-xs opacity-80">{blocks.length}</span>
+          )}
+        </Button>
+        <Button
+          size="sm"
+          variant={tab === "mutes" ? "default" : "ghost"}
+          onClick={() => setTab("mutes")}
+        >
+          Muted
+          {mutes !== null && mutes.length > 0 && (
+            <span className="ml-1.5 text-xs opacity-80">{mutes.length}</span>
+          )}
+        </Button>
+      </div>
+      {error && <p className="text-xs text-destructive">{error}</p>}
+      {tab === "blocks" && (
+        <PrivacyList
+          users={blocks}
+          emptyText="You haven't blocked anyone."
+          renderTrailing={(u) => (
+            <Button
+              size="sm"
+              variant="outline"
+              disabled={busyId === u.id || !u.handle}
+              onClick={() => u.handle && unblock(u.handle, u.id)}
+            >
+              Unblock
+            </Button>
+          )}
+          renderMeta={(u) => `Blocked ${new Date(u.blockedAt).toLocaleDateString()}`}
+        />
+      )}
+      {tab === "mutes" && (
+        <PrivacyList
+          users={mutes}
+          emptyText="You haven't muted anyone."
+          renderTrailing={(u) => (
+            <Button
+              size="sm"
+              variant="outline"
+              disabled={busyId === u.id || !u.handle}
+              onClick={() => u.handle && unmute(u.handle, u.id)}
+            >
+              Unmute
+            </Button>
+          )}
+          renderMeta={(u) => `${labelForScope(u.scope)} · ${new Date(u.mutedAt).toLocaleDateString()}`}
+        />
+      )}
+    </section>
+  )
+}
+
+function labelForScope(scope: "feed" | "notifications" | "both"): string {
+  if (scope === "both") return "Feed + notifications"
+  if (scope === "notifications") return "Notifications only"
+  return "Feed only"
+}
+
+function PrivacyList<T extends { id: string; handle: string | null; displayName: string | null; avatarUrl: string | null }>({
+  users,
+  emptyText,
+  renderTrailing,
+  renderMeta,
+}: {
+  users: Array<T> | null
+  emptyText: string
+  renderTrailing: (u: T) => React.ReactNode
+  renderMeta: (u: T) => string
+}) {
+  if (users === null) {
+    return <p className="text-xs text-muted-foreground">loading…</p>
+  }
+  if (users.length === 0) {
+    return <p className="text-xs text-muted-foreground">{emptyText}</p>
+  }
+  return (
+    <ul className="divide-y divide-border rounded-md border border-border">
+      {users.map((u) => (
+        <li key={u.id} className="flex items-center justify-between gap-3 px-3 py-2">
+          <div className="flex min-w-0 items-center gap-2">
+            <Avatar
+              initial={(u.displayName || u.handle || "?").slice(0, 1).toUpperCase()}
+              src={u.avatarUrl}
+              className="size-8 shrink-0"
+            />
+            <div className="min-w-0">
+              {u.handle ? (
+                <Link
+                  to="/$handle"
+                  params={{ handle: u.handle }}
+                  className="block truncate text-sm font-medium hover:underline"
+                >
+                  {u.displayName ?? `@${u.handle}`}
+                </Link>
+              ) : (
+                <span className="block truncate text-sm font-medium">
+                  {u.displayName ?? "Unknown user"}
+                </span>
+              )}
+              <p className="truncate text-xs text-muted-foreground">{renderMeta(u)}</p>
+            </div>
+          </div>
+          {renderTrailing(u)}
+        </li>
+      ))}
+    </ul>
   )
 }
 

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -1,4 +1,4 @@
 export * as schema from './schema/index.ts'
 export { createDb, createDbFromEnv } from './client.ts'
 export type { Database } from './client.ts'
-export { sql, eq, and, or, not, desc, asc, gt, gte, lt, lte, inArray, isNull, isNotNull, like, ilike } from 'drizzle-orm'
+export { sql, eq, ne, and, or, not, desc, asc, gt, gte, lt, lte, inArray, isNull, isNotNull, like, ilike } from 'drizzle-orm'


### PR DESCRIPTION
Three feature gaps surfaced during a second-pass codebase audit, all built
end-to-end and not covered by any of the open PRs:

DM message requests
- conversation_members.request_state was already in the schema (enum: none /
  pending / accepted / declined) but completely unused. Wired it up:
  - Starting a 1:1 with someone who isn't a mutual sets the receiver's row to
    'pending'; mutuals get 'accepted'. Group joins always 'accepted'.
  - GET /api/dms takes ?folder=inbox|requests; default 'inbox' filters to
    none/accepted so legacy clients are unaffected. Both responses include
    requestCount for the tab badge.
  - GET /api/dms/unread-count excludes pending convos from `count` and
    returns a separate `requestCount`.
  - POST /api/dms/:id/accept and /decline (decline soft-leaves the receiver).
  - Replies are blocked while `requestState='pending'`; sender->receiver
    notifications skip pending receivers so cold DMs don't ring the bell.
- Inbox UI gains Inbox/Requests tabs with badge. Conversation thread renders
  an Accept/Decline banner when the viewer's request_state is 'pending', and
  hides the composer until accepted.

Admin verified-badge management
- users.is_verified existed but had no admin surface. Added
  POST /api/admin/users/:id/verify and /unverify, both audit-logged via
  moderation_actions (uses the existing `warn` action with a privateNote
  prefix so we don't have to extend the mod_action enum).
- Admin user list now exposes is_verified, shows a 'verified' chip, and
  surfaces a Verify/Unverify toggle button.

Block & mute lists
- Schema already supported blocks and mutes, but users had no way to see
  who they'd blocked/muted or to undo without remembering exact handles.
  Added GET /api/me/blocks and GET /api/me/mutes (paginated, newest-first,
  filtering soft-deleted users). Mutes include scope (feed / notifications /
  both) so the UI can show what the mute actually does.
- Settings → Privacy section with Blocked / Muted tabs, inline unblock and
  unmute actions, and per-row metadata (blocked-since, mute scope).

Also exports `ne` from @workspace/db for use in DM filters.