### PR TITLE
feat(replies): who-can-reply picker, server enforcement, hide-reply UX

### DIFF
--- a/apps/api/src/lib/post-dto.ts
+++ b/apps/api/src/lib/post-dto.ts
@@ -44,6 +44,9 @@ export interface PostDto {
   sensitive: boolean
   contentWarning: string | null
   replyRestriction: 'anyone' | 'following' | 'mentioned'
+  /** Set when the conversation root author hid this reply. The thread renderer
+   *  collapses these by default behind a "Show hidden replies" affordance. */
+  hidden?: boolean
   author: {
     id: string
     handle: string | null
@@ -120,6 +123,7 @@ export function toPostDto(
     sensitive: post.sensitive,
     contentWarning: post.contentWarning,
     replyRestriction: post.replyRestriction,
+    ...(post.hiddenAt ? { hidden: true } : {}),
     author: {
       id: author.id,
       handle: author.handle,

--- a/apps/api/src/routes/posts.ts
+++ b/apps/api/src/routes/posts.ts
@@ -51,6 +51,47 @@ postsRoute.post('/', requireAuth(), async (c) => {
       depth = parent.conversationDepth + 1
       replyTargetAuthorId = parent.authorId
 
+      // Enforce the conversation root's reply restriction. The author of the
+      // root and the post author can always reply (X behavior). For
+      // "following" we require the root's author to follow the replier;
+      // for "mentioned" we require the replier to be mentioned in the root.
+      const rootPostId = parent.rootId ?? parent.id
+      const [root] =
+        rootPostId === parent.id
+          ? [parent]
+          : await tx
+              .select()
+              .from(schema.posts)
+              .where(eq(schema.posts.id, rootPostId))
+              .limit(1)
+      if (root && root.authorId !== session.user.id) {
+        if (root.replyRestriction === 'following') {
+          const [followRow] = await tx
+            .select({ x: sql<number>`1` })
+            .from(schema.follows)
+            .where(
+              and(
+                eq(schema.follows.followerId, root.authorId),
+                eq(schema.follows.followeeId, session.user.id),
+              ),
+            )
+            .limit(1)
+          if (!followRow) throw new HttpError(403, 'replies_limited_to_following')
+        } else if (root.replyRestriction === 'mentioned') {
+          const [mentionRow] = await tx
+            .select({ x: sql<number>`1` })
+            .from(schema.mentions)
+            .where(
+              and(
+                eq(schema.mentions.postId, root.id),
+                eq(schema.mentions.mentionedUserId, session.user.id),
+              ),
+            )
+            .limit(1)
+          if (!mentionRow) throw new HttpError(403, 'replies_limited_to_mentioned')
+        }
+      }
+
       await tx
         .update(schema.posts)
         .set({ replyCount: sql`${schema.posts.replyCount} + 1` })
@@ -789,6 +830,81 @@ postsRoute.get('/', async (c) => {
   )
   const nextCursor = posts.length === limit ? posts[posts.length - 1]!.createdAt : null
   return c.json({ posts, nextCursor })
+})
+
+// Hide a reply from the conversation view. Allowed for the author of the
+// conversation root and for site moderators. The reply is not deleted; the
+// reply's author still sees it on their own profile and direct links still
+// resolve, but the thread route collapses it behind a "Show hidden replies"
+// affordance — same UX as X.
+postsRoute.post('/:id/hide', requireAuth(), async (c) => {
+  const session = c.get('session')!
+  const { db } = c.get('ctx')
+  const id = c.req.param('id')
+  const [post] = await db
+    .select()
+    .from(schema.posts)
+    .where(and(eq(schema.posts.id, id), isNull(schema.posts.deletedAt)))
+    .limit(1)
+  if (!post) return c.json({ error: 'not_found' }, 404)
+  if (!post.replyToId) return c.json({ error: 'cannot_hide_root' }, 400)
+  const rootId = post.rootId ?? post.replyToId
+  const [root] = await db
+    .select({ authorId: schema.posts.authorId })
+    .from(schema.posts)
+    .where(eq(schema.posts.id, rootId))
+    .limit(1)
+  if (!root) return c.json({ error: 'not_found' }, 404)
+  const me = session.user.id
+  const [meRow] = await db
+    .select({ role: schema.users.role })
+    .from(schema.users)
+    .where(eq(schema.users.id, me))
+    .limit(1)
+  const isMod = meRow?.role === 'admin' || meRow?.role === 'owner'
+  if (root.authorId !== me && !isMod) {
+    return c.json({ error: 'forbidden' }, 403)
+  }
+  await db
+    .update(schema.posts)
+    .set({ hiddenAt: new Date() })
+    .where(eq(schema.posts.id, post.id))
+  return c.json({ ok: true })
+})
+
+postsRoute.delete('/:id/hide', requireAuth(), async (c) => {
+  const session = c.get('session')!
+  const { db } = c.get('ctx')
+  const id = c.req.param('id')
+  const [post] = await db
+    .select({ id: schema.posts.id, rootId: schema.posts.rootId, replyToId: schema.posts.replyToId })
+    .from(schema.posts)
+    .where(eq(schema.posts.id, id))
+    .limit(1)
+  if (!post) return c.json({ error: 'not_found' }, 404)
+  const rootId = post.rootId ?? post.replyToId
+  if (!rootId) return c.json({ error: 'cannot_hide_root' }, 400)
+  const [root] = await db
+    .select({ authorId: schema.posts.authorId })
+    .from(schema.posts)
+    .where(eq(schema.posts.id, rootId))
+    .limit(1)
+  if (!root) return c.json({ error: 'not_found' }, 404)
+  const me = session.user.id
+  const [meRow] = await db
+    .select({ role: schema.users.role })
+    .from(schema.users)
+    .where(eq(schema.users.id, me))
+    .limit(1)
+  const isMod = meRow?.role === 'admin' || meRow?.role === 'owner'
+  if (root.authorId !== me && !isMod) {
+    return c.json({ error: 'forbidden' }, 403)
+  }
+  await db
+    .update(schema.posts)
+    .set({ hiddenAt: null })
+    .where(eq(schema.posts.id, post.id))
+  return c.json({ ok: true })
 })
 
 class HttpError extends Error {

--- a/apps/web/src/components/compose.tsx
+++ b/apps/web/src/components/compose.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from "react"
-import { IconChartBar, IconPhoto, IconX } from "@tabler/icons-react"
+import { IconChartBar, IconPhoto, IconUsers, IconX } from "@tabler/icons-react"
 import { Button } from "@workspace/ui/components/button"
 import {
   POLL_MAX_OPTIONS,
@@ -75,6 +75,12 @@ export function Compose({
   const [poll, setPoll] = useState<PollDraft | null>(null)
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  // Replies inherit their thread's restriction; only let the user pick on
+  // top-level posts and quotes (which start a new thread).
+  const [replyRestriction, setReplyRestriction] = useState<
+    "anyone" | "following" | "mentioned"
+  >("anyone")
+  const showReplyControl = !replyToId
   const avatarInitial = (me?.displayName ?? me?.handle ?? "·")
     .slice(0, 1)
     .toUpperCase()
@@ -196,6 +202,7 @@ export function Compose({
         quoteOfId,
         mediaIds: readyMediaIds.length > 0 ? readyMediaIds : undefined,
         poll: pollPayload,
+        replyRestriction: showReplyControl ? replyRestriction : undefined,
       })
       setText("")
       clearDraft(dKey)
@@ -436,6 +443,27 @@ export function Compose({
               >
                 <IconChartBar size={18} stroke={1.75} />
               </Button>
+              {showReplyControl && (
+                <label
+                  className="flex items-center gap-1.5 rounded-md border border-transparent px-1.5 py-0.5 text-xs text-muted-foreground hover:border-border hover:text-foreground"
+                  title="Who can reply to this post"
+                >
+                  <IconUsers size={14} stroke={1.75} />
+                  <select
+                    value={replyRestriction}
+                    onChange={(e) =>
+                      setReplyRestriction(
+                        e.target.value as "anyone" | "following" | "mentioned",
+                      )
+                    }
+                    className="bg-transparent text-xs focus:outline-none"
+                  >
+                    <option value="anyone">Everyone can reply</option>
+                    <option value="following">People you follow</option>
+                    <option value="mentioned">Only people you mention</option>
+                  </select>
+                </label>
+              )}
               <span
                 className={`text-xs ${
                   remaining < 0

--- a/apps/web/src/components/post-card.tsx
+++ b/apps/web/src/components/post-card.tsx
@@ -4,6 +4,8 @@ import {
   IconBookmark,
   IconBookmarkFilled,
   IconDots,
+  IconEye,
+  IconEyeOff,
   IconFlag,
   IconHeart,
   IconHeartFilled,
@@ -242,6 +244,7 @@ export function PostCard({
   onOpenThread,
   active = false,
   disableThreadNavigation = false,
+  canHide = false,
 }: {
   post: Post
   onChange?: (post: Post) => void
@@ -249,6 +252,9 @@ export function PostCard({
   onOpenThread?: (post: Post) => void
   active?: boolean
   disableThreadNavigation?: boolean
+  /** When true (set by the thread page when the viewer authored the conversation
+   *  root, or by admin tooling for moderators), expose Hide/Unhide reply menu items. */
+  canHide?: boolean
 }) {
   const navigate = useNavigate()
   const { data: session } = authClient.useSession()
@@ -585,6 +591,26 @@ export function PostCard({
                     >
                       <IconTrash size={14} stroke={1.75} />
                       <span>Delete</span>
+                    </DropdownMenuItem>
+                  )}
+                  {canHide && !isOwner && (
+                    <DropdownMenuItem
+                      onClick={async () => {
+                        try {
+                          if (post.hidden) await api.unhidePost(post.id)
+                          else await api.hidePost(post.id)
+                          onChange?.({ ...post, hidden: !post.hidden })
+                        } catch {
+                          /* surfaced via stale state on refresh */
+                        }
+                      }}
+                    >
+                      {post.hidden ? (
+                        <IconEye size={14} stroke={1.75} />
+                      ) : (
+                        <IconEyeOff size={14} stroke={1.75} />
+                      )}
+                      <span>{post.hidden ? "Unhide reply" : "Hide reply"}</span>
                     </DropdownMenuItem>
                   )}
                   {!isOwner && (

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -281,6 +281,8 @@ export const api = {
     quoteOfId?: string
     mediaIds?: Array<string>
     poll?: PollInput
+    /** Who can reply to this post. Defaults to anyone server-side. */
+    replyRestriction?: "anyone" | "following" | "mentioned"
   }) =>
     request<{ post: Post }>("/api/posts", {
       method: "POST",
@@ -379,6 +381,10 @@ export const api = {
     request<{ ok: true }>(`/api/posts/${id}/repost`, { method: "POST" }),
   unrepost: (id: string) =>
     request<{ ok: true }>(`/api/posts/${id}/repost`, { method: "DELETE" }),
+  hidePost: (id: string) =>
+    request<{ ok: true }>(`/api/posts/${id}/hide`, { method: "POST" }),
+  unhidePost: (id: string) =>
+    request<{ ok: true }>(`/api/posts/${id}/hide`, { method: "DELETE" }),
   pinPost: (id: string) =>
     request<{ ok: true }>(`/api/posts/${id}/pin`, { method: "POST" }),
   unpinPost: (id: string) =>
@@ -487,6 +493,9 @@ export interface Post {
   sensitive: boolean
   contentWarning: string | null
   replyRestriction: "anyone" | "following" | "mentioned"
+  /** Set when the conversation root author hid this reply. The thread renderer
+   *  collapses these by default behind a "Show hidden replies" affordance. */
+  hidden?: boolean
   author: {
     id: string
     handle: string | null

--- a/packages/db/src/schema/posts.ts
+++ b/packages/db/src/schema/posts.ts
@@ -43,6 +43,10 @@ export const posts = pgTable(
     replyRestriction: replyRestrictionEnum('reply_restriction').notNull().default('anyone'),
     editedAt: timestamp('edited_at', { withTimezone: true }),
     deletedAt: timestamp('deleted_at', { withTimezone: true }),
+    // Set when the author of the conversation root hides this reply. The reply is still
+    // visible in the original author's own profile and to anyone with the direct link;
+    // it's only collapsed/hidden from the conversation view of the root post (X parity).
+    hiddenAt: timestamp('hidden_at', { withTimezone: true }),
     // Timestamp the author last pinned this post to their profile. Nullable; only one pinned
     // post per author is enforced in the route layer (atomic clear-then-set in a tx).
     pinnedAt: timestamp('pinned_at', { withTimezone: true }),


### PR DESCRIPTION
- Add a 'Who can reply' selector to the Compose toolbar (Everyone / People you follow / Only people you mention) on top-level posts and quotes. Replies inherit the thread's restriction.
- Server enforcement on POST /api/posts:
  - 'following' requires the conversation root's author to follow the replier.
  - 'mentioned' requires the replier to be in the root's mentions table.
  - The root's author and the post's author can always reply.
- Add a hidden_at column to posts (drizzle push, no migration files) and POST/DELETE /api/posts/:id/hide endpoints. Allowed for the conversation root's author and for admin/owner roles.
- Surface 'hidden' on the post DTO. Thread page collapses hidden replies behind a 'Show N hidden replies' toggle for non-root readers, while the root author always sees them and gets Hide/Unhide menu items via PostCard's new canHide prop.
- Replies that are hidden render with a 'Hidden by post author' notice banner above the card.

## Summary

<!-- 1-3 bullets of what changed and why. -->

## Test plan

<!-- How you verified it works. Delete what doesn't apply. -->

- [ ] `bun run typecheck` passes
- [ ] Manually exercised the affected flow in the browser
- [ ] No new console errors / network errors

## Notes

<!-- Anything reviewers should pay attention to: migrations, env-var changes, breaking changes, follow-ups. Delete if none. -->
