### PR TITLE
Add rich media support to thread view and export card components

### DIFF
--- a/apps/web/src/components/app-header.tsx
+++ b/apps/web/src/components/app-header.tsx
@@ -1,5 +1,6 @@
 import { useLocation, useRouter } from "@tanstack/react-router"
 import { IconArrowLeft } from "@tabler/icons-react"
+import { SidebarTrigger } from "@workspace/ui/components/sidebar"
 import { getRouteInfo } from "../lib/routes"
 
 export function AppHeader() {
@@ -10,6 +11,7 @@ export function AppHeader() {
   return (
     <header className="sticky top-0 z-10 flex justify-center border-b border-border bg-background/90 backdrop-blur-sm">
       <div className="flex w-full max-w-[620px] items-center gap-2.5 px-4 py-2.5">
+        <SidebarTrigger className="size-6" />
         {back && (
           <button
             type="button"

--- a/apps/web/src/components/post-card.tsx
+++ b/apps/web/src/components/post-card.tsx
@@ -76,7 +76,7 @@ function pickLargest(media: NonNullable<Post["media"]>[number]) {
   )
 }
 
-function ArticleCardBlock({
+export function ArticleCardBlock({
   card,
 }: {
   card: NonNullable<Post["articleCard"]>
@@ -121,7 +121,7 @@ function ArticleCardBlock({
   )
 }
 
-function QuoteEmbed({ post }: { post: Post }) {
+export function QuoteEmbed({ post }: { post: Post }) {
   const handle = post.author.handle
   const thumb = post.media?.find((m) => m.processingState === "ready")
   const variant =

--- a/apps/web/src/routes/$handle.p.$id.tsx
+++ b/apps/web/src/routes/$handle.p.$id.tsx
@@ -17,6 +17,8 @@ import { ApiError, api } from "../lib/api"
 import { useSubmitHotkey } from "../lib/hotkeys"
 import { Avatar } from "../components/avatar"
 import { RichText } from "../components/rich-text"
+import { PollBlock } from "../components/poll-block"
+import { ArticleCardBlock, QuoteEmbed } from "../components/post-card"
 import { useMe } from "../lib/me"
 import type { Post, Thread } from "../lib/api"
 
@@ -266,6 +268,20 @@ function AncestorPost({
             </div>
           )}
 
+          {/* Article card */}
+          {post.articleCard && <ArticleCardBlock card={post.articleCard} />}
+
+          {/* Poll */}
+          {post.poll && (
+            <PollBlock
+              poll={post.poll}
+              onChange={(nextPoll) => onChange({ ...post, poll: nextPoll })}
+            />
+          )}
+
+          {/* Quote embed */}
+          {post.quoteOf && <QuoteEmbed post={post.quoteOf} />}
+
           {/* Action bar */}
           <div className="mt-2.5 flex items-center gap-5 text-muted-foreground">
             {authorHandle && (
@@ -420,6 +436,20 @@ function ParentPost({ post, onChange, hasAncestors }: { post: Post; onChange: (p
           })}
         </div>
       )}
+
+      {/* Article card */}
+      {post.articleCard && <ArticleCardBlock card={post.articleCard} />}
+
+      {/* Poll */}
+      {post.poll && (
+        <PollBlock
+          poll={post.poll}
+          onChange={(nextPoll) => onChange({ ...post, poll: nextPoll })}
+        />
+      )}
+
+      {/* Quote embed */}
+      {post.quoteOf && <QuoteEmbed post={post.quoteOf} />}
 
       {/* Activity stats row */}
       <div className="mt-2.5 flex items-center gap-3 font-mono text-[11px] text-muted-foreground">
@@ -670,6 +700,37 @@ function ReplyCard({ post, onChange }: { post: Post; onChange: (p: Post) => void
       <p className="mt-1.5 text-[13.5px] leading-[1.55] whitespace-pre-wrap break-words">
         <RichText text={post.text} />
       </p>
+
+      {/* Media grid if present */}
+      {post.media && post.media.length > 0 && (
+        <div
+          className={`mt-2 grid gap-px overflow-hidden rounded-sm border border-border ${post.media.length === 1 ? "grid-cols-1" : "grid-cols-2"}`}
+          onClick={(e) => e.stopPropagation()}
+        >
+          {post.media.map((m) => {
+            const variant = m.variants.find((v) => v.kind === "medium") ?? m.variants[0]
+            return (
+              <div key={m.id} className="aspect-video bg-muted">
+                {m.processingState === "ready" && (
+                  <img src={variant.url} alt={m.altText ?? ""} className="h-full w-full object-cover" />
+                )}
+              </div>
+            )
+          })}
+        </div>
+      )}
+
+      {/* biome-ignore lint/a11y/useKeyWithClickEvents: stops parent Link from intercepting interactions */}
+      <div onClick={(e) => e.stopPropagation()}>
+        {post.articleCard && <ArticleCardBlock card={post.articleCard} />}
+        {post.poll && (
+          <PollBlock
+            poll={post.poll}
+            onChange={(nextPoll) => onChange({ ...post, poll: nextPoll })}
+          />
+        )}
+        {post.quoteOf && <QuoteEmbed post={post.quoteOf} />}
+      </div>
 
       {/* Action bar - stopPropagation to prevent navigation */}
       {/* biome-ignore lint/a11y/useKeyWithClickEvents: action bar wrapper */}

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "start-monorepo",


### PR DESCRIPTION
## Summary

- Added rendering support for article cards, polls, and quote embeds in the ancestor post, parent post, and reply card components within the thread view
- Exported `ArticleCardBlock` and `QuoteEmbed` components from post-card for reuse across the codebase
- Added media grid rendering to reply cards to display images/videos
- Added `SidebarTrigger` to the app header for mobile navigation

## Test plan

- [ ] `bun run typecheck` passes
- [ ] Manually exercised thread view with posts containing article cards, polls, and quote embeds
- [ ] Verified reply cards display media grids correctly
- [ ] No new console errors / network errors

## Notes

The changes consolidate rich media rendering across different post display contexts (ancestor, parent, and reply cards) by reusing the exported card components. Event propagation is properly stopped on interactive elements to prevent unintended navigation.

https://claude.ai/code/session_01XhzuMZZEutDuyEi7hqhfua