### PR TITLE
feat(bookmarks): folders for organizing saved posts

### DIFF
--- a/apps/api/src/routes/me.ts
+++ b/apps/api/src/routes/me.ts
@@ -1,5 +1,6 @@
 import { Hono } from 'hono'
-import { and, desc, eq, isNull, lt } from '@workspace/db'
+import { z } from 'zod'
+import { and, asc, desc, eq, isNull, lt, sql } from '@workspace/db'
 import { schema } from '@workspace/db'
 import { updateProfileSchema, claimHandleSchema } from '@workspace/validators'
 import { assetUrl, extractKey } from '@workspace/media/s3'
@@ -150,12 +151,22 @@ meRoute.get('/mutes', async (c) => {
   return c.json({ users, nextCursor })
 })
 
-// Viewer's bookmarked posts, newest bookmark first.
+// Viewer's bookmarked posts, newest bookmark first. The optional ?folder
+// query selects either a specific folder by id or the implicit "Unsorted"
+// bucket (folder=none). Without a query param, all bookmarks are returned.
 meRoute.get('/bookmarks', async (c) => {
   const session = c.get('session')!
   const { db, mediaEnv } = c.get('ctx')
   const limit = Math.min(Number(c.req.query('limit') ?? 40), 100)
   const cursor = parseCursor(c.req.query('cursor'))
+  const folderQ = c.req.query('folder')
+
+  const folderFilter =
+    folderQ === 'none'
+      ? isNull(schema.bookmarks.folderId)
+      : folderQ
+        ? eq(schema.bookmarks.folderId, folderQ)
+        : undefined
 
   const rows = await db
     .select({ post: schema.posts, author: schema.users, bookmarkedAt: schema.bookmarks.createdAt })
@@ -167,6 +178,7 @@ meRoute.get('/bookmarks', async (c) => {
         eq(schema.bookmarks.userId, session.user.id),
         isNull(schema.posts.deletedAt),
         cursor ? lt(schema.bookmarks.createdAt, cursor) : undefined,
+        folderFilter,
       ),
     )
     .orderBy(desc(schema.bookmarks.createdAt))
@@ -206,6 +218,146 @@ meRoute.get('/bookmarks', async (c) => {
   )
   const nextCursor = rows.length === limit ? rows[rows.length - 1]!.bookmarkedAt.toISOString() : null
   return c.json({ posts, nextCursor })
+})
+
+// List/create/rename/delete bookmark folders + add/remove a bookmark to/from
+// a folder. Folders are private to the viewer; only their owner can read or
+// modify them.
+meRoute.get('/bookmark-folders', async (c) => {
+  const session = c.get('session')!
+  const { db } = c.get('ctx')
+  const folders = await db
+    .select({
+      id: schema.bookmarkFolders.id,
+      name: schema.bookmarkFolders.name,
+      createdAt: schema.bookmarkFolders.createdAt,
+    })
+    .from(schema.bookmarkFolders)
+    .where(eq(schema.bookmarkFolders.userId, session.user.id))
+    .orderBy(asc(schema.bookmarkFolders.createdAt))
+  // Per-folder counts (including the "unsorted" bucket) so the UI can show
+  // counts beside each folder name.
+  const folderCounts = await db
+    .select({
+      folderId: schema.bookmarks.folderId,
+      n: sql<number>`count(*)::int`,
+    })
+    .from(schema.bookmarks)
+    .where(eq(schema.bookmarks.userId, session.user.id))
+    .groupBy(schema.bookmarks.folderId)
+  const totals = new Map<string | null, number>(
+    folderCounts.map((r) => [r.folderId, r.n]),
+  )
+  return c.json({
+    folders: folders.map((f) => ({
+      id: f.id,
+      name: f.name,
+      createdAt: f.createdAt.toISOString(),
+      bookmarkCount: totals.get(f.id) ?? 0,
+    })),
+    unsortedCount: totals.get(null) ?? 0,
+  })
+})
+
+const folderNameSchema = z.string().trim().min(1).max(50)
+
+meRoute.post('/bookmark-folders', async (c) => {
+  const session = c.get('session')!
+  const { db } = c.get('ctx')
+  const body = z.object({ name: folderNameSchema }).parse(await c.req.json())
+  const [created] = await db
+    .insert(schema.bookmarkFolders)
+    .values({ userId: session.user.id, name: body.name })
+    .returning()
+  if (!created) return c.json({ error: 'insert_failed' }, 500)
+  return c.json({
+    folder: {
+      id: created.id,
+      name: created.name,
+      createdAt: created.createdAt.toISOString(),
+      bookmarkCount: 0,
+    },
+  })
+})
+
+meRoute.patch('/bookmark-folders/:id', async (c) => {
+  const session = c.get('session')!
+  const { db } = c.get('ctx')
+  const id = c.req.param('id')
+  const body = z.object({ name: folderNameSchema }).parse(await c.req.json())
+  const [updated] = await db
+    .update(schema.bookmarkFolders)
+    .set({ name: body.name })
+    .where(
+      and(
+        eq(schema.bookmarkFolders.id, id),
+        eq(schema.bookmarkFolders.userId, session.user.id),
+      ),
+    )
+    .returning()
+  if (!updated) return c.json({ error: 'not_found' }, 404)
+  return c.json({
+    folder: {
+      id: updated.id,
+      name: updated.name,
+      createdAt: updated.createdAt.toISOString(),
+    },
+  })
+})
+
+meRoute.delete('/bookmark-folders/:id', async (c) => {
+  const session = c.get('session')!
+  const { db } = c.get('ctx')
+  const id = c.req.param('id')
+  const result = await db
+    .delete(schema.bookmarkFolders)
+    .where(
+      and(
+        eq(schema.bookmarkFolders.id, id),
+        eq(schema.bookmarkFolders.userId, session.user.id),
+      ),
+    )
+    .returning({ id: schema.bookmarkFolders.id })
+  if (result.length === 0) return c.json({ error: 'not_found' }, 404)
+  return c.json({ ok: true })
+})
+
+// Move (or remove) a bookmark to/from a folder. The bookmark itself must
+// already exist for the viewer; this endpoint never creates new bookmarks.
+meRoute.put('/bookmarks/:postId/folder', async (c) => {
+  const session = c.get('session')!
+  const { db } = c.get('ctx')
+  const postId = c.req.param('postId')
+  const body = z
+    .object({ folderId: z.string().uuid().nullable() })
+    .parse(await c.req.json())
+
+  if (body.folderId) {
+    const [folder] = await db
+      .select({ id: schema.bookmarkFolders.id })
+      .from(schema.bookmarkFolders)
+      .where(
+        and(
+          eq(schema.bookmarkFolders.id, body.folderId),
+          eq(schema.bookmarkFolders.userId, session.user.id),
+        ),
+      )
+      .limit(1)
+    if (!folder) return c.json({ error: 'folder_not_found' }, 404)
+  }
+
+  const [updated] = await db
+    .update(schema.bookmarks)
+    .set({ folderId: body.folderId })
+    .where(
+      and(
+        eq(schema.bookmarks.userId, session.user.id),
+        eq(schema.bookmarks.postId, postId),
+      ),
+    )
+    .returning({ postId: schema.bookmarks.postId })
+  if (!updated) return c.json({ error: 'bookmark_not_found' }, 404)
+  return c.json({ ok: true })
 })
 
 function toSelfDto(

--- a/apps/web/src/components/post-card.tsx
+++ b/apps/web/src/components/post-card.tsx
@@ -5,6 +5,7 @@ import {
   IconBookmarkFilled,
   IconDots,
   IconFlag,
+  IconFolders,
   IconHeart,
   IconHeartFilled,
   IconMessageCircle,
@@ -20,6 +21,10 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
   DropdownMenuTrigger,
 } from "@workspace/ui/components/dropdown-menu"
 import {
@@ -593,6 +598,9 @@ export function PostCard({
                       <span>Report</span>
                     </DropdownMenuItem>
                   )}
+                  {post.viewer?.bookmarked && (
+                    <BookmarkFolderSubmenu postId={post.id} />
+                  )}
                 </DropdownMenuContent>
               </DropdownMenu>
             )}
@@ -815,6 +823,63 @@ function RepostControl({
           />
         </DialogContent>
       </Dialog>
+    </>
+  )
+}
+
+function BookmarkFolderSubmenu({ postId }: { postId: string }) {
+  const [folders, setFolders] = useState<Array<{ id: string; name: string }> | null>(null)
+  const [loading, setLoading] = useState(false)
+  async function load() {
+    if (folders !== null || loading) return
+    setLoading(true)
+    try {
+      const { folders: rows } = await api.bookmarkFolders()
+      setFolders(rows)
+    } catch {
+      setFolders([])
+    } finally {
+      setLoading(false)
+    }
+  }
+  return (
+    <>
+      <DropdownMenuSeparator />
+      <DropdownMenuSub>
+        <DropdownMenuSubTrigger onMouseEnter={load} onFocus={load}>
+          <IconFolders size={14} stroke={1.75} />
+          <span>Move to folder</span>
+        </DropdownMenuSubTrigger>
+        <DropdownMenuSubContent className="w-44">
+          <DropdownMenuItem
+            onClick={() => {
+              api.setBookmarkFolder(postId, null).catch(() => {})
+            }}
+          >
+            <span>Unsorted</span>
+          </DropdownMenuItem>
+          {folders === null && loading && (
+            <DropdownMenuItem disabled>
+              <span className="text-muted-foreground">loading…</span>
+            </DropdownMenuItem>
+          )}
+          {folders?.length === 0 && (
+            <DropdownMenuItem disabled>
+              <span className="text-muted-foreground">no folders yet</span>
+            </DropdownMenuItem>
+          )}
+          {folders?.map((f) => (
+            <DropdownMenuItem
+              key={f.id}
+              onClick={() => {
+                api.setBookmarkFolder(postId, f.id).catch(() => {})
+              }}
+            >
+              <span className="truncate">{f.name}</span>
+            </DropdownMenuItem>
+          ))}
+        </DropdownMenuSubContent>
+      </DropdownMenuSub>
     </>
   )
 }

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -92,8 +92,38 @@ export const api = {
     request<{ users: Array<PublicUser>; posts: Array<Post> }>(
       `/api/search?q=${encodeURIComponent(q)}`
     ),
-  bookmarks: (cursor?: string) =>
-    request<FeedPage>(`/api/me/bookmarks${qs(cursor)}`),
+  bookmarks: (cursor?: string, folder?: string) => {
+    const params = new URLSearchParams()
+    if (cursor) params.set("cursor", cursor)
+    if (folder) params.set("folder", folder)
+    const search = params.toString()
+    return request<FeedPage>(
+      `/api/me/bookmarks${search ? `?${search}` : ""}`,
+    )
+  },
+  bookmarkFolders: () =>
+    request<{ folders: Array<BookmarkFolder>; unsortedCount: number }>(
+      "/api/me/bookmark-folders",
+    ),
+  createBookmarkFolder: (name: string) =>
+    request<{ folder: BookmarkFolder }>("/api/me/bookmark-folders", {
+      method: "POST",
+      body: JSON.stringify({ name }),
+    }),
+  renameBookmarkFolder: (id: string, name: string) =>
+    request<{ folder: BookmarkFolder }>(`/api/me/bookmark-folders/${id}`, {
+      method: "PATCH",
+      body: JSON.stringify({ name }),
+    }),
+  deleteBookmarkFolder: (id: string) =>
+    request<{ ok: true }>(`/api/me/bookmark-folders/${id}`, {
+      method: "DELETE",
+    }),
+  setBookmarkFolder: (postId: string, folderId: string | null) =>
+    request<{ ok: true }>(`/api/me/bookmarks/${postId}/folder`, {
+      method: "PUT",
+      body: JSON.stringify({ folderId }),
+    }),
   blocks: (cursor?: string) =>
     request<{ users: Array<BlockedUser>; nextCursor: string | null }>(
       `/api/me/blocks${qs(cursor)}`
@@ -692,6 +722,13 @@ export interface SelfUser {
   locale: string
   timezone: string | null
   createdAt: string
+}
+
+export interface BookmarkFolder {
+  id: string
+  name: string
+  createdAt: string
+  bookmarkCount?: number
 }
 
 export interface Thread {

--- a/apps/web/src/routes/bookmarks.tsx
+++ b/apps/web/src/routes/bookmarks.tsx
@@ -1,11 +1,16 @@
 import { createFileRoute, useRouter } from "@tanstack/react-router"
-import { useCallback, useEffect } from "react"
-import { api } from "../lib/api"
+import { useCallback, useEffect, useState } from "react"
+import { IconFolderPlus, IconPencil, IconTrash } from "@tabler/icons-react"
+import { Button } from "@workspace/ui/components/button"
+import { ApiError, api } from "../lib/api"
 import { authClient } from "../lib/auth"
 import { Feed } from "../components/feed"
 import { PageFrame } from "../components/page-frame"
+import type { BookmarkFolder } from "../lib/api"
 
 export const Route = createFileRoute("/bookmarks")({ component: Bookmarks })
+
+type FolderSel = "all" | "unsorted" | string
 
 function Bookmarks() {
   const { data: session, isPending } = authClient.useSession()
@@ -14,23 +19,170 @@ function Bookmarks() {
     if (!isPending && !session) router.navigate({ to: "/login" })
   }, [isPending, session, router])
 
-  const load = useCallback((cursor?: string) => api.bookmarks(cursor), [])
+  const [folders, setFolders] = useState<Array<BookmarkFolder> | null>(null)
+  const [unsortedCount, setUnsortedCount] = useState<number>(0)
+  const [sel, setSel] = useState<FolderSel>("all")
+  const [error, setError] = useState<string | null>(null)
+
+  async function refreshFolders() {
+    try {
+      const { folders: rows, unsortedCount: u } = await api.bookmarkFolders()
+      setFolders(rows)
+      setUnsortedCount(u)
+    } catch (e) {
+      setError(e instanceof ApiError ? e.message : "couldn't load folders")
+    }
+  }
+
+  useEffect(() => {
+    if (!session) return
+    refreshFolders()
+  }, [session])
+
+  const load = useCallback(
+    (cursor?: string) =>
+      api.bookmarks(
+        cursor,
+        sel === "all" ? undefined : sel === "unsorted" ? "none" : sel,
+      ),
+    [sel],
+  )
+
+  async function createFolder() {
+    const name = window.prompt("New folder name")?.trim()
+    if (!name) return
+    try {
+      await api.createBookmarkFolder(name)
+      await refreshFolders()
+    } catch (e) {
+      alert(e instanceof ApiError ? e.message : "couldn't create folder")
+    }
+  }
+  async function renameFolder(f: BookmarkFolder) {
+    const name = window.prompt("Rename folder", f.name)?.trim()
+    if (!name || name === f.name) return
+    try {
+      await api.renameBookmarkFolder(f.id, name)
+      await refreshFolders()
+    } catch (e) {
+      alert(e instanceof ApiError ? e.message : "couldn't rename folder")
+    }
+  }
+  async function deleteFolder(f: BookmarkFolder) {
+    if (!window.confirm(`Delete folder “${f.name}”? Bookmarks inside will move to Unsorted.`)) {
+      return
+    }
+    try {
+      await api.deleteBookmarkFolder(f.id)
+      if (sel === f.id) setSel("all")
+      await refreshFolders()
+    } catch (e) {
+      alert(e instanceof ApiError ? e.message : "couldn't delete folder")
+    }
+  }
 
   return (
     <PageFrame>
-      <main className="">
+      <main>
         <header className="border-b border-border px-4 py-3">
           <h1 className="text-base font-semibold">Bookmarks</h1>
           <p className="text-xs text-muted-foreground">
             only you can see this list.
           </p>
         </header>
+        <div className="flex items-center gap-1 overflow-x-auto border-b border-border px-4 py-2 text-sm">
+          <FolderTab
+            active={sel === "all"}
+            onClick={() => setSel("all")}
+            label="All"
+          />
+          <FolderTab
+            active={sel === "unsorted"}
+            onClick={() => setSel("unsorted")}
+            label="Unsorted"
+            count={unsortedCount}
+          />
+          {folders?.map((f) => (
+            <div key={f.id} className="group flex items-center">
+              <FolderTab
+                active={sel === f.id}
+                onClick={() => setSel(f.id)}
+                label={f.name}
+                count={f.bookmarkCount}
+              />
+              {sel === f.id && (
+                <span className="ml-1 flex items-center gap-0.5">
+                  <Button
+                    size="icon-xs"
+                    variant="ghost"
+                    aria-label={`rename ${f.name}`}
+                    onClick={() => renameFolder(f)}
+                  >
+                    <IconPencil size={12} stroke={1.75} />
+                  </Button>
+                  <Button
+                    size="icon-xs"
+                    variant="ghost"
+                    aria-label={`delete ${f.name}`}
+                    onClick={() => deleteFolder(f)}
+                  >
+                    <IconTrash size={12} stroke={1.75} />
+                  </Button>
+                </span>
+              )}
+            </div>
+          ))}
+          <Button
+            size="sm"
+            variant="ghost"
+            onClick={createFolder}
+            className="ml-auto whitespace-nowrap"
+          >
+            <IconFolderPlus size={14} stroke={1.75} />
+            <span>New folder</span>
+          </Button>
+        </div>
+        {error && <p className="px-4 py-2 text-xs text-destructive">{error}</p>}
         <Feed
-          queryKey={["bookmarks"]}
+          key={sel}
+          queryKey={["bookmarks", sel]}
           load={load}
-          emptyMessage="no bookmarks yet. tap the bookmark icon on a post to save it."
+          emptyMessage={
+            sel === "all"
+              ? "no bookmarks yet. tap the bookmark icon on a post to save it."
+              : "this folder is empty."
+          }
         />
       </main>
     </PageFrame>
+  )
+}
+
+function FolderTab({
+  active,
+  onClick,
+  label,
+  count,
+}: {
+  active: boolean
+  onClick: () => void
+  label: string
+  count?: number
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`whitespace-nowrap rounded-full px-3 py-1 text-xs ${
+        active
+          ? "bg-primary text-primary-foreground"
+          : "text-muted-foreground hover:bg-muted hover:text-foreground"
+      }`}
+    >
+      {label}
+      {typeof count === "number" && count > 0 && (
+        <span className="ml-1.5 opacity-80">{count}</span>
+      )}
+    </button>
   )
 }

--- a/packages/db/src/schema/posts.ts
+++ b/packages/db/src/schema/posts.ts
@@ -108,6 +108,25 @@ export const likes = pgTable(
   ],
 )
 
+// User-owned folders for bookmarks. Bookmarks without a folder are surfaced
+// as the implicit "All bookmarks" view; bookmarks WITH a folder are shown
+// inside that folder. A bookmark can live in at most one folder, matching X.
+export const bookmarkFolders = pgTable(
+  'bookmark_folders',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    userId: uuid('user_id')
+      .notNull()
+      .references(() => users.id, { onDelete: 'cascade' }),
+    name: text('name').notNull(),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => [
+    index('bookmark_folders_user_idx').on(t.userId, t.createdAt),
+    check('bookmark_folder_name_len', sql`char_length(${t.name}) BETWEEN 1 AND 50`),
+  ],
+)
+
 export const bookmarks = pgTable(
   'bookmarks',
   {
@@ -117,11 +136,15 @@ export const bookmarks = pgTable(
     postId: uuid('post_id')
       .notNull()
       .references(() => posts.id, { onDelete: 'cascade' }),
+    folderId: uuid('folder_id').references(() => bookmarkFolders.id, {
+      onDelete: 'set null',
+    }),
     createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
   },
   (t) => [
     primaryKey({ columns: [t.userId, t.postId] }),
     index('bookmarks_user_idx').on(t.userId, t.createdAt),
+    index('bookmarks_folder_idx').on(t.folderId, t.createdAt),
   ],
 )
 


### PR DESCRIPTION
- Add bookmark_folders table and a nullable bookmarks.folder_id column (drizzle push, schema only).
- Server endpoints under /api/me:
  - GET /bookmark-folders → list folders + per-folder counts (incl. an 'unsortedCount' bucket for bookmarks not in any folder).
  - POST /bookmark-folders, PATCH /:id, DELETE /:id.
  - PUT /bookmarks/:postId/folder { folderId } moves a bookmark.
  - GET /bookmarks now accepts ?folder=<uuid> or ?folder=none.
- Web client gains api.bookmarkFolders / create / rename / delete / setBookmarkFolder and a BookmarkFolder type.
- /bookmarks page now shows a horizontal folder bar (All / Unsorted / each folder with its count) plus inline rename/delete and a 'New folder' button. The Feed rerenders against the selected folder via the cursor key.
- PostCard's overflow menu gains a 'Move to folder' submenu that appears for bookmarked posts. The folder list is fetched lazily on hover/focus.

## Summary

<!-- 1-3 bullets of what changed and why. -->

## Test plan

<!-- How you verified it works. Delete what doesn't apply. -->

- [ ] `bun run typecheck` passes
- [ ] Manually exercised the affected flow in the browser
- [ ] No new console errors / network errors

## Notes

<!-- Anything reviewers should pay attention to: migrations, env-var changes, breaking changes, follow-ups. Delete if none. -->
