### PR TITLE
fix(settings): allow empty displayName when saving profile

### DIFF
--- a/apps/api/src/routes/me.ts
+++ b/apps/api/src/routes/me.ts
@@ -36,9 +36,10 @@ meRoute.patch('/', async (c) => {
   // treated as "clear this field" (→ null). Missing keys are left untouched.
   const patch: Partial<typeof schema.users.$inferInsert> = { updatedAt: new Date() }
   const has = (k: string) => Object.prototype.hasOwnProperty.call(raw, k)
-  if (has('displayName')) patch.displayName = body.displayName ?? null
-  if (has('bio')) patch.bio = body.bio ?? null
-  if (has('location')) patch.location = body.location ?? null
+  // Empty string from the client means "clear this field" → store NULL.
+  if (has('displayName')) patch.displayName = body.displayName || null
+  if (has('bio')) patch.bio = body.bio || null
+  if (has('location')) patch.location = body.location || null
   if (has('websiteUrl')) patch.websiteUrl = body.websiteUrl || null
   // Store the bare object key so we never have to migrate when the asset host changes.
   if (has('avatarUrl'))

--- a/apps/web/src/routes/settings.tsx
+++ b/apps/web/src/routes/settings.tsx
@@ -51,8 +51,8 @@ function Settings() {
     })
     if (!parsed.success) {
       const issue = parsed.error.issues[0]
-      const field = issue?.path?.[0]
-      setStatus(field ? `${String(field)}: ${issue.message}` : issue?.message ?? "invalid")
+      const field = issue.path[0]
+      setStatus(field ? `${String(field)}: ${issue.message}` : issue.message)
       return
     }
     try {

--- a/apps/web/src/routes/settings.tsx
+++ b/apps/web/src/routes/settings.tsx
@@ -50,7 +50,9 @@ function Settings() {
       websiteUrl,
     })
     if (!parsed.success) {
-      setStatus(parsed.error.issues[0]?.message ?? "invalid")
+      const issue = parsed.error.issues[0]
+      const field = issue?.path?.[0]
+      setStatus(field ? `${String(field)}: ${issue.message}` : issue?.message ?? "invalid")
       return
     }
     try {

--- a/packages/validators/src/users.ts
+++ b/packages/validators/src/users.ts
@@ -13,8 +13,10 @@ export const bioSchema = z.string().max(280)
 export const locationSchema = z.string().max(50)
 export const websiteSchema = z.string().url().max(200)
 
+// Profile text fields accept an empty string in update payloads to mean
+// "clear this field". The API converts empty strings to NULL before writing.
 export const updateProfileSchema = z.object({
-  displayName: displayNameSchema.optional(),
+  displayName: displayNameSchema.optional().or(z.literal('')),
   bio: bioSchema.optional(),
   location: locationSchema.optional(),
   websiteUrl: websiteSchema.optional().or(z.literal('')),


### PR DESCRIPTION
The settings form always submits displayName/bio/location/websiteUrl together. displayNameSchema requires .min(1), so users with no display name set who only change their website saw 'String must contain at least 1 character(s)' rendered just below the website field, making it look like the website itself was rejected.

- Accept '' for displayName in updateProfileSchema, matching websiteUrl, avatarUrl, etc. The /me PATCH already coerces '' to NULL.
- Coerce empty bio/location to NULL on the server too, so clearing them works consistently.
- Prefix the inline form error with the failing field path so future validation errors aren't ambiguous.

## Summary

<!-- 1-3 bullets of what changed and why. -->

## Test plan

<!-- How you verified it works. Delete what doesn't apply. -->

- [ ] `bun run typecheck` passes
- [ ] Manually exercised the affected flow in the browser
- [ ] No new console errors / network errors

## Notes

<!-- Anything reviewers should pay attention to: migrations, env-var changes, breaking changes, follow-ups. Delete if none. -->
