### PR TITLE
Show verified badge next to user names across the app

### DIFF
--- a/apps/api/src/routes/invites.ts
+++ b/apps/api/src/routes/invites.ts
@@ -46,6 +46,7 @@ invitesRoute.get('/:token', async (c) => {
           handle: r.user.handle,
           displayName: r.user.displayName,
           avatarUrl: assetUrl(mediaEnv, r.user.avatarUrl),
+          isVerified: r.user.isVerified,
         })),
       },
       expiresAt: invite.invite.expiresAt?.toISOString() ?? null,

--- a/apps/web/src/components/compose.tsx
+++ b/apps/web/src/components/compose.tsx
@@ -6,6 +6,7 @@ import { ApiError, api } from "../lib/api"
 import { setAltText, uploadImage } from "../lib/media"
 import { clearDraft, draftKey, loadDraft, saveDraft } from "../lib/drafts"
 import { useMe } from "../lib/me"
+import { VerifiedBadge } from "./verified-badge"
 import type { Post } from "../lib/api"
 import type { UploadedMedia } from "../lib/media"
 
@@ -173,8 +174,9 @@ export function Compose({
         {quoted && (
           <div className="mt-2 rounded-md border border-border p-3 text-sm">
             <div className="flex items-center gap-2 text-xs text-muted-foreground">
-              <span className="font-medium text-foreground">
+              <span className="flex items-center gap-1 font-medium text-foreground">
                 {quoted.author.displayName || `@${quoted.author.handle ?? "unknown"}`}
+                {quoted.author.isVerified && <VerifiedBadge size={13} />}
               </span>
               {quoted.author.handle && <span>@{quoted.author.handle}</span>}
             </div>

--- a/apps/web/src/components/post-card.tsx
+++ b/apps/web/src/components/post-card.tsx
@@ -38,6 +38,7 @@ import { ReportDialog } from "./report-dialog"
 import { Avatar } from "./avatar"
 import { ImageLightbox } from "./image-lightbox"
 import { Compose } from "./compose"
+import { VerifiedBadge } from "./verified-badge"
 import type { Post } from "../lib/api"
 
 function relativeTime(iso: string): string {
@@ -131,8 +132,9 @@ function QuoteEmbed({ post }: { post: Post }) {
       <div className="flex gap-3 p-3">
         <div className="min-w-0 flex-1">
           <div className="flex items-center gap-2 text-xs">
-            <span className="font-semibold text-foreground">
+            <span className="flex items-center gap-1 font-semibold text-foreground">
               {post.author.displayName || `@${handle ?? "unknown"}`}
+              {post.author.isVerified && <VerifiedBadge size={13} />}
             </span>
             {handle && <span className="text-muted-foreground">@{handle}</span>}
             <span className="text-muted-foreground">·</span>
@@ -413,9 +415,12 @@ export function PostCard({
           className="mb-2 ml-10 flex items-center gap-1.5 text-xs text-muted-foreground hover:underline"
         >
           <IconRepeat size={14} stroke={1.75} />
-          <span>
-            Reposted by{" "}
-            {outerPost.author.displayName || `@${outerPost.author.handle}`}
+          <span className="flex items-center gap-1">
+            <span>
+              Reposted by{" "}
+              {outerPost.author.displayName || `@${outerPost.author.handle}`}
+            </span>
+            {outerPost.author.isVerified && <VerifiedBadge size={12} />}
           </span>
         </Link>
       )}
@@ -444,13 +449,15 @@ export function PostCard({
             <Link
               to="/$handle"
               params={{ handle: authorHandle }}
-              className="font-semibold text-foreground hover:underline"
+              className="flex items-center gap-1 font-semibold text-foreground hover:underline"
             >
               {post.author.displayName || `@${authorHandle}`}
+              {post.author.isVerified && <VerifiedBadge size={15} />}
             </Link>
           ) : (
-            <span className="font-semibold text-foreground">
+            <span className="flex items-center gap-1 font-semibold text-foreground">
               {post.author.displayName ?? "unknown"}
+              {post.author.isVerified && <VerifiedBadge size={15} />}
             </span>
           )}
           {authorHandle && (

--- a/apps/web/src/components/user-list.tsx
+++ b/apps/web/src/components/user-list.tsx
@@ -1,6 +1,7 @@
 import { Link } from "@tanstack/react-router"
 import { useEffect, useState } from "react"
 import { Button } from "@workspace/ui/components/button"
+import { VerifiedBadge } from "./verified-badge"
 import type { PublicUser, UserListPage } from "../lib/api"
 
 export function UserList({
@@ -63,7 +64,10 @@ export function UserList({
             params={{ handle: u.handle }}
             className="block border-b border-border px-4 py-3 hover:bg-muted/40"
           >
-            <div className="text-sm font-medium">{u.displayName || `@${u.handle}`}</div>
+            <div className="flex items-center gap-1 text-sm font-medium">
+              <span className="truncate">{u.displayName || `@${u.handle}`}</span>
+              {u.isVerified && <VerifiedBadge size={14} />}
+            </div>
             <div className="text-xs text-muted-foreground">@{u.handle}</div>
             {u.bio && <p className="mt-1 text-xs text-muted-foreground line-clamp-2">{u.bio}</p>}
           </Link>

--- a/apps/web/src/components/user-nav.tsx
+++ b/apps/web/src/components/user-nav.tsx
@@ -25,6 +25,7 @@ import { SidebarMenuButton } from "@workspace/ui/components/sidebar"
 import { authClient } from "../lib/auth"
 import { useTheme } from "../lib/theme"
 import { Avatar } from "./avatar"
+import { VerifiedBadge } from "./verified-badge"
 import type { Theme } from "../lib/theme"
 import type { SelfUser } from "../lib/api"
 
@@ -55,8 +56,9 @@ export function UserNav({ user }: { user: SelfUser }) {
           >
             <Avatar initial={initial} src={user.avatarUrl} />
             <div className="flex min-w-0 flex-col leading-tight group-data-[collapsible=icon]:hidden">
-              <span className="truncate text-sm font-medium">
-                {displayName}
+              <span className="flex min-w-0 items-center gap-1 truncate text-sm font-medium">
+                <span className="truncate">{displayName}</span>
+                {user.isVerified && <VerifiedBadge size={14} />}
               </span>
               <span className="truncate text-xs text-muted-foreground">
                 {subtitle}
@@ -74,7 +76,10 @@ export function UserNav({ user }: { user: SelfUser }) {
         <div className="flex items-center gap-3 px-2 py-2">
           <Avatar initial={initial} src={user.avatarUrl} />
           <div className="flex min-w-0 flex-col leading-tight">
-            <span className="truncate text-sm font-medium">{displayName}</span>
+            <span className="flex min-w-0 items-center gap-1 truncate text-sm font-medium">
+              <span className="truncate">{displayName}</span>
+              {user.isVerified && <VerifiedBadge size={14} />}
+            </span>
             <span className="truncate text-xs text-muted-foreground">
               {subtitle}
             </span>

--- a/apps/web/src/components/verified-badge.tsx
+++ b/apps/web/src/components/verified-badge.tsx
@@ -1,0 +1,18 @@
+import { IconRosetteDiscountCheckFilled } from "@tabler/icons-react"
+import { cn } from "@workspace/ui/lib/utils"
+
+export function VerifiedBadge({
+  size = 16,
+  className,
+}: {
+  size?: number
+  className?: string
+}) {
+  return (
+    <IconRosetteDiscountCheckFilled
+      size={size}
+      aria-label="Verified account"
+      className={cn("inline-block shrink-0 text-sky-500", className)}
+    />
+  )
+}

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -622,6 +622,7 @@ export interface InvitePreview {
       handle: string | null
       displayName: string | null
       avatarUrl: string | null
+      isVerified: boolean
     }>
   }
   expiresAt: string | null

--- a/apps/web/src/routes/$handle.a.$slug.tsx
+++ b/apps/web/src/routes/$handle.a.$slug.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from "react"
 import { Button } from "@workspace/ui/components/button"
 import { ApiError,  api } from "../lib/api"
 import { Editor } from "../components/editor/editor"
+import { VerifiedBadge } from "../components/verified-badge"
 import { authClient } from "../lib/auth"
 import type {ArticleDto} from "../lib/api";
 
@@ -70,9 +71,10 @@ function ArticleView() {
             <Link
               to="/$handle"
               params={{ handle: article.author.handle }}
-              className="font-medium text-foreground hover:underline"
+              className="flex items-center gap-1 font-medium text-foreground hover:underline"
             >
               {article.author.displayName || `@${article.author.handle}`}
+              {article.author.isVerified && <VerifiedBadge size={14} />}
             </Link>
           )}
           <span>·</span>

--- a/apps/web/src/routes/$handle.index.tsx
+++ b/apps/web/src/routes/$handle.index.tsx
@@ -5,6 +5,7 @@ import { Feed } from "../components/feed"
 import { ProfileActions } from "../components/profile-actions"
 import { ImageLightbox } from "../components/image-lightbox"
 import { RichText } from "../components/rich-text"
+import { VerifiedBadge } from "../components/verified-badge"
 import type {PublicProfile} from "../lib/api";
 
 export const Route = createFileRoute("/$handle/")({ component: Profile })
@@ -92,7 +93,10 @@ function Profile() {
           </div>
         </div>
         <div className="mt-3">
-          <h1 className="text-xl font-semibold">{displayName}</h1>
+          <h1 className="flex items-center gap-1.5 text-xl font-semibold">
+            {displayName}
+            {user.isVerified && <VerifiedBadge size={20} />}
+          </h1>
           <p className="text-sm text-muted-foreground">@{user.handle}</p>
         </div>
         {user.bio && (

--- a/apps/web/src/routes/admin.users.tsx
+++ b/apps/web/src/routes/admin.users.tsx
@@ -4,6 +4,7 @@ import { Button } from "@workspace/ui/components/button"
 import {  api } from "../lib/api"
 import { useMe } from "../lib/me"
 import { Avatar } from "../components/avatar"
+import { VerifiedBadge } from "../components/verified-badge"
 import type {AdminUser} from "../lib/api";
 
 export const Route = createFileRoute("/admin/users")({ component: AdminUsers })
@@ -132,13 +133,15 @@ function AdminUsers() {
                     <Link
                       to="/$handle"
                       params={{ handle: u.handle }}
-                      className="text-sm font-semibold hover:underline"
+                      className="flex items-center gap-1 text-sm font-semibold hover:underline"
                     >
                       {u.displayName ?? u.handle}
+                      {u.isVerified && <VerifiedBadge size={14} />}
                     </Link>
                   ) : (
-                    <span className="text-sm font-semibold">
+                    <span className="flex items-center gap-1 text-sm font-semibold">
                       {u.displayName ?? u.email}
+                      {u.isVerified && <VerifiedBadge size={14} />}
                     </span>
                   )}
                   {u.handle && (

--- a/apps/web/src/routes/inbox.$conversationId.tsx
+++ b/apps/web/src/routes/inbox.$conversationId.tsx
@@ -25,6 +25,7 @@ import { api } from "../lib/api"
 import { authClient } from "../lib/auth"
 import { Avatar } from "../components/avatar"
 import { ImageLightbox } from "../components/image-lightbox"
+import { VerifiedBadge } from "../components/verified-badge"
 import { subscribeToDmStream } from "../lib/dm-stream"
 import {
   MAX_UPLOAD_BYTES,
@@ -1051,8 +1052,11 @@ function ThreadHeader({
         />
       )}
       <div className="min-w-0">
-        <div className="truncate text-sm font-semibold">
-          {peer?.displayName || (peer?.handle ? `@${peer.handle}` : "Conversation")}
+        <div className="flex items-center gap-1 text-sm font-semibold">
+          <span className="truncate">
+            {peer?.displayName || (peer?.handle ? `@${peer.handle}` : "Conversation")}
+          </span>
+          {peer?.isVerified && <VerifiedBadge size={14} />}
         </div>
         {peer?.handle && (
           <Link
@@ -1210,13 +1214,16 @@ function GroupSettingsDialog({
                     className="size-7"
                   />
                   <div className="min-w-0 flex-1">
-                    <div className="truncate font-medium">
-                      {m.displayName || (m.handle ? `@${m.handle}` : m.id.slice(0, 8))}
+                    <div className="flex flex-wrap items-center gap-1 font-medium">
+                      <span className="truncate">
+                        {m.displayName || (m.handle ? `@${m.handle}` : m.id.slice(0, 8))}
+                      </span>
+                      {m.isVerified && <VerifiedBadge size={13} />}
                       {m.role === "admin" && (
-                        <span className="ml-1 text-xs text-muted-foreground">(admin)</span>
+                        <span className="text-xs text-muted-foreground">(admin)</span>
                       )}
                       {m.id === me && (
-                        <span className="ml-1 text-xs text-muted-foreground">(you)</span>
+                        <span className="text-xs text-muted-foreground">(you)</span>
                       )}
                     </div>
                   </div>
@@ -1259,8 +1266,11 @@ function GroupSettingsDialog({
                           className="size-7"
                         />
                         <div className="min-w-0 flex-1">
-                          <div className="truncate font-medium">
-                            {u.displayName || (u.handle ? `@${u.handle}` : u.id.slice(0, 8))}
+                          <div className="flex items-center gap-1 font-medium">
+                            <span className="truncate">
+                              {u.displayName || (u.handle ? `@${u.handle}` : u.id.slice(0, 8))}
+                            </span>
+                            {u.isVerified && <VerifiedBadge size={13} />}
                           </div>
                           {u.handle && (
                             <div className="truncate text-xs text-muted-foreground">

--- a/apps/web/src/routes/inbox.index.tsx
+++ b/apps/web/src/routes/inbox.index.tsx
@@ -5,6 +5,7 @@ import { Button } from "@workspace/ui/components/button"
 import { Skeleton, SkeletonAvatar } from "@workspace/ui/components/skeleton"
 import { api } from "../lib/api"
 import { Avatar } from "../components/avatar"
+import { VerifiedBadge } from "../components/verified-badge"
 import { subscribeToDmStream } from "../lib/dm-stream"
 import type { DmConversation, DmMember } from "../lib/api"
 
@@ -160,6 +161,8 @@ function ConversationRow({ conversation }: { conversation: DmConversation }) {
   const ts = conversation.lastMessageAt
     ? new Date(conversation.lastMessageAt).toLocaleString()
     : ""
+  const peer =
+    !isGroup && !conversation.title ? conversation.members.at(0) : null
 
   return (
     <li>
@@ -171,7 +174,10 @@ function ConversationRow({ conversation }: { conversation: DmConversation }) {
         <ConversationAvatar conversation={conversation} />
         <div className="min-w-0 flex-1">
           <div className="flex items-baseline justify-between gap-2">
-            <span className="truncate text-sm font-semibold">{title}</span>
+            <span className="flex min-w-0 items-center gap-1 text-sm font-semibold">
+              <span className="truncate">{title}</span>
+              {peer?.isVerified && <VerifiedBadge size={14} />}
+            </span>
             <time className="shrink-0 text-xs text-muted-foreground">{ts}</time>
           </div>
           <p className="truncate text-sm text-muted-foreground">

--- a/apps/web/src/routes/inbox.new.tsx
+++ b/apps/web/src/routes/inbox.new.tsx
@@ -4,6 +4,7 @@ import { IconX } from "@tabler/icons-react"
 import { Button } from "@workspace/ui/components/button"
 import { api } from "../lib/api"
 import { Avatar } from "../components/avatar"
+import { VerifiedBadge } from "../components/verified-badge"
 import type { PublicUser } from "../lib/api"
 
 export const Route = createFileRoute("/inbox/new")({ component: NewConversation })
@@ -91,8 +92,9 @@ function NewConversation() {
                   src={u.avatarUrl}
                   className="size-5"
                 />
-                <span className="font-medium">
+                <span className="flex items-center gap-1 font-medium">
                   {u.displayName || (u.handle ? `@${u.handle}` : u.id.slice(0, 8))}
+                  {u.isVerified && <VerifiedBadge size={12} />}
                 </span>
                 <button
                   type="button"
@@ -151,8 +153,11 @@ function NewConversation() {
                     className="size-8"
                   />
                   <div className="min-w-0 flex-1">
-                    <div className="truncate text-sm font-medium">
-                      {u.displayName || (u.handle ? `@${u.handle}` : u.id.slice(0, 8))}
+                    <div className="flex items-center gap-1 text-sm font-medium">
+                      <span className="truncate">
+                        {u.displayName || (u.handle ? `@${u.handle}` : u.id.slice(0, 8))}
+                      </span>
+                      {u.isVerified && <VerifiedBadge size={14} />}
                     </div>
                     {u.handle && (
                       <div className="truncate text-xs text-muted-foreground">

--- a/apps/web/src/routes/invite.$token.tsx
+++ b/apps/web/src/routes/invite.$token.tsx
@@ -4,6 +4,7 @@ import { Button } from "@workspace/ui/components/button"
 import { ApiError, api } from "../lib/api"
 import { authClient } from "../lib/auth"
 import { Avatar } from "../components/avatar"
+import { VerifiedBadge } from "../components/verified-badge"
 import type { InvitePreview } from "../lib/api"
 
 export const Route = createFileRoute("/invite/$token")({ component: InvitePage })
@@ -77,6 +78,10 @@ function InvitePage() {
       .slice(0, 3)
       .map((m) => m.displayName ?? (m.handle ? `@${m.handle}` : "user"))
       .join(", ")
+  const soloPeer =
+    conv.kind === "dm" && !conv.title && conv.previewMembers.length === 1
+      ? conv.previewMembers[0]
+      : null
 
   return (
     <main className="mx-auto max-w-md px-4 py-16">
@@ -91,7 +96,10 @@ function InvitePage() {
             />
           ))}
         </div>
-        <h1 className="text-lg font-semibold">{title}</h1>
+        <h1 className="flex items-center justify-center gap-1.5 text-lg font-semibold">
+          {title}
+          {soloPeer?.isVerified && <VerifiedBadge size={16} />}
+        </h1>
         <p className="mt-1 text-xs text-muted-foreground">
           {conv.kind === "group" ? "Group conversation" : "Conversation"} ·{" "}
           {conv.memberCount} member{conv.memberCount === 1 ? "" : "s"}

--- a/apps/web/src/routes/notifications.tsx
+++ b/apps/web/src/routes/notifications.tsx
@@ -12,6 +12,7 @@ import { Button } from "@workspace/ui/components/button"
 import { Skeleton, SkeletonAvatar } from "@workspace/ui/components/skeleton"
 import {  api } from "../lib/api"
 import { authClient } from "../lib/auth"
+import { VerifiedBadge } from "../components/verified-badge"
 import type {NotificationItem} from "../lib/api";
 
 export const Route = createFileRoute("/notifications")({ component: Notifications })
@@ -151,12 +152,16 @@ function NotificationRow({ item }: { item: NotificationItem }) {
             <Link
               to="/$handle"
               params={{ handle: actorPath }}
-              className="font-semibold hover:underline"
+              className="inline-flex items-center gap-1 font-semibold align-middle hover:underline"
             >
               {actorLabel}
+              {item.actor?.isVerified && <VerifiedBadge size={14} />}
             </Link>
           ) : (
-            <span className="font-semibold">{actorLabel}</span>
+            <span className="inline-flex items-center gap-1 font-semibold align-middle">
+              {actorLabel}
+              {item.actor?.isVerified && <VerifiedBadge size={14} />}
+            </span>
           )}{" "}
           <span className="text-muted-foreground">{verb}</span>
         </p>

--- a/apps/web/src/routes/search.tsx
+++ b/apps/web/src/routes/search.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from "react"
 import { IconSearch } from "@tabler/icons-react"
 import { Input } from "@workspace/ui/components/input"
 import { PostCard } from "../components/post-card"
+import { VerifiedBadge } from "../components/verified-badge"
 import { api } from "../lib/api"
 import type { Post, PublicUser } from "../lib/api"
 
@@ -108,8 +109,11 @@ function Search() {
                     params={{ handle: u.handle }}
                     className="block border-t border-border px-4 py-3 hover:bg-muted/40"
                   >
-                    <div className="text-sm font-medium">
-                      {u.displayName || `@${u.handle}`}
+                    <div className="flex items-center gap-1 text-sm font-medium">
+                      <span className="truncate">
+                        {u.displayName || `@${u.handle}`}
+                      </span>
+                      {u.isVerified && <VerifiedBadge size={14} />}
                     </div>
                     <div className="text-xs text-muted-foreground">
                       @{u.handle}

--- a/apps/web/src/routes/settings.tsx
+++ b/apps/web/src/routes/settings.tsx
@@ -11,6 +11,7 @@ import { ClaimHandle } from "../components/claim-handle"
 import { AvatarUpload } from "../components/avatar-upload"
 import { BannerUpload } from "../components/banner-upload"
 import { Avatar } from "../components/avatar"
+import { VerifiedBadge } from "../components/verified-badge"
 import type { BlockedUser, MutedUser } from "../lib/api"
 
 export const Route = createFileRoute("/settings")({ component: Settings })
@@ -479,7 +480,7 @@ function labelForScope(scope: "feed" | "notifications" | "both"): string {
   return "Feed only"
 }
 
-function PrivacyList<T extends { id: string; handle: string | null; displayName: string | null; avatarUrl: string | null }>({
+function PrivacyList<T extends { id: string; handle: string | null; displayName: string | null; avatarUrl: string | null; isVerified: boolean }>({
   users,
   emptyText,
   renderTrailing,
@@ -511,13 +512,15 @@ function PrivacyList<T extends { id: string; handle: string | null; displayName:
                 <Link
                   to="/$handle"
                   params={{ handle: u.handle }}
-                  className="block truncate text-sm font-medium hover:underline"
+                  className="flex items-center gap-1 text-sm font-medium hover:underline"
                 >
-                  {u.displayName ?? `@${u.handle}`}
+                  <span className="truncate">{u.displayName ?? `@${u.handle}`}</span>
+                  {u.isVerified && <VerifiedBadge size={13} />}
                 </Link>
               ) : (
-                <span className="block truncate text-sm font-medium">
-                  {u.displayName ?? "Unknown user"}
+                <span className="flex items-center gap-1 text-sm font-medium">
+                  <span className="truncate">{u.displayName ?? "Unknown user"}</span>
+                  {u.isVerified && <VerifiedBadge size={13} />}
                 </span>
               )}
               <p className="truncate text-xs text-muted-foreground">{renderMeta(u)}</p>


### PR DESCRIPTION
Surfaces the existing isVerified flag with a sky-blue rosette tick
wherever a user's name appears: feed/quote/repost in post-card,
profile header, search and notification rows, article byline, user-nav
dropdown, follow/blocked/muted lists, DM peer header + member lists +
new conversation search, admin users table, and invite preview.
Adds isVerified to invitePreview previewMembers in the API so the
invite page can render the badge.