### PR TITLE
Wrap role dropdown menu items in DropdownMenuGroup

### DIFF
--- a/apps/web/src/routes/admin.users.tsx
+++ b/apps/web/src/routes/admin.users.tsx
@@ -17,6 +17,7 @@ import {
 import {
   DropdownMenu,
   DropdownMenuContent,
+  DropdownMenuGroup,
   DropdownMenuItem,
   DropdownMenuLabel,
   DropdownMenuSeparator,
@@ -179,24 +180,27 @@ function AdminUsers() {
                 <IconChevronDown className="size-3" />
               </DropdownMenuTrigger>
               <DropdownMenuContent align="start">
-                <DropdownMenuLabel>Set role</DropdownMenuLabel>
-                <DropdownMenuSeparator />
-                {ROLES.map((r) => (
-                  <DropdownMenuItem
-                    key={r}
-                    disabled={r === u.role}
-                    onClick={() =>
-                      r !== u.role && act(u.id, () => api.adminSetRole(u.id, r))
-                    }
-                  >
-                    <span className="uppercase tracking-wider">{r}</span>
-                    {r === u.role && (
-                      <span className="ml-auto text-[10px] text-muted-foreground">
-                        current
-                      </span>
-                    )}
-                  </DropdownMenuItem>
-                ))}
+                <DropdownMenuGroup>
+                  <DropdownMenuLabel>Set role</DropdownMenuLabel>
+                  <DropdownMenuSeparator />
+                  {ROLES.map((r) => (
+                    <DropdownMenuItem
+                      key={r}
+                      disabled={r === u.role}
+                      onClick={() =>
+                        r !== u.role &&
+                        act(u.id, () => api.adminSetRole(u.id, r))
+                      }
+                    >
+                      <span className="uppercase tracking-wider">{r}</span>
+                      {r === u.role && (
+                        <span className="ml-auto text-[10px] text-muted-foreground">
+                          current
+                        </span>
+                      )}
+                    </DropdownMenuItem>
+                  ))}
+                </DropdownMenuGroup>
               </DropdownMenuContent>
             </DropdownMenu>
           )


### PR DESCRIPTION
## Summary

- Wrapped the "Set role" dropdown menu items in a `DropdownMenuGroup` component for better semantic structure
- Added import for `DropdownMenuGroup` from the dropdown menu component library
- No functional changes to the user role selection behavior

## Test plan

- [ ] `bun run typecheck` passes
- [ ] Manually exercised the role dropdown in the admin users page

## Notes

This is a structural improvement to the dropdown menu component hierarchy. The `DropdownMenuGroup` provides better semantic organization of related menu items (label, separator, and role options).

https://claude.ai/code/session_01Gg5HA46awjbhTFXy8ZKF3G