### PR TITLE
feat(profile): add 'Edit profile' button on your own profile

### DIFF
--- a/apps/web/src/routes/$handle.index.tsx
+++ b/apps/web/src/routes/$handle.index.tsx
@@ -1,17 +1,20 @@
 import { Link, createFileRoute } from "@tanstack/react-router"
 import { useCallback, useEffect, useState } from "react"
+import { Button } from "@workspace/ui/components/button"
 import { ApiError,  api } from "../lib/api"
 import { Feed } from "../components/feed"
 import { ProfileActions } from "../components/profile-actions"
 import { ImageLightbox } from "../components/image-lightbox"
 import { RichText } from "../components/rich-text"
 import { VerifiedBadge } from "../components/verified-badge"
+import { useMe } from "../lib/me"
 import type {PublicProfile} from "../lib/api";
 
 export const Route = createFileRoute("/$handle/")({ component: Profile })
 
 function Profile() {
   const { handle } = Route.useParams()
+  const { me } = useMe()
   const [user, setUser] = useState<PublicProfile | null>(null)
   const [error, setError] = useState<string | null>(null)
 
@@ -89,7 +92,17 @@ function Profile() {
             </div>
           </ImageLightbox>
           <div className="pb-1">
-            <ProfileActions profile={user} onChange={setUser} />
+            {me?.id === user.id ? (
+              <Button
+                size="sm"
+                variant="outline"
+                render={<Link to="/settings" hash="profile" />}
+              >
+                Edit profile
+              </Button>
+            ) : (
+              <ProfileActions profile={user} onChange={setUser} />
+            )}
           </div>
         </div>
         <div className="mt-3">

--- a/apps/web/src/routes/settings.tsx
+++ b/apps/web/src/routes/settings.tsx
@@ -40,6 +40,22 @@ function Settings() {
     setWebsiteUrl(me.websiteUrl ?? "")
   }, [me])
 
+  // After the page renders with the user's data, honor the URL hash
+  // (e.g. /settings#profile from the "Edit profile" button) by scrolling
+  // the matching section into view and focusing the first input in it.
+  useEffect(() => {
+    if (!me || typeof window === "undefined") return
+    const id = window.location.hash.slice(1)
+    if (!id) return
+    const el = document.getElementById(id)
+    if (!el) return
+    el.scrollIntoView({ behavior: "smooth", block: "start" })
+    const firstInput = el.querySelector<HTMLInputElement | HTMLTextAreaElement>(
+      "input, textarea",
+    )
+    firstInput?.focus({ preventScroll: true })
+  }, [me])
+
   async function onSave(e: React.FormEvent) {
     e.preventDefault()
     setStatus(null)
@@ -125,7 +141,7 @@ function Settings() {
       <PrivacySection />
       <DangerZone onDeleted={() => router.navigate({ to: "/" })} />
 
-      <form onSubmit={onSave} className="space-y-3">
+      <form onSubmit={onSave} id="profile" className="scroll-mt-4 space-y-3">
         <h2 className="text-sm font-semibold">Profile details</h2>
         <div className="space-y-1">
           <Label htmlFor="displayName">Display name</Label>

--- a/apps/web/src/routes/settings.tsx
+++ b/apps/web/src/routes/settings.tsx
@@ -133,6 +133,8 @@ function ProfileSection() {
     firstInput?.focus({ preventScroll: true })
   }, [me])
 
+  if (!me) return null
+
   async function onSave(e: React.FormEvent) {
     e.preventDefault()
     setStatus(null)
@@ -192,12 +194,7 @@ function ProfileSection() {
         />
       </section>
 
-      <AccountSection email={me.email} />
-      <SessionsSection currentSessionId={session?.session.id ?? null} />
-      <PrivacySection />
-      <DangerZone onDeleted={() => router.navigate({ to: "/" })} />
-
-      <form onSubmit={onSave} id="profile" className="scroll-mt-4 space-y-3">
+      <form onSubmit={onSave} id="profile" className="scroll-mt-4 space-y-3 border-t border-border pt-6">
         <h2 className="text-sm font-semibold">Profile details</h2>
         <div className="space-y-1">
           <Label htmlFor="displayName">Display name</Label>


### PR DESCRIPTION
When viewing my own profile (`me.id === user.id`), swap the follow / message / mute / block actions for an 'Edit profile' button that links to `/settings#profile`. The Profile details form on the settings page now has `id="profile"`, and the page scrolls to the hashed section and focuses its first input on load.

## Summary

<!-- 1-3 bullets of what changed and why. -->

## Test plan

<!-- How you verified it works. Delete what doesn't apply. -->

- [ ] `bun run typecheck` passes
- [ ] Manually exercised the affected flow in the browser
- [ ] No new console errors / network errors

## Notes

<!-- Anything reviewers should pay attention to: migrations, env-var changes, breaking changes, follow-ups. Delete if none. -->
