### PR TITLE
Redesign notifications UI with post previews and colored icons

### DIFF
--- a/apps/api/src/routes/dms.ts
+++ b/apps/api/src/routes/dms.ts
@@ -5,7 +5,7 @@ import { and, desc, eq, inArray, isNull, lt, ne, or, sql } from '@workspace/db'
 import { schema, type Database } from '@workspace/db'
 import { assetUrl } from '@workspace/media/s3'
 import { requireAuth, type HonoEnv } from '../middleware/session.ts'
-import { notify, invalidateUnreadCounts } from '../lib/notify.ts'
+import { invalidateUnreadCounts } from '../lib/notify.ts'
 import { parseCursor } from '../lib/cursor.ts'
 import { dmChannel } from '../lib/pubsub.ts'
 import { toMediaDto, type MediaDto } from '../lib/post-dto.ts'
@@ -866,14 +866,11 @@ dmsRoute.post('/:id/messages', async (c) => {
         ),
       )
 
-    // Notify everyone else still in the conversation. Members in 'pending' (an unaccepted
-    // message request) are skipped so cold DMs don't ring their notification bell — the
-    // request itself is surfaced via the inbox tab badge instead.
+    // Surface this message to every other member's session (so their inbox/unread counters
+    // refresh). DMs are intentionally NOT fanned out to the notifications table — the
+    // messages tab carries its own unread count via /api/dms/unread-count.
     const others = await tx
-      .select({
-        userId: schema.conversationMembers.userId,
-        requestState: schema.conversationMembers.requestState,
-      })
+      .select({ userId: schema.conversationMembers.userId })
       .from(schema.conversationMembers)
       .where(
         and(
@@ -882,19 +879,6 @@ dmsRoute.post('/:id/messages', async (c) => {
           sql`${schema.conversationMembers.userId} <> ${me}`,
         ),
       )
-    const notifiable = others.filter((o) => o.requestState !== 'pending')
-    if (notifiable.length > 0) {
-      await notify(
-        tx,
-        notifiable.map((o) => ({
-          userId: o.userId,
-          actorId: me,
-          kind: 'dm' as const,
-          entityType: 'conversation' as const,
-          entityId: conversationId,
-        })),
-      )
-    }
     return { message: m, otherUserIds: others.map((o) => o.userId) }
   })
 
@@ -924,13 +908,11 @@ dmsRoute.post('/:id/messages', async (c) => {
 
   // Fan-out: every member (including me, so my other tabs stay in sync) gets the event.
   const recipients = [...message.otherUserIds, me]
-  const { cache } = c.get('ctx')
-  await Promise.all([
-    ...recipients.map((userId) =>
+  await Promise.all(
+    recipients.map((userId) =>
       pubsub.publish(dmChannel(userId), { type: 'message', conversationId, message: payload }),
     ),
-    invalidateUnreadCounts(cache, message.otherUserIds),
-  ])
+  )
 
   return c.json({ message: payload })
 })

--- a/apps/api/src/routes/notifications.ts
+++ b/apps/api/src/routes/notifications.ts
@@ -1,10 +1,14 @@
 import { Hono } from 'hono'
-import { and, desc, eq, inArray, isNull, lt, sql } from '@workspace/db'
+import { and, desc, eq, inArray, isNull, lt, ne, sql } from '@workspace/db'
 import { schema } from '@workspace/db'
 import { assetUrl } from '@workspace/media/s3'
 import { requireAuth, type HonoEnv } from '../middleware/session.ts'
 import { notificationsUnreadCacheKey } from '../lib/notify.ts'
 import { parseCursor } from '../lib/cursor.ts'
+import { toPostDto, type PostDto } from '../lib/post-dto.ts'
+import { loadPostMedia } from '../lib/post-media.ts'
+import { loadArticleCards } from '../lib/article-cards.ts'
+import { loadViewerFlags } from '../lib/viewer-flags.ts'
 
 export const notificationsRoute = new Hono<HonoEnv>()
 
@@ -22,11 +26,17 @@ notificationsRoute.get('/unread-count', async (c) => {
     c.header('x-cache', 'hit')
     return c.json(hit)
   }
+  // DMs are excluded — the messages tab carries its own unread count via
+  // /api/dms/unread-count and shouldn't double-count here.
   const [row] = await db
     .select({ n: sql<number>`count(*)::int` })
     .from(schema.notifications)
     .where(
-      and(eq(schema.notifications.userId, session.user.id), isNull(schema.notifications.readAt)),
+      and(
+        eq(schema.notifications.userId, session.user.id),
+        isNull(schema.notifications.readAt),
+        ne(schema.notifications.kind, 'dm'),
+      ),
     )
   const response = { count: row?.n ?? 0 }
   await cache.set(key, response, UNREAD_COUNT_TTL_SEC)
@@ -42,6 +52,7 @@ notificationsRoute.get('/', async (c) => {
   const cursor = parseCursor(c.req.query('cursor'))
   const unreadOnly = c.req.query('unread') === '1'
 
+  // DMs aren't surfaced here — they live in the messages tab with their own unread count.
   const rows = await db
     .select({
       n: schema.notifications,
@@ -52,12 +63,52 @@ notificationsRoute.get('/', async (c) => {
     .where(
       and(
         eq(schema.notifications.userId, session.user.id),
+        ne(schema.notifications.kind, 'dm'),
         unreadOnly ? isNull(schema.notifications.readAt) : undefined,
         cursor ? lt(schema.notifications.createdAt, cursor) : undefined,
       ),
     )
     .orderBy(desc(schema.notifications.createdAt))
     .limit(limit)
+
+  // Hydrate the post referenced by each notification so the UI can render a card preview.
+  // For replies / mentions / quotes the entity is the new post that triggered the notif;
+  // for likes / reposts it's the original (recipient's) post that was engaged with.
+  const postIds = Array.from(
+    new Set(
+      rows
+        .filter((r) => r.n.entityType === 'post' && r.n.entityId)
+        .map((r) => r.n.entityId as string),
+    ),
+  )
+
+  const [postRows, mediaMap, articleMap, viewerFlags] = await Promise.all([
+    postIds.length > 0
+      ? db
+          .select({ post: schema.posts, author: schema.users })
+          .from(schema.posts)
+          .innerJoin(schema.users, eq(schema.users.id, schema.posts.authorId))
+          .where(and(inArray(schema.posts.id, postIds), isNull(schema.posts.deletedAt)))
+      : Promise.resolve([]),
+    loadPostMedia(db, postIds),
+    loadArticleCards(db, postIds),
+    loadViewerFlags(db, session.user.id, postIds),
+  ])
+
+  const postById = new Map<string, PostDto>()
+  for (const r of postRows) {
+    postById.set(
+      r.post.id,
+      toPostDto(
+        r.post,
+        r.author,
+        viewerFlags.get(r.post.id),
+        mediaMap.get(r.post.id),
+        mediaEnv,
+        articleMap.get(r.post.id),
+      ),
+    )
+  }
 
   const items = rows.map((r) => ({
     id: r.n.id,
@@ -75,6 +126,8 @@ notificationsRoute.get('/', async (c) => {
           isVerified: r.actor.isVerified,
         }
       : null,
+    target:
+      r.n.entityType === 'post' && r.n.entityId ? postById.get(r.n.entityId) ?? null : null,
   }))
   const nextCursor = rows.length === limit ? rows[rows.length - 1]!.n.createdAt.toISOString() : null
   return c.json({ notifications: items, nextCursor })

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -624,7 +624,6 @@ export interface NotificationItem {
     | "reply"
     | "mention"
     | "follow"
-    | "dm"
     | "article_reply"
     | "quote"
   createdAt: string
@@ -638,6 +637,9 @@ export interface NotificationItem {
     avatarUrl: string | null
     isVerified: boolean
   } | null
+  /** Hydrated for kinds whose entity is a post (like / repost / reply / mention / quote /
+   *  article_reply). Null when the post was deleted or the kind has no associated post. */
+  target: Post | null
 }
 
 export interface ArticleInput {

--- a/apps/web/src/routes/notifications.tsx
+++ b/apps/web/src/routes/notifications.tsx
@@ -10,11 +10,12 @@ import {
 } from "@tabler/icons-react"
 import { Button } from "@workspace/ui/components/button"
 import { Skeleton, SkeletonAvatar } from "@workspace/ui/components/skeleton"
-import {  api } from "../lib/api"
+import { api } from "../lib/api"
 import { authClient } from "../lib/auth"
+import { Avatar } from "../components/avatar"
 import { PageFrame } from "../components/page-frame"
 import { VerifiedBadge } from "../components/verified-badge"
-import type {NotificationItem} from "../lib/api";
+import type { NotificationItem, Post } from "../lib/api"
 
 export const Route = createFileRoute("/notifications")({ component: Notifications })
 
@@ -77,103 +78,176 @@ function Notifications() {
 
   return (
     <PageFrame>
-    <main>
-      <header className="sticky top-0 z-10 flex items-center justify-between border-b border-border bg-background/80 px-4 py-3 backdrop-blur-sm">
-        <h1 className="text-base font-semibold">Notifications</h1>
-        <Button
-          size="sm"
-          variant="ghost"
-          disabled={!hasUnread}
-          onClick={markAllRead}
-        >
-          Mark all read
-        </Button>
-      </header>
-      {loading ? (
-        <ul>
-          {Array.from({ length: 5 }).map((_, i) => (
-            <li
-              key={i}
-              className="flex items-start gap-3 border-b border-border px-4 py-3"
-            >
-              <SkeletonAvatar className="size-8" />
-              <div className="flex-1 space-y-2">
-                <Skeleton className="h-4 w-2/3" />
-                <Skeleton className="h-3 w-1/3" />
-              </div>
-            </li>
-          ))}
-        </ul>
-      ) : error ? (
-        <p className="p-4 text-sm text-destructive">{error}</p>
-      ) : items.length === 0 ? (
-        <div className="px-4 py-16 text-center">
-          <p className="text-sm font-semibold">All caught up</p>
-          <p className="mt-1 text-xs text-muted-foreground">
-            New likes, replies, mentions, and follows will show up here.
-          </p>
-        </div>
-      ) : (
-        <ul>
-          {items.map((n) => (
-            <NotificationRow key={n.id} item={n} />
-          ))}
-          {cursor && (
-            <li className="flex justify-center py-3">
-              <Button variant="ghost" size="sm" onClick={loadMore} disabled={loadingMore}>
-                {loadingMore ? "loading…" : "load more"}
-              </Button>
-            </li>
-          )}
-        </ul>
-      )}
-    </main>
+      <main>
+        <header className="sticky top-0 z-10 flex items-center justify-between border-b border-border bg-background/80 px-4 py-3 backdrop-blur-sm">
+          <h1 className="text-base font-semibold">Notifications</h1>
+          <Button
+            size="sm"
+            variant="ghost"
+            disabled={!hasUnread}
+            onClick={markAllRead}
+          >
+            Mark all read
+          </Button>
+        </header>
+        {loading ? (
+          <ul>
+            {Array.from({ length: 5 }).map((_, i) => (
+              <li
+                key={i}
+                className="flex items-start gap-3 border-b border-border px-4 py-3"
+              >
+                <SkeletonAvatar className="size-10" />
+                <div className="flex-1 space-y-2">
+                  <Skeleton className="h-4 w-2/3" />
+                  <Skeleton className="h-3 w-1/3" />
+                </div>
+              </li>
+            ))}
+          </ul>
+        ) : error ? (
+          <p className="p-4 text-sm text-destructive">{error}</p>
+        ) : items.length === 0 ? (
+          <div className="px-4 py-16 text-center">
+            <p className="text-sm font-semibold">All caught up</p>
+            <p className="mt-1 text-xs text-muted-foreground">
+              New likes, replies, mentions, and follows will show up here.
+            </p>
+          </div>
+        ) : (
+          <ul>
+            {items.map((n) => (
+              <NotificationRow key={n.id} item={n} />
+            ))}
+            {cursor && (
+              <li className="flex justify-center py-3">
+                <Button variant="ghost" size="sm" onClick={loadMore} disabled={loadingMore}>
+                  {loadingMore ? "loading…" : "load more"}
+                </Button>
+              </li>
+            )}
+          </ul>
+        )}
+      </main>
     </PageFrame>
   )
 }
 
 function NotificationRow({ item }: { item: NotificationItem }) {
   const Icon = iconForKind(item.kind)
+  const iconClass = iconClassForKind(item.kind)
+  const verb = verbForKind(item.kind)
   const actorLabel = item.actor
     ? item.actor.displayName || (item.actor.handle ? `@${item.actor.handle}` : "someone")
     : "someone"
-  const actorPath = item.actor?.handle ? item.actor.handle : null
-  const verb = verbForKind(item.kind)
+  const actorHandle = item.actor?.handle ?? null
+  const actorInitial = (item.actor?.displayName ?? actorHandle ?? "·")
+    .slice(0, 1)
+    .toUpperCase()
 
   return (
     <li
-      className={`flex items-start gap-3 border-b border-border px-4 py-3 transition-colors hover:bg-muted/20 ${
+      className={`border-b border-border px-4 py-3 transition-colors hover:bg-muted/20 ${
         !item.readAt ? "bg-primary/5" : ""
       }`}
     >
-      <div className="mt-0.5 flex size-8 shrink-0 items-center justify-center rounded-full bg-muted text-foreground/80">
-        <Icon size={18} stroke={1.75} />
-      </div>
-      <div className="min-w-0 flex-1 text-sm">
-        <p>
-          {actorPath ? (
-            <Link
-              to="/$handle"
-              params={{ handle: actorPath }}
-              className="inline-flex items-center gap-1 font-semibold align-middle hover:underline"
-            >
-              {actorLabel}
-              {item.actor?.isVerified && <VerifiedBadge size={14} />}
+      <div className="flex items-start gap-3">
+        <div className={`mt-0.5 flex size-8 shrink-0 items-center justify-center rounded-full ${iconClass}`}>
+          <Icon size={18} stroke={1.75} />
+        </div>
+        <div className="min-w-0 flex-1 text-sm">
+          {actorHandle ? (
+            <Link to="/$handle" params={{ handle: actorHandle }} className="inline-block">
+              <Avatar
+                initial={actorInitial}
+                src={item.actor?.avatarUrl}
+                className="size-8 ring-1 ring-border"
+              />
             </Link>
           ) : (
-            <span className="inline-flex items-center gap-1 font-semibold align-middle">
-              {actorLabel}
-              {item.actor?.isVerified && <VerifiedBadge size={14} />}
-            </span>
-          )}{" "}
-          <span className="text-muted-foreground">{verb}</span>
-        </p>
-        <time className="text-xs text-muted-foreground" dateTime={item.createdAt}>
-          {new Date(item.createdAt).toLocaleString()}
-        </time>
+            <Avatar
+              initial={actorInitial}
+              src={item.actor?.avatarUrl}
+              className="size-8 ring-1 ring-border"
+            />
+          )}
+          <p className="mt-2">
+            {actorHandle ? (
+              <Link
+                to="/$handle"
+                params={{ handle: actorHandle }}
+                className="inline-flex items-center gap-1 align-middle font-semibold hover:underline"
+              >
+                {actorLabel}
+                {item.actor?.isVerified && <VerifiedBadge size={14} />}
+              </Link>
+            ) : (
+              <span className="inline-flex items-center gap-1 align-middle font-semibold">
+                {actorLabel}
+                {item.actor?.isVerified && <VerifiedBadge size={14} />}
+              </span>
+            )}{" "}
+            <span className="text-muted-foreground">{verb}</span>
+          </p>
+          {item.target && <TargetCard post={item.target} />}
+          <time className="mt-1 block text-xs text-muted-foreground" dateTime={item.createdAt}>
+            {new Date(item.createdAt).toLocaleString()}
+          </time>
+        </div>
       </div>
     </li>
   )
+}
+
+/**
+ * Compact preview of the post a notification refers to. For likes/reposts the post is the
+ * recipient's own; for replies/mentions/quotes it's the actor's new post. We render the body
+ * (or quoted body), an optional media thumbnail, and link the whole card to the post page.
+ */
+function TargetCard({ post }: { post: Post }) {
+  const handle = post.author.handle
+  const thumb = post.media?.find((m) => m.processingState === "ready")
+  const variant =
+    thumb?.variants.find((v) => v.kind === "thumb") ??
+    thumb?.variants.find((v) => v.kind === "medium") ??
+    thumb?.variants[0]
+
+  const body = (
+    <div className="mt-2 overflow-hidden rounded-md border border-border transition hover:bg-muted/40">
+      <div className="flex gap-3 p-3">
+        <div className="min-w-0 flex-1">
+          {post.text ? (
+            <p className="line-clamp-4 text-sm leading-relaxed whitespace-pre-wrap break-words">
+              {post.text}
+            </p>
+          ) : post.articleCard ? (
+            <p className="line-clamp-2 text-sm">
+              <span className="font-semibold">{post.articleCard.title}</span>
+              {post.articleCard.subtitle && (
+                <span className="text-muted-foreground"> — {post.articleCard.subtitle}</span>
+              )}
+            </p>
+          ) : (
+            <p className="text-sm text-muted-foreground italic">[media post]</p>
+          )}
+        </div>
+        {variant && (
+          <div className="size-16 shrink-0 overflow-hidden rounded">
+            <img src={variant.url} alt="" className="h-full w-full object-cover" />
+          </div>
+        )}
+      </div>
+    </div>
+  )
+
+  if (handle) {
+    return (
+      <Link to="/$handle/p/$id" params={{ handle, id: post.id }} className="block">
+        {body}
+      </Link>
+    )
+  }
+  return body
 }
 
 function iconForKind(kind: NotificationItem["kind"]) {
@@ -184,7 +258,6 @@ function iconForKind(kind: NotificationItem["kind"]) {
       return IconRepeat
     case "reply":
     case "article_reply":
-    case "dm":
       return IconMessageCircle
     case "quote":
       return IconQuote
@@ -194,6 +267,24 @@ function iconForKind(kind: NotificationItem["kind"]) {
       return IconAt
     default:
       return IconHeart
+  }
+}
+
+function iconClassForKind(kind: NotificationItem["kind"]): string {
+  switch (kind) {
+    case "like":
+      return "bg-rose-500/10 text-rose-600"
+    case "repost":
+      return "bg-emerald-500/10 text-emerald-600"
+    case "follow":
+      return "bg-sky-500/10 text-sky-600"
+    case "quote":
+      return "bg-amber-500/10 text-amber-600"
+    case "mention":
+    case "reply":
+    case "article_reply":
+    default:
+      return "bg-muted text-foreground/80"
   }
 }
 
@@ -213,7 +304,5 @@ function verbForKind(kind: NotificationItem["kind"]): string {
       return "mentioned you in a post"
     case "article_reply":
       return "replied to your article"
-    case "dm":
-      return "sent you a message"
   }
 }


### PR DESCRIPTION
## Summary

- Redesigned the notifications list UI to display actor avatars and colored notification type icons (e.g., rose for likes, emerald for reposts)
- Added `TargetCard` component to render compact previews of posts referenced by notifications, including text, media thumbnails, and links to the full post
- Excluded DMs from the notifications tab entirely—they now live exclusively in the messages tab with their own unread count
- Updated the API to hydrate post data for notifications so the UI can render preview cards
- Fixed indentation and import formatting

## Test plan

- [x] `bun run typecheck` passes
- [x] Manually verified notifications display with avatars, colored icons, and post preview cards
- [x] Confirmed DMs no longer appear in notifications tab
- [x] Verified unread count excludes DMs
- [x] No new console errors

## Notes

- DMs are now completely removed from the notifications system. The `/api/notifications/unread-count` endpoint now explicitly filters out `kind = 'dm'` records, and the `/api/notifications` list endpoint does the same. This prevents double-counting in the UI since messages have their own unread tracking.
- The `NotificationItem` type no longer includes `"dm"` as a valid `kind` value.
- Post hydration in the API uses existing helper functions (`toPostDto`, `loadPostMedia`, `loadArticleCards`, `loadViewerFlags`) to ensure consistency with other post rendering throughout the app.

https://claude.ai/code/session_01G5TeuaW7s7nsEmPQ7iraNi