### PR TITLE
Render rich text formatting in direct messages

### DIFF
--- a/apps/web/src/routes/inbox.$conversationId.tsx
+++ b/apps/web/src/routes/inbox.$conversationId.tsx
@@ -26,6 +26,7 @@ import { authClient } from "../lib/auth"
 import { Avatar } from "../components/avatar"
 import { ImageLightbox } from "../components/image-lightbox"
 import { PageFrame } from "../components/page-frame"
+import { RichText } from "../components/rich-text"
 import { VerifiedBadge } from "../components/verified-badge"
 import { subscribeToDmStream } from "../lib/dm-stream"
 import {
@@ -934,7 +935,11 @@ function Bubble({
           ) : (
             <>
               {message.media && <MessageImage media={message.media} />}
-              {message.text && <p className="break-words whitespace-pre-wrap">{message.text}</p>}
+              {message.text && (
+                <p className="break-words whitespace-pre-wrap">
+                  <RichText text={message.text} />
+                </p>
+              )}
               {!message.media && !message.text && <em className="opacity-70">[unsupported]</em>}
             </>
           )}


### PR DESCRIPTION
## Summary

- Added `RichText` component to render formatted text in direct messages
- Updated the message bubble to use `RichText` component for message text instead of plain text rendering
- Enables support for rich text formatting (links, bold, italic, etc.) in DM conversations

## Test plan

- [ ] `bun run typecheck` passes
- [ ] Manually exercised the affected flow in the browser
- [ ] No new console errors / network errors

## Notes

The `RichText` component is now used to process and render message text, allowing for formatted content in direct messages while maintaining the existing break-words and whitespace-pre-wrap styling.

https://claude.ai/code/session_01U4WAdBgUPmxvjpJ9MuyEYF