### PR TITLE
Add tab navigation to switch between following and all feeds

### DIFF
--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -12,10 +12,13 @@ import type { Post } from "../lib/api"
 
 export const Route = createFileRoute("/")({ component: Landing })
 
+type FeedTab = "following" | "all"
+
 function Landing() {
   const { data: session, isPending } = authClient.useSession()
   const { me } = useMe()
   const [newPost, setNewPost] = useState<Post | null>(null)
+  const [tab, setTab] = useState<FeedTab>("following")
 
   const loadFeed = useCallback((cursor?: string) => api.feed(cursor), [])
   const loadPublic = useCallback(
@@ -51,14 +54,34 @@ function Landing() {
         ) : (
           <Compose onCreated={(p) => setNewPost(p)} />
         )}
-        <Feed
-          load={loadFeed}
-          emptyMessage="Follow people to see posts here. Try the public timeline below."
-          prependItem={newPost}
-        />
-        <section className="border-t border-border">
-          <Feed load={loadPublic} emptyMessage="No posts yet. Be the first." />
-        </section>
+        <div className="flex border-b border-border">
+          {(["following", "all"] as Array<FeedTab>).map((t) => (
+            <button
+              key={t}
+              onClick={() => setTab(t)}
+              className={`flex-1 px-4 py-3 text-sm font-medium transition ${
+                tab === t
+                  ? "border-b-2 border-primary text-foreground"
+                  : "text-muted-foreground hover:text-foreground"
+              }`}
+            >
+              {t === "following" ? "Following" : "All"}
+            </button>
+          ))}
+        </div>
+        {tab === "following" ? (
+          <Feed
+            load={loadFeed}
+            emptyMessage="Follow people to see posts here. Switch to All to see the public timeline."
+            prependItem={newPost}
+          />
+        ) : (
+          <Feed
+            load={loadPublic}
+            emptyMessage="No posts yet. Be the first."
+            prependItem={newPost}
+          />
+        )}
         </main>
       </PageFrame>
     )


### PR DESCRIPTION
## Summary

- Added a tabbed interface to the landing page allowing users to switch between "Following" and "All" feeds
- Introduced `FeedTab` type and `tab` state to track the active feed view
- Replaced the stacked feed layout with conditional rendering based on the selected tab
- Updated empty state message for the following feed to guide users to the All tab

## Test plan

- [ ] `bun run typecheck` passes
- [ ] Manually exercised the affected flow in the browser
  - Verify tab buttons render and are clickable
  - Verify switching between "Following" and "All" tabs displays the correct feed
  - Verify new posts prepend to both feeds when created
  - Verify empty state messages display appropriately for each tab
- [ ] No new console errors / network errors

## Notes

The new posts (`prependItem={newPost}`) are now prepended to both the following and all feeds, whereas previously new posts only appeared in the following feed.

https://claude.ai/code/session_01H4MREj4f1eJUDUdEeS5EDn