### PR TITLE
feat(lists): pin to profile + 'Lists I'm on'

### DIFF
--- a/apps/api/src/routes/lists.ts
+++ b/apps/api/src/routes/lists.ts
@@ -24,6 +24,7 @@ interface ListDto {
   description: string | null
   isPrivate: boolean
   memberCount: number
+  pinnedAt: string | null
   createdAt: string
   updatedAt: string
 }
@@ -51,7 +52,13 @@ listsRoute.get('/by/:handle', async (c) => {
         isOwnerViewer ? undefined : eq(schema.userLists.isPrivate, false),
       ),
     )
-    .orderBy(desc(schema.userLists.createdAt))
+    // Pinned lists first (most-recently pinned at the top), then everything
+    // else by creation time.
+    .orderBy(
+      sql`(${schema.userLists.pinnedAt} IS NULL)`,
+      desc(schema.userLists.pinnedAt),
+      desc(schema.userLists.createdAt),
+    )
 
   return c.json({
     lists: rows.map((l) => toListDto(l, owner.handle, owner.displayName)),
@@ -71,7 +78,11 @@ listsRoute.get('/me', requireAuth(), async (c) => {
     .select()
     .from(schema.userLists)
     .where(eq(schema.userLists.ownerId, session.user.id))
-    .orderBy(desc(schema.userLists.createdAt))
+    .orderBy(
+      sql`(${schema.userLists.pinnedAt} IS NULL)`,
+      desc(schema.userLists.pinnedAt),
+      desc(schema.userLists.createdAt),
+    )
   return c.json({
     lists: rows.map((l) => toListDto(l, me?.handle ?? null, me?.displayName ?? null)),
   })
@@ -155,6 +166,75 @@ listsRoute.patch('/:id', requireAuth(), async (c) => {
     .where(eq(schema.users.id, session.user.id))
     .limit(1)
   return c.json({ list: toListDto(row, me?.handle ?? null, me?.displayName ?? null) })
+})
+
+// Pin / unpin a list to the owner's profile. The /by/:handle endpoint sorts
+// pinned lists to the top, so this single boolean controls profile ordering.
+listsRoute.post('/:id/pin', requireAuth(), async (c) => {
+  const session = c.get('session')!
+  const { db } = c.get('ctx')
+  const id = c.req.param('id')
+  const [row] = await db
+    .update(schema.userLists)
+    .set({ pinnedAt: new Date(), updatedAt: new Date() })
+    .where(
+      and(eq(schema.userLists.id, id), eq(schema.userLists.ownerId, session.user.id)),
+    )
+    .returning({ id: schema.userLists.id })
+  if (!row) return c.json({ error: 'not_found' }, 404)
+  return c.json({ ok: true })
+})
+
+listsRoute.delete('/:id/pin', requireAuth(), async (c) => {
+  const session = c.get('session')!
+  const { db } = c.get('ctx')
+  const id = c.req.param('id')
+  const [row] = await db
+    .update(schema.userLists)
+    .set({ pinnedAt: null, updatedAt: new Date() })
+    .where(
+      and(eq(schema.userLists.id, id), eq(schema.userLists.ownerId, session.user.id)),
+    )
+    .returning({ id: schema.userLists.id })
+  if (!row) return c.json({ error: 'not_found' }, 404)
+  return c.json({ ok: true })
+})
+
+// "Lists I'm on" — public lists this user is a member of. Excludes private
+// lists owned by anyone other than the viewer.
+listsRoute.get('/listed-on/:handle', async (c) => {
+  const { db } = c.get('ctx')
+  const viewerId = c.get('session')?.user.id
+  const handle = c.req.param('handle').replace(/^@/, '')
+  const [user] = await db
+    .select({ id: schema.users.id })
+    .from(schema.users)
+    .where(and(eq(schema.users.handle, handle), isNull(schema.users.deletedAt)))
+    .limit(1)
+  if (!user) return c.json({ lists: [] })
+  const rows = await db
+    .select({
+      list: schema.userLists,
+      ownerHandle: schema.users.handle,
+      ownerDisplayName: schema.users.displayName,
+    })
+    .from(schema.userListMembers)
+    .innerJoin(schema.userLists, eq(schema.userLists.id, schema.userListMembers.listId))
+    .innerJoin(schema.users, eq(schema.users.id, schema.userLists.ownerId))
+    .where(
+      and(
+        eq(schema.userListMembers.memberId, user.id),
+        // Hide private lists unless the viewer owns them.
+        viewerId
+          ? sql`(${schema.userLists.isPrivate} = false OR ${schema.userLists.ownerId} = ${viewerId})`
+          : eq(schema.userLists.isPrivate, false),
+      ),
+    )
+    .orderBy(desc(schema.userListMembers.addedAt))
+    .limit(100)
+  return c.json({
+    lists: rows.map((r) => toListDto(r.list, r.ownerHandle, r.ownerDisplayName)),
+  })
 })
 
 listsRoute.delete('/:id', requireAuth(), async (c) => {
@@ -350,6 +430,7 @@ function toListDto(
     description: l.description,
     isPrivate: l.isPrivate,
     memberCount: l.memberCount,
+    pinnedAt: l.pinnedAt ? l.pinnedAt.toISOString() : null,
     createdAt: l.createdAt.toISOString(),
     updatedAt: l.updatedAt.toISOString(),
   }

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -357,6 +357,12 @@ export const api = {
     }),
   listTimeline: (id: string, cursor?: string) =>
     request<FeedPage>(`/api/lists/${id}/timeline${qs(cursor)}`),
+  pinList: (id: string) =>
+    request<{ ok: true }>(`/api/lists/${id}/pin`, { method: "POST" }),
+  unpinList: (id: string) =>
+    request<{ ok: true }>(`/api/lists/${id}/pin`, { method: "DELETE" }),
+  listsListedOn: (handle: string) =>
+    request<{ lists: Array<UserList> }>(`/api/lists/listed-on/${h(handle)}`),
   post: (id: string) => request<{ post: Post }>(`/api/posts/${id}`),
   thread: (id: string) => request<Thread>(`/api/posts/${id}/thread`),
   deletePost: (id: string) =>
@@ -580,6 +586,7 @@ export interface UserList {
   description: string | null
   isPrivate: boolean
   memberCount: number
+  pinnedAt: string | null
   createdAt: string
   updatedAt: string
 }

--- a/apps/web/src/routes/$handle.index.tsx
+++ b/apps/web/src/routes/$handle.index.tsx
@@ -8,7 +8,7 @@ import { ImageLightbox } from "../components/image-lightbox"
 import { RichText } from "../components/rich-text"
 import { VerifiedBadge } from "../components/verified-badge"
 import { useMe } from "../lib/me"
-import type { PublicProfile } from "../lib/api"
+import type { PublicProfile, UserList } from "../lib/api"
 
 export const Route = createFileRoute("/$handle/")({ component: Profile })
 
@@ -159,6 +159,7 @@ function Profile() {
           </span>
         </div>
       </div>
+      {user.handle && <ProfileLists handle={user.handle} />}
       <div className="border-t border-border">
         <Feed
           queryKey={["userPosts", handle]}
@@ -167,5 +168,83 @@ function Profile() {
         />
       </div>
     </main>
+  )
+}
+
+function ProfileLists({ handle }: { handle: string }) {
+  const [pinned, setPinned] = useState<Array<UserList> | null>(null)
+  const [listedOn, setListedOn] = useState<Array<UserList> | null>(null)
+  useEffect(() => {
+    let cancelled = false
+    api
+      .userLists(handle)
+      .then(({ lists }) => {
+        if (cancelled) return
+        setPinned(lists.filter((l) => l.pinnedAt))
+      })
+      .catch(() => {
+        if (!cancelled) setPinned([])
+      })
+    api
+      .listsListedOn(handle)
+      .then(({ lists }) => {
+        if (!cancelled) setListedOn(lists.slice(0, 10))
+      })
+      .catch(() => {
+        if (!cancelled) setListedOn([])
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [handle])
+
+  if ((pinned === null || pinned.length === 0) && (listedOn === null || listedOn.length === 0)) {
+    return null
+  }
+  return (
+    <div className="border-t border-border px-4 py-3 text-xs">
+      {pinned && pinned.length > 0 && (
+        <div className="mb-2">
+          <h2 className="mb-1 text-[11px] font-semibold tracking-wide text-muted-foreground uppercase">
+            Pinned lists
+          </h2>
+          <div className="flex flex-wrap gap-1.5">
+            {pinned.map((l) => (
+              <Link
+                key={l.id}
+                to="/lists/$id"
+                params={{ id: l.id }}
+                className="rounded-full border border-border bg-muted/40 px-2.5 py-1 hover:bg-muted"
+              >
+                {l.title}
+                <span className="ml-1.5 text-muted-foreground">{l.memberCount}</span>
+              </Link>
+            ))}
+          </div>
+        </div>
+      )}
+      {listedOn && listedOn.length > 0 && (
+        <div>
+          <h2 className="mb-1 text-[11px] font-semibold tracking-wide text-muted-foreground uppercase">
+            Lists @{handle} is on
+          </h2>
+          <div className="flex flex-wrap gap-1.5">
+            {listedOn.map((l) => (
+              <Link
+                key={l.id}
+                to="/lists/$id"
+                params={{ id: l.id }}
+                className="rounded-full border border-border px-2.5 py-1 hover:bg-muted/40"
+              >
+                {l.title}
+                {l.ownerHandle && (
+                  <span className="ml-1.5 text-muted-foreground">@{l.ownerHandle}</span>
+                )}
+              </Link>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
   )
 }

--- a/apps/web/src/routes/lists.index.tsx
+++ b/apps/web/src/routes/lists.index.tsx
@@ -1,6 +1,6 @@
 import { Link, createFileRoute, useRouter } from "@tanstack/react-router"
 import { useEffect, useState } from "react"
-import { IconLock, IconUsers } from "@tabler/icons-react"
+import { IconLock, IconPin, IconPinFilled, IconUsers } from "@tabler/icons-react"
 import { Button } from "@workspace/ui/components/button"
 import { LIST_SLUG_RE, LIST_TITLE_MAX } from "@workspace/validators"
 import { ApiError, api } from "../lib/api"
@@ -76,14 +76,22 @@ function ListsIndex() {
         ) : (
           <ul className="divide-y divide-border">
             {lists.map((list) => (
-              <li key={list.id}>
+              <li
+                key={list.id}
+                className="flex items-start gap-2 px-4 py-3 transition hover:bg-muted/40"
+              >
                 <Link
                   to="/lists/$id"
                   params={{ id: list.id }}
-                  className="block px-4 py-3 transition hover:bg-muted/40"
+                  className="min-w-0 flex-1"
                 >
                   <div className="flex items-center justify-between">
-                    <h2 className="text-sm font-semibold">{list.title}</h2>
+                    <h2 className="flex items-center gap-1.5 text-sm font-semibold">
+                      {list.pinnedAt && (
+                        <IconPinFilled size={12} className="text-primary" />
+                      )}
+                      {list.title}
+                    </h2>
                     {list.isPrivate && (
                       <span className="flex items-center gap-1 text-xs text-muted-foreground">
                         <IconLock size={12} /> private
@@ -101,6 +109,34 @@ function ListsIndex() {
                     {list.memberCount === 1 ? "member" : "members"}
                   </p>
                 </Link>
+                <Button
+                  size="icon-sm"
+                  variant="ghost"
+                  aria-label={
+                    list.pinnedAt ? "unpin list" : "pin list to profile"
+                  }
+                  title={
+                    list.pinnedAt
+                      ? "Pinned to your profile — click to unpin"
+                      : "Pin to your profile"
+                  }
+                  onClick={async (e) => {
+                    e.preventDefault()
+                    try {
+                      if (list.pinnedAt) await api.unpinList(list.id)
+                      else await api.pinList(list.id)
+                      await refresh()
+                    } catch {
+                      /* swallow — refresh on next mount */
+                    }
+                  }}
+                >
+                  {list.pinnedAt ? (
+                    <IconPinFilled size={14} className="text-primary" />
+                  ) : (
+                    <IconPin size={14} />
+                  )}
+                </Button>
               </li>
             ))}
           </ul>

--- a/packages/db/src/schema/lists.ts
+++ b/packages/db/src/schema/lists.ts
@@ -22,12 +22,19 @@ export const userLists = pgTable(
     description: text('description'),
     isPrivate: boolean('is_private').notNull().default(false),
     memberCount: integer('member_count').notNull().default(0),
+    // Set when the owner pinned this list to their profile. Multiple lists can
+    // be pinned simultaneously; profile views render pinned lists first ordered
+    // by `pinnedAt` (most recent first), with the rest below.
+    pinnedAt: timestamp('pinned_at', { withTimezone: true }),
     createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
   },
   (t) => [
     uniqueIndex('user_lists_owner_slug_uq').on(t.ownerId, t.slug),
     index('user_lists_owner_idx').on(t.ownerId, t.createdAt),
+    index('user_lists_owner_pinned_idx')
+      .on(t.ownerId)
+      .where(sql`${t.pinnedAt} IS NOT NULL`),
     check('user_lists_title_len', sql`char_length(${t.title}) BETWEEN 1 AND 60`),
     check('user_lists_slug_format', sql`${t.slug} ~ '^[a-z0-9-]{1,40}$'`),
   ],


### PR DESCRIPTION
Schema
- Add user_lists.pinned_at + a partial index on (owner_id) WHERE pinned_at IS NOT NULL (drizzle push, no migration files).

API
- /api/lists/by/:handle and /api/lists/me now order pinned lists first (most-recently-pinned at the top), then the rest by createdAt.
- New POST/DELETE /api/lists/:id/pin (auth required, owner only).
- New GET /api/lists/listed-on/:handle returns public lists the user is a member of (private lists are hidden from non-owners). Capped at 100 most-recent memberships.
- ListDto carries pinnedAt; UserList client type updated.

Web
- /lists/index renders a pin/unpin icon button on each row and shows a small primary-tinted pin marker next to pinned list titles.
- Profile pages render two new chip rows above the post feed: 'Pinned lists' (the user's own pinned lists) and 'Lists @handle is on' (top 10 from listed-on).

## Summary

<!-- 1-3 bullets of what changed and why. -->

## Test plan

<!-- How you verified it works. Delete what doesn't apply. -->

- [ ] `bun run typecheck` passes
- [ ] Manually exercised the affected flow in the browser
- [ ] No new console errors / network errors

## Notes

<!-- Anything reviewers should pay attention to: migrations, env-var changes, breaking changes, follow-ups. Delete if none. -->
