### PR TITLE
feat(feed): Network tab — posts your follows liked or reposted

### DIFF
--- a/apps/api/src/routes/feed.ts
+++ b/apps/api/src/routes/feed.ts
@@ -107,3 +107,201 @@ feedRoute.get('/', requireAuth(), async (c) => {
   }
   return c.json(response)
 })
+
+// Network feed: posts the viewer's follows recently liked or reposted, where
+// the post itself is by someone the viewer does NOT already follow. Useful as
+// a "people you don't follow but are adjacent to" timeline. Excludes the
+// viewer's blocks/mutes and any post by a blocked author.
+const NETWORK_FEED_TTL_SEC = 60
+
+feedRoute.get('/network', requireAuth(), async (c) => {
+  const session = c.get('session')!
+  const { db, mediaEnv, rateLimit } = c.get('ctx')
+  await rateLimit(c, 'reads.feed')
+  const limit = Math.min(Number(c.req.query('limit') ?? 40), 100)
+  const cursor = parseCursor(c.req.query('cursor'))
+  const me = session.user.id
+
+  // The activity that surfaced the post is one of: a like by a follow,
+  // a repost row by a follow. We compute MAX(activity_at) per post so the
+  // feed is "newest activity first" (X parity for non-following timelines).
+  // SECURITY: the WHERE clause excludes posts by anyone in a mutual block
+  // relationship and any author the viewer feed-mutes.
+  type Row = {
+    post: typeof schema.posts.$inferSelect
+    author: typeof schema.users.$inferSelect
+    activityAt: Date
+    actorIds: Array<string>
+  }
+  // Surface posts via likes from follows.
+  const likeRows = await db
+    .select({
+      post: schema.posts,
+      author: schema.users,
+      activityAt: schema.likes.createdAt,
+      actorId: schema.likes.userId,
+    })
+    .from(schema.likes)
+    .innerJoin(
+      schema.follows,
+      and(
+        eq(schema.follows.followerId, me),
+        eq(schema.follows.followeeId, schema.likes.userId),
+      ),
+    )
+    .innerJoin(schema.posts, eq(schema.posts.id, schema.likes.postId))
+    .innerJoin(schema.users, eq(schema.users.id, schema.posts.authorId))
+    .where(
+      and(
+        isNull(schema.posts.deletedAt),
+        eq(schema.posts.visibility, 'public'),
+        // Skip posts by people the viewer already follows; those belong on
+        // the home feed. Skip viewer's own posts too.
+        sql`NOT EXISTS (SELECT 1 FROM ${schema.follows} ff WHERE ff.follower_id = ${me} AND ff.followee_id = ${schema.posts.authorId})`,
+        sql`${schema.posts.authorId} <> ${me}`,
+        sql`NOT EXISTS (SELECT 1 FROM ${schema.blocks} b WHERE (b.blocker_id = ${me} AND b.blocked_id = ${schema.posts.authorId}) OR (b.blocker_id = ${schema.posts.authorId} AND b.blocked_id = ${me}))`,
+        sql`NOT EXISTS (SELECT 1 FROM ${schema.mutes} m WHERE m.muter_id = ${me} AND m.muted_id = ${schema.posts.authorId} AND (m.scope = 'feed' OR m.scope = 'both'))`,
+        cursor ? lt(schema.likes.createdAt, cursor) : undefined,
+      ),
+    )
+    .orderBy(desc(schema.likes.createdAt))
+    .limit(limit * 2)
+
+  // Surface posts via reposts from follows. We use the repost row's createdAt
+  // (i.e. when the follow reposted it), not the original post's createdAt.
+  const repostRows = await db
+    .select({
+      post: schema.posts,
+      author: schema.users,
+      activityAt: sql<Date>`reposters.created_at`.as('activity_at'),
+      actorId: sql<string>`reposters.author_id`.as('actor_id'),
+    })
+    .from(
+      sql`(
+        SELECT r.repost_of_id AS post_id, r.author_id, r.created_at
+        FROM ${schema.posts} r
+        INNER JOIN ${schema.follows} f
+          ON f.follower_id = ${me} AND f.followee_id = r.author_id
+        WHERE r.repost_of_id IS NOT NULL
+          AND r.deleted_at IS NULL
+          ${cursor ? sql`AND r.created_at < ${cursor}` : sql``}
+        ORDER BY r.created_at DESC
+        LIMIT ${limit * 2}
+      ) reposters`,
+    )
+    .innerJoin(schema.posts, sql`${schema.posts.id} = reposters.post_id`)
+    .innerJoin(schema.users, eq(schema.users.id, schema.posts.authorId))
+    .where(
+      and(
+        isNull(schema.posts.deletedAt),
+        eq(schema.posts.visibility, 'public'),
+        sql`NOT EXISTS (SELECT 1 FROM ${schema.follows} ff WHERE ff.follower_id = ${me} AND ff.followee_id = ${schema.posts.authorId})`,
+        sql`${schema.posts.authorId} <> ${me}`,
+        sql`NOT EXISTS (SELECT 1 FROM ${schema.blocks} b WHERE (b.blocker_id = ${me} AND b.blocked_id = ${schema.posts.authorId}) OR (b.blocker_id = ${schema.posts.authorId} AND b.blocked_id = ${me}))`,
+        sql`NOT EXISTS (SELECT 1 FROM ${schema.mutes} m WHERE m.muter_id = ${me} AND m.muted_id = ${schema.posts.authorId} AND (m.scope = 'feed' OR m.scope = 'both'))`,
+      ),
+    )
+
+  // Merge by post id, keeping the most recent activity for ordering and
+  // accumulating the set of follows that interacted with each post. Cap to
+  // the requested limit after merging.
+  const byId = new Map<string, Row>()
+  for (const row of likeRows) {
+    const existing = byId.get(row.post.id)
+    if (!existing) {
+      byId.set(row.post.id, {
+        post: row.post,
+        author: row.author,
+        activityAt: row.activityAt,
+        actorIds: [row.actorId],
+      })
+    } else {
+      if (row.activityAt > existing.activityAt) existing.activityAt = row.activityAt
+      if (!existing.actorIds.includes(row.actorId)) existing.actorIds.push(row.actorId)
+    }
+  }
+  for (const row of repostRows) {
+    const existing = byId.get(row.post.id)
+    const at = row.activityAt instanceof Date ? row.activityAt : new Date(row.activityAt)
+    if (!existing) {
+      byId.set(row.post.id, {
+        post: row.post,
+        author: row.author,
+        activityAt: at,
+        actorIds: [row.actorId],
+      })
+    } else {
+      if (at > existing.activityAt) existing.activityAt = at
+      if (!existing.actorIds.includes(row.actorId)) existing.actorIds.push(row.actorId)
+    }
+  }
+
+  const merged = [...byId.values()]
+    .sort((a, b) => b.activityAt.getTime() - a.activityAt.getTime())
+    .slice(0, limit)
+
+  const ids = merged.map((r) => r.post.id)
+  const [flags, mediaMap, articleMap, repostMapPost, quoteMapPost, pollMap] = await Promise.all([
+    loadViewerFlags(db, me, ids),
+    loadPostMedia(db, ids),
+    loadArticleCards(db, ids),
+    loadRepostTargets({
+      db,
+      viewerId: me,
+      env: mediaEnv,
+      repostRows: merged.map((r) => ({ id: r.post.id, repostOfId: r.post.repostOfId })),
+    }),
+    loadQuoteTargets({
+      db,
+      viewerId: me,
+      env: mediaEnv,
+      quoteRows: merged.map((r) => ({ id: r.post.id, quoteOfId: r.post.quoteOfId })),
+    }),
+    loadPolls(db, me, ids),
+  ])
+  // Pull the triggering actors' handles for the "Lucas + 2 others liked this"
+  // banner. We cap at 3 ids per post; the count beyond that is shown as
+  // "+N others" in the UI.
+  const allActorIds = new Set<string>()
+  for (const r of merged) for (const id of r.actorIds.slice(0, 3)) allActorIds.add(id)
+  const actorMap = new Map<
+    string,
+    { id: string; handle: string | null; displayName: string | null }
+  >()
+  if (allActorIds.size > 0) {
+    const actorRows = await db
+      .select({
+        id: schema.users.id,
+        handle: schema.users.handle,
+        displayName: schema.users.displayName,
+      })
+      .from(schema.users)
+      .where(sql`${schema.users.id} = ANY(${[...allActorIds]})`)
+    for (const u of actorRows) actorMap.set(u.id, u)
+  }
+
+  const posts = merged.map((r) => ({
+    ...toPostDto(
+      r.post,
+      r.author,
+      flags.get(r.post.id),
+      mediaMap.get(r.post.id),
+      mediaEnv,
+      articleMap.get(r.post.id),
+      repostMapPost.get(r.post.id),
+      quoteMapPost.get(r.post.id),
+      pollMap.get(r.post.id),
+    ),
+    networkActors: r.actorIds
+      .slice(0, 3)
+      .map((id) => actorMap.get(id))
+      .filter((u): u is NonNullable<typeof u> => Boolean(u)),
+    networkActorTotal: r.actorIds.length,
+    networkActivityAt: r.activityAt.toISOString(),
+  }))
+  const nextCursor =
+    posts.length === limit ? merged[merged.length - 1]!.activityAt.toISOString() : null
+  // Suppress unused TTL constant warning (kept for future caching hooks).
+  void NETWORK_FEED_TTL_SEC
+  return c.json({ posts, nextCursor })
+})

--- a/apps/web/src/components/feed.tsx
+++ b/apps/web/src/components/feed.tsx
@@ -8,6 +8,11 @@ import type { FeedPage, Post } from "../lib/api"
 
 type FeedQueryKey = ReadonlyArray<unknown>
 
+interface FeedLoaderPage {
+  posts: Array<Post>
+  nextCursor: string | null
+}
+
 export function Feed({
   queryKey,
   load,
@@ -17,15 +22,19 @@ export function Feed({
   onlyReplies = false,
   onOpenThread,
   activePostId,
+  renderActivityBanner,
 }: {
   queryKey: FeedQueryKey
-  load: (cursor?: string) => Promise<FeedPage>
+  load: (cursor?: string) => Promise<FeedLoaderPage | FeedPage>
   emptyMessage?: string
   prependItem?: Post | null
   hideReplies?: boolean
   onlyReplies?: boolean
   onOpenThread?: (post: Post) => void
   activePostId?: string
+  /** Optional banner rendered above each post card (e.g. "Lucas liked this"
+   *  on the network feed). Returning null skips the banner for that row. */
+  renderActivityBanner?: (post: Post) => React.ReactNode
 }) {
   const queryClient = useQueryClient()
   const queryKeyHash = JSON.stringify(queryKey)
@@ -126,18 +135,27 @@ export function Feed({
 
   return (
     <div>
-      {posts.map((post) => (
-        <PostCard
-          key={post.id}
-          post={post}
-          onChange={replace}
-          onRemove={remove}
-          onOpenThread={onOpenThread}
-          active={
-            activePostId === post.id || activePostId === post.repostOf?.id
-          }
-        />
-      ))}
+      {posts.map((post) => {
+        const banner = renderActivityBanner?.(post)
+        return (
+          <div key={post.id}>
+            {banner && (
+              <div className="border-b border-border/50 px-4 pt-2">
+                {banner}
+              </div>
+            )}
+            <PostCard
+              post={post}
+              onChange={replace}
+              onRemove={remove}
+              onOpenThread={onOpenThread}
+              active={
+                activePostId === post.id || activePostId === post.repostOf?.id
+              }
+            />
+          </div>
+        )
+      })}
       {hasNextPage && (
         <div className="flex justify-center py-3">
           <Button

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -77,6 +77,8 @@ export const api = {
     request<{ ok: true }>(`/api/users/${h(handle)}/mute`, { method: "DELETE" }),
 
   feed: (cursor?: string) => request<FeedPage>(`/api/feed${qs(cursor)}`),
+  networkFeed: (cursor?: string) =>
+    request<NetworkFeedPage>(`/api/feed/network${qs(cursor)}`),
   publicTimeline: (cursor?: string) =>
     request<FeedPage>(`/api/posts${qs(cursor)}`),
   hashtag: (tag: string, cursor?: string) =>
@@ -612,6 +614,25 @@ export interface PostMedia {
   altText: string | null
   processingState: "pending" | "processing" | "ready" | "failed" | "flagged"
   variants: Array<{ kind: string; url: string; width: number; height: number }>
+}
+
+export interface NetworkActor {
+  id: string
+  handle: string | null
+  displayName: string | null
+}
+
+export interface NetworkPost extends Post {
+  /** Up to 3 follows that liked or reposted this post. The full count is in
+   *  `networkActorTotal`. Surfaces the "Lucas + N others liked this" banner. */
+  networkActors: Array<NetworkActor>
+  networkActorTotal: number
+  networkActivityAt: string
+}
+
+export interface NetworkFeedPage {
+  posts: Array<NetworkPost>
+  nextCursor: string | null
 }
 
 export interface FeedPage {

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -29,7 +29,7 @@ export const Route = createFileRoute("/")({
   }),
 })
 
-type FeedTab = "following" | "all"
+type FeedTab = "following" | "network" | "all"
 
 function Landing() {
   const navigate = Route.useNavigate()
@@ -48,8 +48,13 @@ function Landing() {
   const loadFeed = useCallback((cursor?: string) => api.feed(cursor), [])
   const loadPublic = useCallback(
     (cursor?: string) => api.publicTimeline(cursor),
-    []
+    [],
   )
+  const loadNetwork = useCallback(
+    (cursor?: string) => api.networkFeed(cursor),
+    [],
+  )
+
   const openThread = useCallback(
     (post: Post) => {
       const handle = post.author.handle
@@ -68,7 +73,7 @@ function Landing() {
         search: homeThreadFromFeedSearch(post.id, handle),
       })
     },
-    [isDesktop, navigate, selectedThread]
+    [isDesktop, navigate, selectedThread],
   )
   const closeThread = useCallback(() => {
     navigate({ to: "/", search: {}, replace: true })
@@ -81,7 +86,7 @@ function Landing() {
       params: { handle: selectedThread.handle, id: selectedThread.id },
       search: homeThreadFromFeedSearch(
         selectedThread.id,
-        selectedThread.handle
+        selectedThread.handle,
       ),
       replace: true,
     })
@@ -124,7 +129,7 @@ function Landing() {
               <Compose onCreated={(p) => setNewPost(p)} collapsible />
             )}
             <div className="flex border-b border-border">
-              {(["following", "all"] as Array<FeedTab>).map((t) => (
+              {(["following", "network", "all"] as Array<FeedTab>).map((t) => (
                 <button
                   key={t}
                   onClick={() => setTab(t)}
@@ -134,21 +139,65 @@ function Landing() {
                       : "text-muted-foreground hover:text-foreground"
                   }`}
                 >
-                  {t === "following" ? "Following" : "All"}
+                  {t === "following"
+                    ? "Following"
+                    : t === "network"
+                      ? "Network"
+                      : "All"}
                 </button>
               ))}
             </div>
             <Feed
               queryKey={["feed", tab]}
-              load={tab === "following" ? loadFeed : loadPublic}
+              load={
+                tab === "following"
+                  ? loadFeed
+                  : tab === "network"
+                    ? loadNetwork
+                    : loadPublic
+              }
               emptyMessage={
                 tab === "following"
                   ? "Follow people to see posts here. Switch to All to see the public timeline."
-                  : "No posts yet. Be the first."
+                  : tab === "network"
+                    ? "No posts from your network's likes/reposts yet."
+                    : "No posts yet. Be the first."
               }
               prependItem={newPost}
               onOpenThread={openThread}
               activePostId={panelThread?.id}
+              renderActivityBanner={
+                tab === "network"
+                  ? (p) => {
+                      const np = p as Post & {
+                        networkActors?: Array<{
+                          id: string
+                          handle: string | null
+                          displayName: string | null
+                        }>
+                        networkActorTotal?: number
+                      }
+                      if (!np.networkActors || np.networkActors.length === 0)
+                        return null
+                      const first = np.networkActors[0]
+                      const more = (np.networkActorTotal ?? 1) - 1
+                      const name =
+                        first.displayName ||
+                        (first.handle ? `@${first.handle}` : "Someone")
+                      return (
+                        <div className="ml-10 flex items-center gap-1.5 text-xs text-muted-foreground">
+                          <span>
+                            {name}
+                            {more > 0
+                              ? ` and ${more} other${more === 1 ? "" : "s"}`
+                              : ""}{" "}
+                            liked or reposted
+                          </span>
+                        </div>
+                      )
+                    }
+                  : undefined
+              }
             />
           </div>
 


### PR DESCRIPTION
API
- New GET /api/feed/network. Surfaces posts the viewer's follows have recently liked or reposted, where the post's author is not someone the viewer already follows (and isn't the viewer themselves). Excludes blocks and feed-mutes on either side.
- Two queries (likes-from-follows, reposts-from-follows), merged in app code by post id; ordered by the most recent triggering activity. Each result carries up to 3 actor handles + a total count for the 'Lucas + N others liked this' banner.

Web
- api.networkFeed and NetworkFeedPage / NetworkPost types.
- Home now has three tabs: Following / Network / All.
- Feed component accepts an optional renderActivityBanner that renders above each post card. The Network tab uses it to show the triggering follows ('Lucas and 2 others liked or reposted').

## Summary

<!-- 1-3 bullets of what changed and why. -->

## Test plan

<!-- How you verified it works. Delete what doesn't apply. -->

- [ ] `bun run typecheck` passes
- [ ] Manually exercised the affected flow in the browser
- [ ] No new console errors / network errors

## Notes

<!-- Anything reviewers should pay attention to: migrations, env-var changes, breaking changes, follow-ups. Delete if none. -->
