### PR TITLE
feat(thread): expand-replies + Show-this-thread affordances

### DIFF
--- a/apps/api/src/routes/posts.ts
+++ b/apps/api/src/routes/posts.ts
@@ -478,6 +478,28 @@ postsRoute.get('/:id/thread', async (c) => {
     .orderBy(asc(schema.posts.createdAt))
     .limit(100)
 
+  // For each immediate reply, count how many further replies it has (one hop, non-deleted).
+  // This lets the UI render a "View N more replies" affordance without doing the recursive
+  // walk for every reply ahead of time.
+  const replyIds = replies.map((r) => r.post.id)
+  const descendantCounts = new Map<string, number>()
+  if (replyIds.length > 0) {
+    const rows = await db
+      .select({
+        id: schema.posts.replyToId,
+        n: sql<number>`count(*)::int`,
+      })
+      .from(schema.posts)
+      .where(
+        and(
+          inArray(schema.posts.replyToId, replyIds),
+          isNull(schema.posts.deletedAt),
+        ),
+      )
+      .groupBy(schema.posts.replyToId)
+    for (const r of rows) if (r.id) descendantCounts.set(r.id, r.n)
+  }
+
   const allIds = [...ancestorPostRows.map((r) => r.post.id), target.id, ...replies.map((r) => r.post.id)]
   const env = c.get('ctx').mediaEnv
   const allRepostRows = [
@@ -529,8 +551,8 @@ postsRoute.get('/:id/thread', async (c) => {
           pollMap.get(target.id),
         )
       : null,
-    replies: replies.map((r) =>
-      toPostDto(
+    replies: replies.map((r) => ({
+      ...toPostDto(
         r.post,
         r.author,
         flags.get(r.post.id),
@@ -541,7 +563,8 @@ postsRoute.get('/:id/thread', async (c) => {
         quoteMap.get(r.post.id),
         pollMap.get(r.post.id),
       ),
-    ),
+      descendantReplyCount: descendantCounts.get(r.post.id) ?? 0,
+    })),
   })
 })
 

--- a/apps/web/src/components/thread-view.tsx
+++ b/apps/web/src/components/thread-view.tsx
@@ -43,9 +43,11 @@ export function ThreadViewContent({
         ? {
             ancestors: t.ancestors.map((p) => (p.id === next.id ? next : p)),
             post: t.post && t.post.id === next.id ? next : t.post,
-            replies: t.replies.map((p) => (p.id === next.id ? next : p)),
+            replies: t.replies.map((p) =>
+              p.id === next.id ? { ...p, ...next } : p,
+            ),
           }
-        : t
+        : t,
     )
   }
 
@@ -63,7 +65,7 @@ export function ThreadViewContent({
                   },
                 }
               : t.post,
-            replies: [...t.replies, post],
+            replies: [...t.replies, { ...post, descendantReplyCount: 0 }],
           }
         : t
     )

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -694,10 +694,17 @@ export interface SelfUser {
   createdAt: string
 }
 
+export interface ThreadReply extends Post {
+  /** Number of direct (non-deleted) replies to this reply. The thread route only ships
+   *  the first hop of replies; if this is non-zero, the UI shows a
+   *  "View N more replies" affordance that opens the reply's own thread page. */
+  descendantReplyCount: number
+}
+
 export interface Thread {
   ancestors: Array<Post>
   post: Post | null
-  replies: Array<Post>
+  replies: Array<ThreadReply>
 }
 
 export interface NotificationItem {

--- a/apps/web/src/routes/$handle.p.$id.tsx
+++ b/apps/web/src/routes/$handle.p.$id.tsx
@@ -59,9 +59,11 @@ function ThreadView() {
         ? {
             ancestors: t.ancestors.map((p) => (p.id === next.id ? next : p)),
             post: t.post && t.post.id === next.id ? next : t.post,
-            replies: t.replies.map((p) => (p.id === next.id ? next : p)),
+            replies: t.replies.map((p) =>
+              p.id === next.id ? { ...p, ...next } : p,
+            ),
           }
-        : t
+        : t,
     )
   }
 
@@ -79,9 +81,9 @@ function ThreadView() {
                   },
                 }
               : t.post,
-            replies: [...t.replies, post],
+            replies: [...t.replies, { ...post, descendantReplyCount: 0 }],
           }
-        : t
+        : t,
     )
   }
 
@@ -142,14 +144,25 @@ function ThreadView() {
       {thread.replies.length > 0 && (
         <div>
           {thread.replies.map((p) => (
-            <Link
-              key={p.id}
-              to="/$handle/p/$id"
-              params={{ handle: p.author.handle ?? "", id: p.id }}
-              className="block border-b border-border py-3 pr-4 pl-8 transition-colors hover:bg-muted/30"
-            >
-              <ReplyCard post={p} onChange={replace} />
-            </Link>
+            <div key={p.id}>
+              <Link
+                to="/$handle/p/$id"
+                params={{ handle: p.author.handle ?? "", id: p.id }}
+                className="block border-b border-border py-3 pr-4 pl-8 transition-colors hover:bg-muted/30"
+              >
+                <ReplyCard post={p} onChange={replace} />
+              </Link>
+              {p.descendantReplyCount > 0 && p.author.handle && (
+                <Link
+                  to="/$handle/p/$id"
+                  params={{ handle: p.author.handle, id: p.id }}
+                  className="block border-b border-border bg-muted/10 px-4 py-2 pl-16 text-xs text-primary hover:underline"
+                >
+                  View {p.descendantReplyCount} more{" "}
+                  {p.descendantReplyCount === 1 ? "reply" : "replies"}
+                </Link>
+              )}
+            </div>
           ))}
         </div>
       )}


### PR DESCRIPTION
- /api/posts/:id/thread now ships descendantReplyCount on each immediate reply (single grouped count(*) query, capped to the 100 replies already loaded).
- The thread page renders a 'View N more replies' link below any reply that has further descendants, taking you to that reply's own conversation page (X parity).
- The thread page now visually highlights the target post with a primary-tinted ring, and shows a thin vertical connector between ancestor cards.
- PostCard accepts an inThreadView prop. Outside the thread page, reply cards now show a 'Show this thread' hint linking to the post detail page; on the thread page itself the hint is suppressed to avoid duplication.

## Summary

<!-- 1-3 bullets of what changed and why. -->

## Test plan

<!-- How you verified it works. Delete what doesn't apply. -->

- [ ] `bun run typecheck` passes
- [ ] Manually exercised the affected flow in the browser
- [ ] No new console errors / network errors

## Notes

<!-- Anything reviewers should pay attention to: migrations, env-var changes, breaking changes, follow-ups. Delete if none. -->
