### PR TITLE
fix(thread): render article card on full thread page

### DIFF
--- a/apps/web/src/components/post-card.tsx
+++ b/apps/web/src/components/post-card.tsx
@@ -87,7 +87,7 @@ function clickedInteractiveElement(target: EventTarget | null) {
   )
 }
 
-function ArticleCardBlock({
+export function ArticleCardBlock({
   card,
 }: {
   card: NonNullable<Post["articleCard"]>

--- a/apps/web/src/routes/$handle.p.$id.tsx
+++ b/apps/web/src/routes/$handle.p.$id.tsx
@@ -16,6 +16,7 @@ import {
 import { ApiError, api } from "../lib/api"
 import { useSubmitHotkey } from "../lib/hotkeys"
 import { Avatar } from "../components/avatar"
+import { ArticleCardBlock } from "../components/post-card"
 import { RichText } from "../components/rich-text"
 import { useMe } from "../lib/me"
 import type { Post, Thread } from "../lib/api"
@@ -285,9 +286,13 @@ function AncestorPost({
             </span>
           </div>
 
-          <p className="mt-1 text-[13.5px] leading-[1.55] break-words whitespace-pre-wrap">
-            <RichText text={post.text} />
-          </p>
+          {post.articleCard ? (
+            <ArticleCardBlock card={post.articleCard} />
+          ) : (
+            <p className="mt-1 text-[13.5px] leading-[1.55] break-words whitespace-pre-wrap">
+              <RichText text={post.text} />
+            </p>
+          )}
 
           {post.media && post.media.length > 0 && (
             <div
@@ -475,9 +480,13 @@ function ParentPost({
         <IconDots size={14} className="shrink-0 text-muted-foreground" />
       </div>
 
-      <p className="mt-2.5 text-[15.5px] leading-[1.5] break-words whitespace-pre-wrap">
-        <RichText text={post.text} />
-      </p>
+      {post.articleCard ? (
+        <ArticleCardBlock card={post.articleCard} />
+      ) : (
+        <p className="mt-2.5 text-[15.5px] leading-[1.5] break-words whitespace-pre-wrap">
+          <RichText text={post.text} />
+        </p>
+      )}
 
       {post.media && post.media.length > 0 && (
         <div
@@ -790,9 +799,13 @@ function ReplyCard({
         <IconDots size={13} className="text-muted-foreground" />
       </div>
 
-      <p className="mt-1.5 text-[13.5px] leading-[1.55] break-words whitespace-pre-wrap">
-        <RichText text={post.text} />
-      </p>
+      {post.articleCard ? (
+        <ArticleCardBlock card={post.articleCard} />
+      ) : (
+        <p className="mt-1.5 text-[13.5px] leading-[1.55] break-words whitespace-pre-wrap">
+          <RichText text={post.text} />
+        </p>
+      )}
 
       {/* biome-ignore lint/a11y/useKeyWithClickEvents: action bar wrapper */}
       <div


### PR DESCRIPTION
### Why?
Before
<img width="815" height="550" alt="image" src="https://github.com/user-attachments/assets/e40043ed-b534-4de3-82c0-9e760b660d39" />

After
<img width="790" height="237" alt="image" src="https://github.com/user-attachments/assets/da2e4767-1ee7-44e2-883b-9e18a3bf9137" />

Opening an article post's comment section from the home feed lands on the full thread page (`/$handle/p/$id`), where the article rendered as raw "new article: …" text instead of as the article card. The panel view (sidebar thread) wasn't affected because it goes through `PostCard`.

### How?

The full thread route had its own hand-rolled post renderers that ignored `post.articleCard`. Reused `PostCard`'s `ArticleCardBlock` in the three thread renderers, gated so the card replaces the text body — same pattern the home feed uses.