### PR TITLE
Migrate Feed component to TanStack Query for data fetching

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -23,6 +23,7 @@
     "@tabler/icons-react": "^3.41.1",
     "@tailwindcss/vite": "^4.1.18",
     "@tanstack/react-hotkeys": "^0.9.1",
+    "@tanstack/react-query": "^5.100.3",
     "@tanstack/react-router": "^1.132.0",
     "@tanstack/react-start": "^1.132.0",
     "@tanstack/react-table": "^8.21.3",

--- a/apps/web/src/components/feed.tsx
+++ b/apps/web/src/components/feed.tsx
@@ -1,10 +1,15 @@
-import { useEffect, useState } from "react"
+import { useEffect, useMemo } from "react"
+import { useInfiniteQuery, useQueryClient } from "@tanstack/react-query"
 import { Button } from "@workspace/ui/components/button"
 import { SkeletonPostCard } from "@workspace/ui/components/skeleton"
 import { PostCard } from "./post-card"
+import type { InfiniteData } from "@tanstack/react-query"
 import type { FeedPage, Post } from "../lib/api"
 
+type FeedQueryKey = ReadonlyArray<unknown>
+
 export function Feed({
+  queryKey,
   load,
   emptyMessage = "Nothing here yet.",
   prependItem,
@@ -13,6 +18,7 @@ export function Feed({
   onOpenThread,
   activePostId,
 }: {
+  queryKey: FeedQueryKey
   load: (cursor?: string) => Promise<FeedPage>
   emptyMessage?: string
   prependItem?: Post | null
@@ -21,65 +27,83 @@ export function Feed({
   onOpenThread?: (post: Post) => void
   activePostId?: string
 }) {
-  const [posts, setPosts] = useState<Array<Post>>([])
-  const [cursor, setCursor] = useState<string | null>(null)
-  const [loading, setLoading] = useState(true)
-  const [error, setError] = useState<string | null>(null)
-  const [loadingMore, setLoadingMore] = useState(false)
+  const queryClient = useQueryClient()
+  const queryKeyHash = JSON.stringify(queryKey)
 
-  const filterPosts = (posts: Array<Post>) => {
-    if (hideReplies) return posts.filter((p) => !p.replyToId)
-    if (onlyReplies) return posts.filter((p) => p.replyToId)
-    return posts
-  }
-
-  useEffect(() => {
-    let cancel = false
-    setLoading(true)
-    load()
-      .then((page) => {
-        if (cancel) return
-        setPosts(filterPosts(page.posts))
-        setCursor(page.nextCursor)
-      })
-      .catch((e) => {
-        if (!cancel) setError(e instanceof Error ? e.message : "failed to load")
-      })
-      .finally(() => {
-        if (!cancel) setLoading(false)
-      })
-    return () => {
-      cancel = true
-    }
-  }, [hideReplies, load, onlyReplies])
+  const {
+    data,
+    error,
+    isPending,
+    fetchNextPage,
+    isFetchingNextPage,
+    hasNextPage,
+  } = useInfiniteQuery<FeedPage, Error, InfiniteData<FeedPage, string | undefined>, FeedQueryKey, string | undefined>({
+    queryKey,
+    queryFn: ({ pageParam }) => load(pageParam),
+    initialPageParam: undefined,
+    getNextPageParam: (last) => last.nextCursor ?? undefined,
+  })
 
   useEffect(() => {
     if (!prependItem) return
-    setPosts((prev) =>
-      prev.some((p) => p.id === prependItem.id) ? prev : [prependItem, ...prev]
+    queryClient.setQueryData<InfiniteData<FeedPage, string | undefined>>(
+      queryKey,
+      (current) => {
+        if (!current || current.pages.length === 0) return current
+        const exists = current.pages.some((page) =>
+          page.posts.some((p) => p.id === prependItem.id),
+        )
+        if (exists) return current
+        const [first, ...rest] = current.pages
+        return {
+          ...current,
+          pages: [{ ...first, posts: [prependItem, ...first.posts] }, ...rest],
+        }
+      },
     )
-  }, [prependItem])
+    // queryKeyHash captures the key identity; queryKey ref may change each render.
+  }, [prependItem, queryClient, queryKeyHash])
 
-  async function loadMore() {
-    if (!cursor || loadingMore) return
-    setLoadingMore(true)
-    try {
-      const page = await load(cursor)
-      setPosts((prev) => [...prev, ...filterPosts(page.posts)])
-      setCursor(page.nextCursor)
-    } finally {
-      setLoadingMore(false)
-    }
-  }
+  const posts = useMemo(() => {
+    const all = data?.pages.flatMap((p) => p.posts) ?? []
+    if (hideReplies) return all.filter((p) => !p.replyToId)
+    if (onlyReplies) return all.filter((p) => p.replyToId)
+    return all
+  }, [data, hideReplies, onlyReplies])
 
   function replace(next: Post) {
-    setPosts((prev) => prev.map((p) => (p.id === next.id ? next : p)))
-  }
-  function remove(id: string) {
-    setPosts((prev) => prev.filter((p) => p.id !== id))
+    queryClient.setQueryData<InfiniteData<FeedPage, string | undefined>>(
+      queryKey,
+      (current) => {
+        if (!current) return current
+        return {
+          ...current,
+          pages: current.pages.map((page) => ({
+            ...page,
+            posts: page.posts.map((p) => (p.id === next.id ? next : p)),
+          })),
+        }
+      },
+    )
   }
 
-  if (loading)
+  function remove(id: string) {
+    queryClient.setQueryData<InfiniteData<FeedPage, string | undefined>>(
+      queryKey,
+      (current) => {
+        if (!current) return current
+        return {
+          ...current,
+          pages: current.pages.map((page) => ({
+            ...page,
+            posts: page.posts.filter((p) => p.id !== id),
+          })),
+        }
+      },
+    )
+  }
+
+  if (isPending)
     return (
       <div>
         {Array.from({ length: 4 }).map((_, i) => (
@@ -88,7 +112,11 @@ export function Feed({
       </div>
     )
   if (error)
-    return <div className="px-4 py-6 text-sm text-destructive">{error}</div>
+    return (
+      <div className="px-4 py-6 text-sm text-destructive">
+        {error.message}
+      </div>
+    )
   if (posts.length === 0)
     return (
       <div className="p-8 text-center text-sm text-muted-foreground">
@@ -110,15 +138,15 @@ export function Feed({
           }
         />
       ))}
-      {cursor && (
+      {hasNextPage && (
         <div className="flex justify-center py-3">
           <Button
             variant="ghost"
             size="sm"
-            onClick={loadMore}
-            disabled={loadingMore}
+            onClick={() => fetchNextPage()}
+            disabled={isFetchingNextPage}
           >
-            {loadingMore ? "loading…" : "load more"}
+            {isFetchingNextPage ? "loading…" : "load more"}
           </Button>
         </div>
       )}

--- a/apps/web/src/lib/query.tsx
+++ b/apps/web/src/lib/query.tsx
@@ -1,0 +1,20 @@
+import { useState } from "react"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+
+function makeQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        staleTime: 30_000,
+        gcTime: 5 * 60_000,
+        refetchOnWindowFocus: false,
+        retry: 1,
+      },
+    },
+  })
+}
+
+export function QueryProvider({ children }: { children: React.ReactNode }) {
+  const [client] = useState(makeQueryClient)
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>
+}

--- a/apps/web/src/routes/$handle.index.tsx
+++ b/apps/web/src/routes/$handle.index.tsx
@@ -160,7 +160,11 @@ function Profile() {
         </div>
       </div>
       <div className="border-t border-border">
-        <Feed load={load} emptyMessage={`@${user.handle} hasn't posted yet.`} />
+        <Feed
+          queryKey={["userPosts", handle]}
+          load={load}
+          emptyMessage={`@${user.handle} hasn't posted yet.`}
+        />
       </div>
     </main>
   )

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -11,6 +11,7 @@ import { PageFrame } from "../components/page-frame"
 import { ThemeProvider, themeBootstrapScript } from "../lib/theme"
 import { APP_NAME, WEB_URL } from "../lib/env"
 import { MeProvider } from "../lib/me"
+import { QueryProvider } from "../lib/query"
 
 const DESCRIPTION = `${APP_NAME} — open-source, free-for-everyone social platform. No AI ranking, no paywalls, no ads.`
 
@@ -55,13 +56,15 @@ export const Route = createRootRoute({
   ),
   shellComponent: RootDocument,
   component: () => (
-    <ThemeProvider>
-      <MeProvider>
-        <AppShell>
-          <Outlet />
-        </AppShell>
-      </MeProvider>
-    </ThemeProvider>
+    <QueryProvider>
+      <ThemeProvider>
+        <MeProvider>
+          <AppShell>
+            <Outlet />
+          </AppShell>
+        </MeProvider>
+      </ThemeProvider>
+    </QueryProvider>
   ),
 })
 

--- a/apps/web/src/routes/bookmarks.tsx
+++ b/apps/web/src/routes/bookmarks.tsx
@@ -26,6 +26,7 @@ function Bookmarks() {
           </p>
         </header>
         <Feed
+          queryKey={["bookmarks"]}
           load={load}
           emptyMessage="no bookmarks yet. tap the bookmark icon on a post to save it."
         />

--- a/apps/web/src/routes/hashtag.$tag.tsx
+++ b/apps/web/src/routes/hashtag.$tag.tsx
@@ -21,7 +21,11 @@ function HashtagPage() {
             public posts with this hashtag
           </p>
         </header>
-        <Feed load={load} emptyMessage={`Nothing tagged #${tag} yet.`} />
+        <Feed
+          queryKey={["hashtag", tag]}
+          load={load}
+          emptyMessage={`Nothing tagged #${tag} yet.`}
+        />
       </main>
     </PageFrame>
   )

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -139,7 +139,7 @@ function Landing() {
               ))}
             </div>
             <Feed
-              key={tab}
+              queryKey={["feed", tab]}
               load={tab === "following" ? loadFeed : loadPublic}
               emptyMessage={
                 tab === "following"

--- a/apps/web/src/routes/lists.$id.tsx
+++ b/apps/web/src/routes/lists.$id.tsx
@@ -147,6 +147,7 @@ function ListDetail() {
         )}
 
         <Feed
+          queryKey={["listTimeline", id]}
           load={load}
           emptyMessage={
             isOwner

--- a/bun.lock
+++ b/bun.lock
@@ -50,6 +50,7 @@
         "@tabler/icons-react": "^3.41.1",
         "@tailwindcss/vite": "^4.1.18",
         "@tanstack/react-hotkeys": "^0.9.1",
+        "@tanstack/react-query": "^5.100.3",
         "@tanstack/react-router": "^1.132.0",
         "@tanstack/react-start": "^1.132.0",
         "@tanstack/react-table": "^8.21.3",
@@ -1011,7 +1012,11 @@
 
     "@tanstack/hotkeys": ["@tanstack/hotkeys@0.7.1", "", { "dependencies": { "@tanstack/store": "^0.9.3" } }, "sha512-YHVO1z6wnvUCu7bg870Kv5k2D+FIuIOSIcbN0dAmTTsJ3mLMDLwcTVx0qVaq+SZp1B514JJTqGVstvUp85yIpQ=="],
 
+    "@tanstack/query-core": ["@tanstack/query-core@5.100.3", "", {}, "sha512-oMO1imV4qStH+GqddafkI7Q7r2ktPL7/0Mu74W1XEhfHHd3oTIrwP3OOIsbtpnnbe8y/IU+8Lm7Bi2LlMhVdNA=="],
+
     "@tanstack/react-hotkeys": ["@tanstack/react-hotkeys@0.9.1", "", { "dependencies": { "@tanstack/hotkeys": "0.7.1", "@tanstack/react-store": "^0.9.3" }, "peerDependencies": { "react": ">=16.8", "react-dom": ">=16.8" } }, "sha512-/qdQUUVkYAHAWRGdFXqFgWpW/S+a6OzkvxWNWKLLDHQODJlO6EPBPa073CglaafBfzig58RK07T09ET+NnZhpg=="],
+
+    "@tanstack/react-query": ["@tanstack/react-query@5.100.3", "", { "dependencies": { "@tanstack/query-core": "5.100.3" }, "peerDependencies": { "react": "^18 || ^19" } }, "sha512-8Fgb4vKmBHllRHUjz3ZOwgV0v9b7cxCdN5T0iFQvvWJJVs6xvaxHERO1BclTL03bbK8vZAuXVKN3IeVS1sUdeQ=="],
 
     "@tanstack/react-router": ["@tanstack/react-router@1.168.23", "", { "dependencies": { "@tanstack/history": "1.161.6", "@tanstack/react-store": "^0.9.3", "@tanstack/router-core": "1.168.15", "isbot": "^5.1.22" }, "peerDependencies": { "react": ">=18.0.0 || >=19.0.0", "react-dom": ">=18.0.0 || >=19.0.0" } }, "sha512-+GblieDnutG6oipJJPNtRJjrWF8QTZEG/l0532+BngFkVK48oHNOcvIkSoAFYftK1egAwM7KBxXsb0Ou+X6/MQ=="],
 


### PR DESCRIPTION
## Summary

- Replaced manual state management (`useState`) in the Feed component with TanStack Query's `useInfiniteQuery` hook for more robust pagination and caching
- Created a new `QueryProvider` component to set up TanStack Query with sensible defaults (30s stale time, 5min cache, no refetch on window focus, 1 retry)
- Updated all Feed consumers to pass a `queryKey` prop for query identification and caching
- Simplified post filtering, prepending, replacing, and removal logic by using `queryClient.setQueryData` to update the cache directly

## Test plan

- [ ] `bun run typecheck` passes
- [ ] Manually exercised feed pagination, bookmarks, hashtag pages, user profiles, and list timelines in the browser
- [ ] No new console errors / network errors

## Notes

- The `queryKey` prop is now required on all Feed instances to enable proper query caching and invalidation
- Post filtering (hideReplies/onlyReplies) is now applied client-side via `useMemo` after data is fetched, rather than during the fetch
- Error handling now accesses `error.message` instead of the error object directly

https://claude.ai/code/session_01MhXmpb9CuYAG1SfMs4243y