### PR TITLE
Add build job to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,3 +42,19 @@ jobs:
 
       - name: Lint
         run: bun run lint
+
+  build:
+    name: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Build
+        run: bun run build


### PR DESCRIPTION
## Summary

- Added a new `build` job to the CI workflow that runs after linting
- The job installs dependencies and runs the build script to ensure the project builds successfully
- This provides early feedback on build failures in the CI pipeline

## Test plan

- CI workflow executes successfully with the new build job
- Build step completes without errors

## Notes

The build job runs on `ubuntu-latest` and uses the same Bun setup as the existing lint job. It uses `--frozen-lockfile` to ensure reproducible builds.

https://claude.ai/code/session_0148dpqc2LUp4AsfMLH3rGAo