### PR TITLE
Add rich content rendering to post thread views

### DIFF
--- a/apps/web/src/components/post-card.tsx
+++ b/apps/web/src/components/post-card.tsx
@@ -89,7 +89,7 @@ function clickedInteractiveElement(target: EventTarget | null) {
   )
 }
 
-function ArticleCardBlock({
+export function ArticleCardBlock({
   card,
 }: {
   card: NonNullable<Post["articleCard"]>
@@ -134,7 +134,7 @@ function ArticleCardBlock({
   )
 }
 
-function QuoteEmbed({ post }: { post: Post }) {
+export function QuoteEmbed({ post }: { post: Post }) {
   const handle = post.author.handle
   const thumb = post.media?.find((m) => m.processingState === "ready")
   const variant =

--- a/apps/web/src/routes/$handle.p.$id.tsx
+++ b/apps/web/src/routes/$handle.p.$id.tsx
@@ -17,6 +17,8 @@ import { ApiError, api } from "../lib/api"
 import { useSubmitHotkey } from "../lib/hotkeys"
 import { Avatar } from "../components/avatar"
 import { RichText } from "../components/rich-text"
+import { PollBlock } from "../components/poll-block"
+import { ArticleCardBlock, QuoteEmbed } from "../components/post-card"
 import { useMe } from "../lib/me"
 import type { Post, Thread } from "../lib/api"
 
@@ -324,6 +326,17 @@ function AncestorPost({
             </div>
           )}
 
+          {post.articleCard && <ArticleCardBlock card={post.articleCard} />}
+
+          {post.poll && (
+            <PollBlock
+              poll={post.poll}
+              onChange={(nextPoll) => onChange({ ...post, poll: nextPoll })}
+            />
+          )}
+
+          {post.quoteOf && <QuoteEmbed post={post.quoteOf} />}
+
           <div className="mt-2.5 flex items-center gap-5 text-muted-foreground">
             {authorHandle && (
               <Link
@@ -513,6 +526,17 @@ function ParentPost({
           })}
         </div>
       )}
+
+      {post.articleCard && <ArticleCardBlock card={post.articleCard} />}
+
+      {post.poll && (
+        <PollBlock
+          poll={post.poll}
+          onChange={(nextPoll) => onChange({ ...post, poll: nextPoll })}
+        />
+      )}
+
+      {post.quoteOf && <QuoteEmbed post={post.quoteOf} />}
 
       <div className="mt-2.5 flex items-center gap-3 font-mono text-[11px] text-muted-foreground">
         {post.counts.reposts > 0 && <span>{post.counts.reposts} reposts</span>}
@@ -806,6 +830,42 @@ function ReplyCard({
       <p className="mt-1.5 text-[13.5px] leading-[1.55] break-words whitespace-pre-wrap">
         <RichText text={post.text} />
       </p>
+
+      {post.media && post.media.length > 0 && (
+        // biome-ignore lint/a11y/useKeyWithClickEvents: stops parent Link from intercepting interactions
+        <div
+          className={`mt-2 grid gap-px overflow-hidden rounded-sm border border-border ${post.media.length === 1 ? "grid-cols-1" : "grid-cols-2"}`}
+          onClick={(e) => e.stopPropagation()}
+        >
+          {post.media.map((m) => {
+            const variant =
+              m.variants.find((v) => v.kind === "medium") ?? m.variants[0]
+            return (
+              <div key={m.id} className="aspect-video bg-muted">
+                {m.processingState === "ready" && (
+                  <img
+                    src={variant.url}
+                    alt={m.altText ?? ""}
+                    className="h-full w-full object-cover"
+                  />
+                )}
+              </div>
+            )
+          })}
+        </div>
+      )}
+
+      {/* biome-ignore lint/a11y/useKeyWithClickEvents: stops parent Link from intercepting interactions */}
+      <div onClick={(e) => e.stopPropagation()}>
+        {post.articleCard && <ArticleCardBlock card={post.articleCard} />}
+        {post.poll && (
+          <PollBlock
+            poll={post.poll}
+            onChange={(nextPoll) => onChange({ ...post, poll: nextPoll })}
+          />
+        )}
+        {post.quoteOf && <QuoteEmbed post={post.quoteOf} />}
+      </div>
 
       {/* biome-ignore lint/a11y/useKeyWithClickEvents: action bar wrapper */}
       <div


### PR DESCRIPTION
## Summary

- Export `ArticleCardBlock` and `QuoteEmbed` components from post-card to enable reuse across the codebase
- Add rendering of article cards, polls, and quote embeds in ancestor and parent post components
- Add media gallery and rich content rendering to reply cards with proper event handling to prevent link interception

## Test plan

- [ ] `bun run typecheck` passes
- [ ] Manually exercised thread view with posts containing articles, polls, and quotes
- [ ] Verified media gallery displays correctly in reply cards
- [ ] No new console errors / network errors

## Notes

The changes ensure consistent rendering of rich content (articles, polls, quotes, media) across different post display contexts in the thread view. Event handlers are properly configured to prevent parent Link elements from intercepting clicks on interactive content.

https://claude.ai/code/session_01Sm5289DR19b74iVyMKeM1P