### PR TITLE
fix(feed): network actor lookup uses inArray instead of raw ANY()

### DIFF
--- a/apps/api/src/routes/feed.ts
+++ b/apps/api/src/routes/feed.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono'
-import { and, desc, eq, isNull, lt, sql } from '@workspace/db'
+import { and, desc, eq, inArray, isNull, lt, sql } from '@workspace/db'
 import { schema } from '@workspace/db'
 import { requireAuth, type HonoEnv } from '../middleware/session.ts'
 import { toPostDto } from '../lib/post-dto.ts'
@@ -269,6 +269,11 @@ feedRoute.get('/network', requireAuth(), async (c) => {
     { id: string; handle: string | null; displayName: string | null }
   >()
   if (allActorIds.size > 0) {
+    // Drizzle's tagged sql expands a JS array into N separate parameters
+    // (e.g. `ANY(($1, $2, $3))`) — that's a row constructor, not an array,
+    // and Postgres rejects it with "operator does not exist: uuid = record".
+    // Use the canonical inArray() helper which always emits the correct
+    // `= ANY($1::uuid[])` binding.
     const actorRows = await db
       .select({
         id: schema.users.id,
@@ -276,7 +281,7 @@ feedRoute.get('/network', requireAuth(), async (c) => {
         displayName: schema.users.displayName,
       })
       .from(schema.users)
-      .where(sql`${schema.users.id} = ANY(${[...allActorIds]})`)
+      .where(inArray(schema.users.id, [...allActorIds]))
     for (const u of actorRows) actorMap.set(u.id, u)
   }
 


### PR DESCRIPTION
Drizzle's tagged sql template expands a JS array into N separate parameters, so the existing query rendered as
`ANY(($1, $2, $3, $4, $5))` — that's a row constructor, not an array, and Postgres rejected the query with 'operator does not exist: uuid = record'.

Use the canonical inArray() helper instead, which emits the correct `= ANY($1::uuid[])` binding. inArray is what the rest of the API uses for batched id lookups.

Reproduces by switching to /, Network with at least one post in the result set whose triggering actors live in the users table: the response 500'd with 'Failed query: ... ANY(($1, $2, ...))'.

## Summary

<!-- 1-3 bullets of what changed and why. -->

## Test plan

<!-- How you verified it works. Delete what doesn't apply. -->

- [ ] `bun run typecheck` passes
- [ ] Manually exercised the affected flow in the browser
- [ ] No new console errors / network errors

## Notes

<!-- Anything reviewers should pay attention to: migrations, env-var changes, breaking changes, follow-ups. Delete if none. -->
