### PR TITLE
Add 404 page for invalid handles

### DIFF
--- a/apps/web/src/routes/$handle.tsx
+++ b/apps/web/src/routes/$handle.tsx
@@ -4,12 +4,28 @@ import { PageFrame } from "../components/page-frame"
 // Parent layout for all /$handle/... routes. Static routes (/login, /settings, /hashtag/:tag)
 // take precedence via TanStack Router's static-before-dynamic matcher; reserved handles
 // are enforced on the API side at claim time so collisions can't happen going forward.
-export const Route = createFileRoute("/$handle")({ component: HandleLayout })
+export const Route = createFileRoute("/$handle")({
+  component: HandleLayout,
+  notFoundComponent: HandleNotFound,
+})
 
 function HandleLayout() {
   return (
     <PageFrame>
       <Outlet />
+    </PageFrame>
+  )
+}
+
+function HandleNotFound() {
+  return (
+    <PageFrame>
+      <main className="p-4 pt-16">
+        <h1 className="text-lg font-semibold">404</h1>
+        <p className="text-sm text-muted-foreground">
+          That page doesn't exist.
+        </p>
+      </main>
     </PageFrame>
   )
 }


### PR DESCRIPTION
## Summary

- Added a `notFoundComponent` to the `/$handle` route to display a custom 404 page when a handle doesn't exist
- Created `HandleNotFound` component that displays a user-friendly error message within the page frame layout
- Ensures consistent styling and UX when users navigate to non-existent handles

## Test plan

- [ ] `bun run typecheck` passes
- [ ] Manually navigate to an invalid handle (e.g., `/nonexistenthandle`) and verify the 404 page displays correctly
- [ ] Verify the 404 page maintains consistent styling with the rest of the app

## Notes

The route's static-before-dynamic matcher and API-side handle validation remain unchanged, so no collisions can occur going forward.

https://claude.ai/code/session_01Rk5ibAxNTRW3crJ6CbY5ER