### PR TITLE
Add user role support to verified badge component

### DIFF
--- a/apps/api/src/lib/post-dto.ts
+++ b/apps/api/src/lib/post-dto.ts
@@ -51,6 +51,7 @@ export interface PostDto {
     avatarUrl: string | null
     isVerified: boolean
     isBot: boolean
+    role: 'user' | 'admin' | 'owner'
   }
   counts: {
     likes: number
@@ -127,6 +128,7 @@ export function toPostDto(
       avatarUrl: env ? assetUrl(env, author.avatarUrl) : author.avatarUrl,
       isVerified: author.isVerified,
       isBot: author.isBot,
+      role: author.role,
     },
     counts: {
       likes: post.likeCount,

--- a/apps/api/src/routes/articles.ts
+++ b/apps/api/src/routes/articles.ts
@@ -59,6 +59,7 @@ function toArticleDto(
       displayName: author.displayName,
       avatarUrl: assetUrl(env, author.avatarUrl),
       isVerified: author.isVerified,
+      role: author.role,
     },
   }
 }

--- a/apps/api/src/routes/dms.ts
+++ b/apps/api/src/routes/dms.ts
@@ -214,6 +214,7 @@ dmsRoute.get('/', async (c) => {
       displayName: u.displayName,
       avatarUrl: assetUrl(mediaEnv, u.avatarUrl),
       isVerified: u.isVerified,
+      role: u.role,
     }))
     const latest = latestByConv.get(r.conv.id)
     return {
@@ -718,7 +719,8 @@ dmsRoute.get('/:id', async (c) => {
         displayName: r.user.displayName,
         avatarUrl: assetUrl(mediaEnv, r.user.avatarUrl),
         isVerified: r.user.isVerified,
-        role: r.member.role,
+        role: r.user.role,
+        chatRole: r.member.role,
         lastReadMessageId: r.member.lastReadMessageId,
       })),
     },
@@ -796,6 +798,7 @@ dmsRoute.get('/:id/messages', async (c) => {
       displayName: r.sender.displayName,
       avatarUrl: assetUrl(mediaEnv, r.sender.avatarUrl),
       isVerified: r.sender.isVerified,
+      role: r.sender.role,
     },
   }))
   const nextCursor =

--- a/apps/api/src/routes/invites.ts
+++ b/apps/api/src/routes/invites.ts
@@ -47,6 +47,7 @@ invitesRoute.get('/:token', async (c) => {
           displayName: r.user.displayName,
           avatarUrl: assetUrl(mediaEnv, r.user.avatarUrl),
           isVerified: r.user.isVerified,
+          role: r.user.role,
         })),
       },
       expiresAt: invite.invite.expiresAt?.toISOString() ?? null,

--- a/apps/api/src/routes/lists.ts
+++ b/apps/api/src/routes/lists.ts
@@ -190,6 +190,7 @@ listsRoute.get('/:id/members', async (c) => {
       displayName: r.user.displayName,
       avatarUrl: assetUrl(mediaEnv, r.user.avatarUrl),
       isVerified: r.user.isVerified,
+      role: r.user.role,
       addedAt: r.addedAt.toISOString(),
     })),
   })

--- a/apps/api/src/routes/me.ts
+++ b/apps/api/src/routes/me.ts
@@ -108,6 +108,7 @@ meRoute.get('/blocks', async (c) => {
     displayName: r.user.displayName,
     avatarUrl: assetUrl(mediaEnv, r.user.avatarUrl),
     isVerified: r.user.isVerified,
+    role: r.user.role,
     blockedAt: r.block.createdAt.toISOString(),
   }))
   const nextCursor =
@@ -142,6 +143,7 @@ meRoute.get('/mutes', async (c) => {
     displayName: r.user.displayName,
     avatarUrl: assetUrl(mediaEnv, r.user.avatarUrl),
     isVerified: r.user.isVerified,
+    role: r.user.role,
     mutedAt: r.mute.createdAt.toISOString(),
     scope: r.mute.scope,
   }))

--- a/apps/api/src/routes/notifications.ts
+++ b/apps/api/src/routes/notifications.ts
@@ -124,6 +124,7 @@ notificationsRoute.get('/', async (c) => {
           displayName: r.actor.displayName,
           avatarUrl: assetUrl(mediaEnv, r.actor.avatarUrl),
           isVerified: r.actor.isVerified,
+          role: r.actor.role,
         }
       : null,
     target:

--- a/apps/api/src/routes/search.ts
+++ b/apps/api/src/routes/search.ts
@@ -40,6 +40,7 @@ searchRoute.get('/', async (c) => {
       bannerUrl: schema.users.bannerUrl,
       isVerified: schema.users.isVerified,
       isBot: schema.users.isBot,
+      role: schema.users.role,
       createdAt: schema.users.createdAt,
     })
     .from(schema.users)

--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -84,6 +84,7 @@ usersRoute.get('/:handle', async (c) => {
       bannerUrl: assetUrl(mediaEnv, user.bannerUrl),
       isVerified: user.isVerified,
       isBot: user.isBot,
+      role: user.role,
       createdAt: user.createdAt,
       counts: {
         followers: followers?.n ?? 0,
@@ -323,6 +324,7 @@ usersRoute.get('/:handle/articles/:slug', async (c) => {
         displayName: user.displayName,
         avatarUrl: assetUrl(mediaEnv, user.avatarUrl),
         isVerified: user.isVerified,
+        role: user.role,
       },
     },
   })
@@ -518,6 +520,7 @@ function publicUser(
     bannerUrl: assetUrl(env, u.bannerUrl),
     isVerified: u.isVerified,
     isBot: u.isBot,
+    role: u.role,
     createdAt: u.createdAt,
   }
 }

--- a/apps/web/src/components/compose.tsx
+++ b/apps/web/src/components/compose.tsx
@@ -256,7 +256,9 @@ export function Compose({
               <span className="flex items-center gap-1 font-medium text-foreground">
                 {quoted.author.displayName ||
                   `@${quoted.author.handle ?? "unknown"}`}
-                {quoted.author.isVerified && <VerifiedBadge size={13} />}
+                {quoted.author.isVerified && (
+                  <VerifiedBadge size={13} role={quoted.author.role} />
+                )}
               </span>
               {quoted.author.handle && <span>@{quoted.author.handle}</span>}
             </div>

--- a/apps/web/src/components/post-card.tsx
+++ b/apps/web/src/components/post-card.tsx
@@ -146,7 +146,9 @@ function QuoteEmbed({ post }: { post: Post }) {
           <div className="flex items-center gap-2 text-xs">
             <span className="flex items-center gap-1 font-semibold text-foreground">
               {post.author.displayName || `@${handle ?? "unknown"}`}
-              {post.author.isVerified && <VerifiedBadge size={13} />}
+              {post.author.isVerified && (
+                <VerifiedBadge size={13} role={post.author.role} />
+              )}
             </span>
             {handle && <span className="text-muted-foreground">@{handle}</span>}
             <span className="text-muted-foreground">·</span>
@@ -458,7 +460,9 @@ export function PostCard({
               Reposted by{" "}
               {outerPost.author.displayName || `@${outerPost.author.handle}`}
             </span>
-            {outerPost.author.isVerified && <VerifiedBadge size={12} />}
+            {outerPost.author.isVerified && (
+              <VerifiedBadge size={12} role={outerPost.author.role} />
+            )}
           </span>
         </Link>
       )}
@@ -501,12 +505,16 @@ export function PostCard({
                 className="flex items-center gap-1 font-semibold text-foreground hover:underline"
               >
                 {post.author.displayName || `@${authorHandle}`}
-                {post.author.isVerified && <VerifiedBadge size={15} />}
+                {post.author.isVerified && (
+                  <VerifiedBadge size={15} role={post.author.role} />
+                )}
               </Link>
             ) : (
               <span className="flex items-center gap-1 font-semibold text-foreground">
                 {post.author.displayName ?? "unknown"}
-                {post.author.isVerified && <VerifiedBadge size={15} />}
+                {post.author.isVerified && (
+                  <VerifiedBadge size={15} role={post.author.role} />
+                )}
               </span>
             )}
             {authorHandle && (

--- a/apps/web/src/components/user-list.tsx
+++ b/apps/web/src/components/user-list.tsx
@@ -76,7 +76,7 @@ export function UserList({
               <span className="truncate">
                 {u.displayName || `@${u.handle}`}
               </span>
-              {u.isVerified && <VerifiedBadge size={14} />}
+              {u.isVerified && <VerifiedBadge size={14} role={u.role} />}
             </div>
             <div className="text-xs text-muted-foreground">@{u.handle}</div>
             {u.bio && (

--- a/apps/web/src/components/user-nav.tsx
+++ b/apps/web/src/components/user-nav.tsx
@@ -58,7 +58,9 @@ export function UserNav({ user }: { user: SelfUser }) {
             <div className="flex min-w-0 flex-col leading-tight group-data-[collapsible=icon]:hidden">
               <span className="flex min-w-0 items-center gap-1 truncate text-sm font-medium">
                 <span className="truncate">{displayName}</span>
-                {user.isVerified && <VerifiedBadge size={14} />}
+                {user.isVerified && (
+                  <VerifiedBadge size={14} role={user.role} />
+                )}
               </span>
               <span className="truncate text-xs text-muted-foreground">
                 {subtitle}
@@ -78,7 +80,9 @@ export function UserNav({ user }: { user: SelfUser }) {
           <div className="flex min-w-0 flex-col leading-tight">
             <span className="flex min-w-0 items-center gap-1 truncate text-sm font-medium">
               <span className="truncate">{displayName}</span>
-              {user.isVerified && <VerifiedBadge size={14} />}
+              {user.isVerified && (
+                <VerifiedBadge size={14} role={user.role} />
+              )}
             </span>
             <span className="truncate text-xs text-muted-foreground">
               {subtitle}

--- a/apps/web/src/components/verified-badge.tsx
+++ b/apps/web/src/components/verified-badge.tsx
@@ -1,18 +1,39 @@
 import { IconRosetteDiscountCheckFilled } from "@tabler/icons-react"
 import { cn } from "@workspace/ui/lib/utils"
 
+export type VerifiedBadgeRole = "user" | "admin" | "owner"
+
+const roleColorClass: Record<VerifiedBadgeRole, string> = {
+  user: "text-sky-500",
+  admin: "text-emerald-500",
+  owner: "text-amber-400",
+}
+
+const roleAriaLabel: Record<VerifiedBadgeRole, string> = {
+  user: "Verified account",
+  admin: "Verified admin account",
+  owner: "Verified owner account",
+}
+
 export function VerifiedBadge({
   size = 16,
+  role = "user",
   className,
 }: {
   size?: number
+  role?: VerifiedBadgeRole | null
   className?: string
 }) {
+  const resolvedRole: VerifiedBadgeRole = role ?? "user"
   return (
     <IconRosetteDiscountCheckFilled
       size={size}
-      aria-label="Verified account"
-      className={cn("inline-block shrink-0 text-sky-500", className)}
+      aria-label={roleAriaLabel[resolvedRole]}
+      className={cn(
+        "inline-block shrink-0",
+        roleColorClass[resolvedRole],
+        className,
+      )}
     />
   )
 }

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -494,6 +494,7 @@ export interface Post {
     avatarUrl: string | null
     isVerified: boolean
     isBot: boolean
+    role: "user" | "admin" | "owner"
   }
   counts: {
     likes: number
@@ -590,6 +591,7 @@ export interface UserListMember {
   displayName: string | null
   avatarUrl: string | null
   isVerified: boolean
+  role: "user" | "admin" | "owner"
   addedAt: string
 }
 
@@ -632,6 +634,7 @@ export interface PublicUser {
   bannerUrl: string | null
   isVerified: boolean
   isBot: boolean
+  role: "user" | "admin" | "owner"
   createdAt: string
 }
 
@@ -661,6 +664,7 @@ export interface BlockedUser {
   displayName: string | null
   avatarUrl: string | null
   isVerified: boolean
+  role: "user" | "admin" | "owner"
   blockedAt: string
 }
 
@@ -670,6 +674,7 @@ export interface MutedUser {
   displayName: string | null
   avatarUrl: string | null
   isVerified: boolean
+  role: "user" | "admin" | "owner"
   mutedAt: string
   scope: "feed" | "notifications" | "both"
 }
@@ -720,6 +725,7 @@ export interface NotificationItem {
     displayName: string | null
     avatarUrl: string | null
     isVerified: boolean
+    role: "user" | "admin" | "owner"
   } | null
   /** Hydrated for kinds whose entity is a post (like / repost / reply / mention / quote /
    *  article_reply). Null when the post was deleted or the kind has no associated post. */
@@ -773,6 +779,7 @@ export interface ArticleDto {
     displayName: string | null
     avatarUrl: string | null
     isVerified: boolean
+    role: "user" | "admin" | "owner"
   }
 }
 
@@ -782,6 +789,7 @@ export interface DmMember {
   displayName: string | null
   avatarUrl: string | null
   isVerified: boolean
+  role: "user" | "admin" | "owner"
 }
 
 export type DmRequestState = "none" | "pending" | "accepted" | "declined"
@@ -812,7 +820,7 @@ export interface DmConversationDetail {
   myRole: "member" | "admin"
   myRequestState: DmRequestState
   members: Array<
-    DmMember & { role: "member" | "admin"; lastReadMessageId: string | null }
+    DmMember & { chatRole: "member" | "admin"; lastReadMessageId: string | null }
   >
 }
 
@@ -838,6 +846,7 @@ export interface InvitePreview {
       displayName: string | null
       avatarUrl: string | null
       isVerified: boolean
+      role: "user" | "admin" | "owner"
     }>
   }
   expiresAt: string | null

--- a/apps/web/src/routes/$handle.a.$slug.tsx
+++ b/apps/web/src/routes/$handle.a.$slug.tsx
@@ -82,7 +82,9 @@ function ArticleView() {
               className="flex items-center gap-1 font-medium text-foreground hover:underline"
             >
               {article.author.displayName || `@${article.author.handle}`}
-              {article.author.isVerified && <VerifiedBadge size={14} />}
+              {article.author.isVerified && (
+                <VerifiedBadge size={14} role={article.author.role} />
+              )}
             </Link>
           )}
           <span>·</span>

--- a/apps/web/src/routes/$handle.index.tsx
+++ b/apps/web/src/routes/$handle.index.tsx
@@ -109,7 +109,7 @@ function Profile() {
         <div className="mt-3">
           <h1 className="flex items-center gap-1.5 text-xl font-semibold">
             {displayName}
-            {user.isVerified && <VerifiedBadge size={20} />}
+            {user.isVerified && <VerifiedBadge size={20} role={user.role} />}
           </h1>
           <p className="text-sm text-muted-foreground">@{user.handle}</p>
         </div>

--- a/apps/web/src/routes/admin.users.tsx
+++ b/apps/web/src/routes/admin.users.tsx
@@ -124,12 +124,16 @@ function AdminUsers() {
                     className="flex items-center gap-1 text-sm font-semibold hover:underline"
                   >
                     {u.displayName ?? u.handle}
-                    {u.isVerified && <VerifiedBadge size={14} />}
+                    {u.isVerified && (
+                      <VerifiedBadge size={14} role={u.role} />
+                    )}
                   </Link>
                 ) : (
                   <span className="flex items-center gap-1 text-sm font-semibold">
                     {u.displayName ?? u.email}
-                    {u.isVerified && <VerifiedBadge size={14} />}
+                    {u.isVerified && (
+                      <VerifiedBadge size={14} role={u.role} />
+                    )}
                   </span>
                 )}
                 {u.handle && (

--- a/apps/web/src/routes/inbox.$conversationId.tsx
+++ b/apps/web/src/routes/inbox.$conversationId.tsx
@@ -1121,7 +1121,9 @@ function ThreadHeader({
             {peer?.displayName ||
               (peer?.handle ? `@${peer.handle}` : "Conversation")}
           </span>
-          {peer?.isVerified && <VerifiedBadge size={14} />}
+          {peer?.isVerified && (
+            <VerifiedBadge size={14} role={peer.role} />
+          )}
         </div>
         {peer?.handle && (
           <Link
@@ -1293,8 +1295,10 @@ function GroupSettingsDialog({
                         {m.displayName ||
                           (m.handle ? `@${m.handle}` : m.id.slice(0, 8))}
                       </span>
-                      {m.isVerified && <VerifiedBadge size={13} />}
-                      {m.role === "admin" && (
+                      {m.isVerified && (
+                        <VerifiedBadge size={13} role={m.role} />
+                      )}
+                      {m.chatRole === "admin" && (
                         <span className="text-xs text-muted-foreground">
                           (admin)
                         </span>
@@ -1354,7 +1358,9 @@ function GroupSettingsDialog({
                               {u.displayName ||
                                 (u.handle ? `@${u.handle}` : u.id.slice(0, 8))}
                             </span>
-                            {u.isVerified && <VerifiedBadge size={13} />}
+                            {u.isVerified && (
+                              <VerifiedBadge size={13} role={u.role} />
+                            )}
                           </div>
                           {u.handle && (
                             <div className="truncate text-xs text-muted-foreground">

--- a/apps/web/src/routes/inbox.index.tsx
+++ b/apps/web/src/routes/inbox.index.tsx
@@ -188,7 +188,9 @@ function ConversationRow({ conversation }: { conversation: DmConversation }) {
           <div className="flex items-baseline justify-between gap-2">
             <span className="flex min-w-0 items-center gap-1 text-sm font-semibold">
               <span className="truncate">{title}</span>
-              {peer?.isVerified && <VerifiedBadge size={14} />}
+              {peer?.isVerified && (
+                <VerifiedBadge size={14} role={peer.role} />
+              )}
             </span>
             <time className="shrink-0 text-xs text-muted-foreground">{ts}</time>
           </div>

--- a/apps/web/src/routes/inbox.new.tsx
+++ b/apps/web/src/routes/inbox.new.tsx
@@ -110,7 +110,9 @@ function NewConversation() {
                   <span className="flex items-center gap-1 font-medium">
                     {u.displayName ||
                       (u.handle ? `@${u.handle}` : u.id.slice(0, 8))}
-                    {u.isVerified && <VerifiedBadge size={12} />}
+                    {u.isVerified && (
+                      <VerifiedBadge size={12} role={u.role} />
+                    )}
                   </span>
                   <button
                     type="button"
@@ -180,7 +182,9 @@ function NewConversation() {
                           {u.displayName ||
                             (u.handle ? `@${u.handle}` : u.id.slice(0, 8))}
                         </span>
-                        {u.isVerified && <VerifiedBadge size={14} />}
+                        {u.isVerified && (
+                          <VerifiedBadge size={14} role={u.role} />
+                        )}
                       </div>
                       {u.handle && (
                         <div className="truncate text-xs text-muted-foreground">

--- a/apps/web/src/routes/invite.$token.tsx
+++ b/apps/web/src/routes/invite.$token.tsx
@@ -115,7 +115,9 @@ function InvitePage() {
           </div>
           <h1 className="flex items-center justify-center gap-1.5 text-lg font-semibold">
             {title}
-            {soloPeer?.isVerified && <VerifiedBadge size={16} />}
+            {soloPeer?.isVerified && (
+              <VerifiedBadge size={16} role={soloPeer.role} />
+            )}
           </h1>
           <p className="mt-1 text-xs text-muted-foreground">
             {conv.kind === "group" ? "Group conversation" : "Conversation"} ·{" "}

--- a/apps/web/src/routes/notifications.tsx
+++ b/apps/web/src/routes/notifications.tsx
@@ -195,12 +195,16 @@ function NotificationRow({ item }: { item: NotificationItem }) {
                 className="inline-flex items-center gap-1 align-middle font-semibold hover:underline"
               >
                 {actorLabel}
-                {item.actor?.isVerified && <VerifiedBadge size={14} />}
+                {item.actor?.isVerified && (
+                  <VerifiedBadge size={14} role={item.actor.role} />
+                )}
               </Link>
             ) : (
               <span className="inline-flex items-center gap-1 align-middle font-semibold">
                 {actorLabel}
-                {item.actor?.isVerified && <VerifiedBadge size={14} />}
+                {item.actor?.isVerified && (
+                  <VerifiedBadge size={14} role={item.actor.role} />
+                )}
               </span>
             )}{" "}
             <span className="text-muted-foreground">{verb}</span>

--- a/apps/web/src/routes/search.tsx
+++ b/apps/web/src/routes/search.tsx
@@ -115,7 +115,9 @@ function Search() {
                         <span className="truncate">
                           {u.displayName || `@${u.handle}`}
                         </span>
-                        {u.isVerified && <VerifiedBadge size={14} />}
+                        {u.isVerified && (
+                          <VerifiedBadge size={14} role={u.role} />
+                        )}
                       </div>
                       <div className="text-xs text-muted-foreground">
                         @{u.handle}

--- a/apps/web/src/routes/settings.tsx
+++ b/apps/web/src/routes/settings.tsx
@@ -627,6 +627,7 @@ function PrivacyList<
     displayName: string | null
     avatarUrl: string | null
     isVerified: boolean
+    role: "user" | "admin" | "owner"
   },
 >({
   users,
@@ -670,14 +671,18 @@ function PrivacyList<
                   <span className="truncate">
                     {u.displayName ?? `@${u.handle}`}
                   </span>
-                  {u.isVerified && <VerifiedBadge size={13} />}
+                  {u.isVerified && (
+                    <VerifiedBadge size={13} role={u.role} />
+                  )}
                 </Link>
               ) : (
                 <span className="flex items-center gap-1 text-sm font-medium">
                   <span className="truncate">
                     {u.displayName ?? "Unknown user"}
                   </span>
-                  {u.isVerified && <VerifiedBadge size={13} />}
+                  {u.isVerified && (
+                    <VerifiedBadge size={13} role={u.role} />
+                  )}
                 </span>
               )}
               <p className="truncate text-xs text-muted-foreground">


### PR DESCRIPTION
## Summary

- Enhanced `VerifiedBadge` component to display different colors and labels based on user role (user/admin/owner)
- Added `role` field to all user-related API DTOs and interfaces across the codebase
- Updated all `VerifiedBadge` usages to pass the user's role for proper badge styling
- Fixed DM conversation member role field naming: separated user `role` from chat-specific `chatRole`

## Test plan

- [ ] `bun run typecheck` passes
- [ ] Manually verified verified badges display correct colors for different user roles in:
  - Post cards and quote embeds
  - User profiles and search results
  - DM conversations and group settings
  - Notifications and admin users page
- [ ] No new console errors / network errors

## Notes

- The `DmConversationDetail` members array now uses `chatRole` for the conversation-specific role (member/admin) and `role` for the user's platform role (user/admin/owner)
- All API routes updated to include the `role` field in user DTOs for consistency

https://claude.ai/code/session_01A1qUs97JQxLe2GqVcnQwmj