### PR TITLE
feat(posts): clickable edited indicator that opens edit history

### DIFF
--- a/apps/api/src/routes/posts.ts
+++ b/apps/api/src/routes/posts.ts
@@ -697,6 +697,37 @@ postsRoute.delete('/:id/pin', requireAuth(), async (c) => {
   return c.json({ ok: true })
 })
 
+// Read the prior versions of a post — newest first. We expose this to anyone
+// who can already see the post (i.e. it isn't deleted) so the "edited" badge
+// can link to a "View edit history" sheet, mirroring X's UX.
+postsRoute.get('/:id/edits', async (c) => {
+  const { db } = c.get('ctx')
+  const id = c.req.param('id')
+  const [post] = await db
+    .select({ id: schema.posts.id, deletedAt: schema.posts.deletedAt })
+    .from(schema.posts)
+    .where(eq(schema.posts.id, id))
+    .limit(1)
+  if (!post || post.deletedAt) return c.json({ error: 'not_found' }, 404)
+  const edits = await db
+    .select({
+      id: schema.postEdits.id,
+      previousText: schema.postEdits.previousText,
+      editedAt: schema.postEdits.editedAt,
+    })
+    .from(schema.postEdits)
+    .where(eq(schema.postEdits.postId, id))
+    .orderBy(desc(schema.postEdits.editedAt))
+    .limit(50)
+  return c.json({
+    edits: edits.map((e) => ({
+      id: e.id,
+      previousText: e.previousText,
+      editedAt: e.editedAt.toISOString(),
+    })),
+  })
+})
+
 postsRoute.delete('/:id', requireAuth(), async (c) => {
   const session = c.get('session')!
   const { db, cache } = c.get('ctx')

--- a/apps/web/src/components/post-card.tsx
+++ b/apps/web/src/components/post-card.tsx
@@ -40,7 +40,7 @@ import { ImageLightbox } from "./image-lightbox"
 import { Compose } from "./compose"
 import { PollBlock } from "./poll-block"
 import { VerifiedBadge } from "./verified-badge"
-import type { Post } from "../lib/api"
+import type { Post, PostEdit } from "../lib/api"
 
 function relativeTime(iso: string): string {
   const d = new Date(iso).getTime()
@@ -310,6 +310,7 @@ export function PostCard({
   const [reportOpen, setReportOpen] = useState(false)
   const [editText, setEditText] = useState(post.text)
   const [editError, setEditError] = useState<string | null>(null)
+  const [historyOpen, setHistoryOpen] = useState(false)
   const authorHandle = post.author.handle
   const showProfileLink = Boolean(authorHandle)
   const showPostLink = Boolean(authorHandle && !disableThreadNavigation)
@@ -530,7 +531,14 @@ export function PostCard({
               </time>
             )}
             {post.editedAt && (
-              <span className="text-xs text-muted-foreground">(edited)</span>
+              <button
+                type="button"
+                onClick={() => setHistoryOpen(true)}
+                className="text-xs text-muted-foreground hover:underline"
+                title="View edit history"
+              >
+                (edited)
+              </button>
             )}
             {(isOwner || session) && (
               <DropdownMenu>
@@ -604,6 +612,11 @@ export function PostCard({
               subjectLabel={
                 authorHandle ? `@${authorHandle}'s post` : "this post"
               }
+            />
+            <EditHistoryDialog
+              open={historyOpen}
+              onOpenChange={setHistoryOpen}
+              post={post}
             />
           </header>
           {editing ? (
@@ -816,5 +829,73 @@ function RepostControl({
         </DialogContent>
       </Dialog>
     </>
+  )
+}
+
+function EditHistoryDialog({
+  open,
+  onOpenChange,
+  post,
+}: {
+  open: boolean
+  onOpenChange: (next: boolean) => void
+  post: Post
+}) {
+  const [edits, setEdits] = useState<Array<PostEdit> | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!open) return
+    setError(null)
+    setEdits(null)
+    api
+      .postEdits(post.id)
+      .then(({ edits: rows }) => setEdits(rows))
+      .catch((e) =>
+        setError(e instanceof ApiError ? e.message : "couldn't load history"),
+      )
+  }, [open, post.id])
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle className="text-sm font-semibold">Edit history</DialogTitle>
+          <DialogDescription className="sr-only">
+            Previous versions of this post, newest first.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="max-h-[60vh] space-y-3 overflow-y-auto pt-2">
+          <div className="rounded-md border border-border p-3">
+            <div className="mb-1 text-xs text-muted-foreground">
+              Current version
+              {post.editedAt
+                ? ` · edited ${new Date(post.editedAt).toLocaleString()}`
+                : ""}
+            </div>
+            <p className="text-sm leading-relaxed whitespace-pre-wrap">
+              {post.text}
+            </p>
+          </div>
+          {error && <p className="text-xs text-destructive">{error}</p>}
+          {!error && edits === null && (
+            <p className="text-xs text-muted-foreground">loading…</p>
+          )}
+          {edits && edits.length === 0 && (
+            <p className="text-xs text-muted-foreground">No prior versions.</p>
+          )}
+          {edits?.map((edit) => (
+            <div key={edit.id} className="rounded-md border border-border p-3">
+              <div className="mb-1 text-xs text-muted-foreground">
+                Replaced at {new Date(edit.editedAt).toLocaleString()}
+              </div>
+              <p className="text-sm leading-relaxed whitespace-pre-wrap text-muted-foreground">
+                {edit.previousText}
+              </p>
+            </div>
+          ))}
+        </div>
+      </DialogContent>
+    </Dialog>
   )
 }

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -366,6 +366,8 @@ export const api = {
       method: "PATCH",
       body: JSON.stringify({ text }),
     }),
+  postEdits: (id: string) =>
+    request<{ edits: Array<PostEdit> }>(`/api/posts/${id}/edits`),
 
   like: (id: string) =>
     request<{ ok: true }>(`/api/posts/${id}/like`, { method: "POST" }),
@@ -474,6 +476,12 @@ export type ReportReason =
   | "impersonation"
   | "illegal"
   | "other"
+
+export interface PostEdit {
+  id: string
+  previousText: string
+  editedAt: string
+}
 
 export interface Post {
   id: string


### PR DESCRIPTION
- Add GET /api/posts/:id/edits returning every prior version of a post (newest first, capped at 50). Open to anyone who can already see the post — same visibility model as the post itself.
- Expose api.postEdits() and a PostEdit type on the web client.
- Make the existing '(edited)' indicator on PostCard a button that opens an EditHistoryDialog. The dialog shows the current text up top, then each prior version with its replacement timestamp.

## Summary

<!-- 1-3 bullets of what changed and why. -->

## Test plan

<!-- How you verified it works. Delete what doesn't apply. -->

- [ ] `bun run typecheck` passes
- [ ] Manually exercised the affected flow in the browser
- [ ] No new console errors / network errors

## Notes

<!-- Anything reviewers should pay attention to: migrations, env-var changes, breaking changes, follow-ups. Delete if none. -->
