### PR TITLE
Add virtualization to feed and convert quotes to single quotes

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -27,6 +27,7 @@
     "@tanstack/react-router": "^1.132.0",
     "@tanstack/react-start": "^1.132.0",
     "@tanstack/react-table": "^8.21.3",
+    "@tanstack/react-virtual": "^3.13.24",
     "@tanstack/router-plugin": "^1.132.0",
     "@workspace/auth": "workspace:*",
     "@workspace/ui": "workspace:*",

--- a/apps/web/src/components/feed.tsx
+++ b/apps/web/src/components/feed.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useMemo } from "react"
+import { useEffect, useMemo, useRef, useState } from "react"
 import { useInfiniteQuery, useQueryClient } from "@tanstack/react-query"
-import { Button } from "@workspace/ui/components/button"
+import { useVirtualizer } from "@tanstack/react-virtual"
 import { SkeletonPostCard } from "@workspace/ui/components/skeleton"
 import { PostCard } from "./post-card"
 import type { InfiniteData } from "@tanstack/react-query"
@@ -11,6 +11,18 @@ type FeedQueryKey = ReadonlyArray<unknown>
 interface FeedLoaderPage {
   posts: Array<Post>
   nextCursor: string | null
+}
+
+// Walk up the DOM to find the nearest ancestor that scrolls. Falls back to
+// document.scrollingElement for the page-level scroll case.
+function findScrollParent(el: HTMLElement | null): HTMLElement | null {
+  let node: HTMLElement | null = el?.parentElement ?? null
+  while (node) {
+    const style = getComputedStyle(node)
+    if (/(auto|scroll|overlay)/.test(style.overflowY)) return node
+    node = node.parentElement
+  }
+  return (document.scrollingElement as HTMLElement | null) ?? document.documentElement
 }
 
 export function Feed({
@@ -118,6 +130,44 @@ export function Feed({
     )
   }
 
+  const wrapperRef = useRef<HTMLDivElement>(null)
+  const sentinelRef = useRef<HTMLDivElement>(null)
+  const [scrollEl, setScrollEl] = useState<HTMLElement | null>(null)
+
+  useEffect(() => {
+    setScrollEl(findScrollParent(wrapperRef.current))
+  }, [])
+
+  const virtualizer = useVirtualizer({
+    count: posts.length,
+    getScrollElement: () => scrollEl,
+    estimateSize: () => 220,
+    overscan: 6,
+  })
+
+  // Auto-load the next page when the bottom sentinel approaches the viewport.
+  useEffect(() => {
+    const node = sentinelRef.current
+    if (!node || !hasNextPage) return
+    // IntersectionObserver only accepts an Element (not document.scrollingElement)
+    // as `root`; null falls back to the viewport, which is what we want for
+    // page-level scrolling.
+    const root =
+      scrollEl && scrollEl !== document.scrollingElement && scrollEl !== document.documentElement
+        ? scrollEl
+        : null
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries.some((e) => e.isIntersecting) && !isFetchingNextPage) {
+          fetchNextPage()
+        }
+      },
+      { root, rootMargin: "600px 0px" }
+    )
+    observer.observe(node)
+    return () => observer.disconnect()
+  }, [hasNextPage, isFetchingNextPage, fetchNextPage, scrollEl])
+
   if (isPending)
     return (
       <div>
@@ -137,39 +187,83 @@ export function Feed({
       </div>
     )
 
+  const virtualItems = virtualizer.getVirtualItems()
+  const totalSize = virtualizer.getTotalSize()
+
   return (
     <div>
-      {posts.map((post) => {
-        const banner = renderActivityBanner?.(post)
-        return (
-          <div key={post.id}>
-            {banner && (
-              <div className="border-b border-border/50 px-4 pt-2">
-                {banner}
-              </div>
-            )}
-            <PostCard
-              post={post}
-              onChange={replace}
-              onRemove={remove}
-              onOpenThread={onOpenThread}
-              active={
-                activePostId === post.id || activePostId === post.repostOf?.id
-              }
-            />
-          </div>
-        )
-      })}
+      <div
+        ref={wrapperRef}
+        style={{
+          height: scrollEl ? totalSize : undefined,
+          position: "relative",
+          width: "100%",
+        }}
+      >
+        {scrollEl
+          ? virtualItems.map((virtualItem) => {
+              const post = posts[virtualItem.index]
+              const banner = renderActivityBanner?.(post)
+              return (
+                <div
+                  key={post.id}
+                  ref={virtualizer.measureElement}
+                  data-index={virtualItem.index}
+                  style={{
+                    position: "absolute",
+                    top: 0,
+                    left: 0,
+                    width: "100%",
+                    transform: `translateY(${virtualItem.start}px)`,
+                  }}
+                >
+                  {banner && (
+                    <div className="border-b border-border/50 px-4 pt-2">
+                      {banner}
+                    </div>
+                  )}
+                  <PostCard
+                    post={post}
+                    onChange={replace}
+                    onRemove={remove}
+                    onOpenThread={onOpenThread}
+                    active={
+                      activePostId === post.id ||
+                      activePostId === post.repostOf?.id
+                    }
+                  />
+                </div>
+              )
+            })
+          : // Fallback render (used for the first paint before we resolve the
+            // scroll parent) so SSR/initial HTML still shows posts.
+            posts.map((post) => {
+              const banner = renderActivityBanner?.(post)
+              return (
+                <div key={post.id}>
+                  {banner && (
+                    <div className="border-b border-border/50 px-4 pt-2">
+                      {banner}
+                    </div>
+                  )}
+                  <PostCard
+                    post={post}
+                    onChange={replace}
+                    onRemove={remove}
+                    onOpenThread={onOpenThread}
+                    active={
+                      activePostId === post.id ||
+                      activePostId === post.repostOf?.id
+                    }
+                  />
+                </div>
+              )
+            })}
+      </div>
+      <div ref={sentinelRef} aria-hidden className="h-px" />
       {hasNextPage && (
-        <div className="flex justify-center py-3">
-          <Button
-            variant="ghost"
-            size="sm"
-            onClick={() => fetchNextPage()}
-            disabled={isFetchingNextPage}
-          >
-            {isFetchingNextPage ? "loading…" : "load more"}
-          </Button>
+        <div className="flex justify-center py-4 text-xs text-muted-foreground">
+          {isFetchingNextPage ? "loading…" : ""}
         </div>
       )}
     </div>

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -8,365 +8,365 @@
 // You should NOT make any changes in this file as it will be overwritten.
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
-import { Route as rootRouteImport } from "./routes/__root"
-import { Route as SignupRouteImport } from "./routes/signup"
-import { Route as SettingsRouteImport } from "./routes/settings"
-import { Route as SearchRouteImport } from "./routes/search"
-import { Route as NotificationsRouteImport } from "./routes/notifications"
-import { Route as LoginRouteImport } from "./routes/login"
-import { Route as InboxRouteImport } from "./routes/inbox"
-import { Route as DraftsRouteImport } from "./routes/drafts"
-import { Route as BookmarksRouteImport } from "./routes/bookmarks"
-import { Route as AnalyticsRouteImport } from "./routes/analytics"
-import { Route as AdminRouteImport } from "./routes/admin"
-import { Route as HandleRouteImport } from "./routes/$handle"
-import { Route as IndexRouteImport } from "./routes/index"
-import { Route as ListsIndexRouteImport } from "./routes/lists.index"
-import { Route as InboxIndexRouteImport } from "./routes/inbox.index"
-import { Route as AdminIndexRouteImport } from "./routes/admin.index"
-import { Route as HandleIndexRouteImport } from "./routes/$handle.index"
-import { Route as ListsIdRouteImport } from "./routes/lists.$id"
-import { Route as InviteTokenRouteImport } from "./routes/invite.$token"
-import { Route as InboxNewRouteImport } from "./routes/inbox.new"
-import { Route as InboxConversationIdRouteImport } from "./routes/inbox.$conversationId"
-import { Route as HashtagTagRouteImport } from "./routes/hashtag.$tag"
-import { Route as ArticlesNewRouteImport } from "./routes/articles.new"
-import { Route as AdminUsersRouteImport } from "./routes/admin.users"
-import { Route as AdminReportsRouteImport } from "./routes/admin.reports"
-import { Route as HandleFollowingRouteImport } from "./routes/$handle.following"
-import { Route as HandleFollowersRouteImport } from "./routes/$handle.followers"
-import { Route as ArticlesIdEditRouteImport } from "./routes/articles.$id.edit"
-import { Route as HandlePIdRouteImport } from "./routes/$handle.p.$id"
-import { Route as HandleASlugRouteImport } from "./routes/$handle.a.$slug"
+import { Route as rootRouteImport } from './routes/__root'
+import { Route as SignupRouteImport } from './routes/signup'
+import { Route as SettingsRouteImport } from './routes/settings'
+import { Route as SearchRouteImport } from './routes/search'
+import { Route as NotificationsRouteImport } from './routes/notifications'
+import { Route as LoginRouteImport } from './routes/login'
+import { Route as InboxRouteImport } from './routes/inbox'
+import { Route as DraftsRouteImport } from './routes/drafts'
+import { Route as BookmarksRouteImport } from './routes/bookmarks'
+import { Route as AnalyticsRouteImport } from './routes/analytics'
+import { Route as AdminRouteImport } from './routes/admin'
+import { Route as HandleRouteImport } from './routes/$handle'
+import { Route as IndexRouteImport } from './routes/index'
+import { Route as ListsIndexRouteImport } from './routes/lists.index'
+import { Route as InboxIndexRouteImport } from './routes/inbox.index'
+import { Route as AdminIndexRouteImport } from './routes/admin.index'
+import { Route as HandleIndexRouteImport } from './routes/$handle.index'
+import { Route as ListsIdRouteImport } from './routes/lists.$id'
+import { Route as InviteTokenRouteImport } from './routes/invite.$token'
+import { Route as InboxNewRouteImport } from './routes/inbox.new'
+import { Route as InboxConversationIdRouteImport } from './routes/inbox.$conversationId'
+import { Route as HashtagTagRouteImport } from './routes/hashtag.$tag'
+import { Route as ArticlesNewRouteImport } from './routes/articles.new'
+import { Route as AdminUsersRouteImport } from './routes/admin.users'
+import { Route as AdminReportsRouteImport } from './routes/admin.reports'
+import { Route as HandleFollowingRouteImport } from './routes/$handle.following'
+import { Route as HandleFollowersRouteImport } from './routes/$handle.followers'
+import { Route as ArticlesIdEditRouteImport } from './routes/articles.$id.edit'
+import { Route as HandlePIdRouteImport } from './routes/$handle.p.$id'
+import { Route as HandleASlugRouteImport } from './routes/$handle.a.$slug'
 
 const SignupRoute = SignupRouteImport.update({
-  id: "/signup",
-  path: "/signup",
+  id: '/signup',
+  path: '/signup',
   getParentRoute: () => rootRouteImport,
 } as any)
 const SettingsRoute = SettingsRouteImport.update({
-  id: "/settings",
-  path: "/settings",
+  id: '/settings',
+  path: '/settings',
   getParentRoute: () => rootRouteImport,
 } as any)
 const SearchRoute = SearchRouteImport.update({
-  id: "/search",
-  path: "/search",
+  id: '/search',
+  path: '/search',
   getParentRoute: () => rootRouteImport,
 } as any)
 const NotificationsRoute = NotificationsRouteImport.update({
-  id: "/notifications",
-  path: "/notifications",
+  id: '/notifications',
+  path: '/notifications',
   getParentRoute: () => rootRouteImport,
 } as any)
 const LoginRoute = LoginRouteImport.update({
-  id: "/login",
-  path: "/login",
+  id: '/login',
+  path: '/login',
   getParentRoute: () => rootRouteImport,
 } as any)
 const InboxRoute = InboxRouteImport.update({
-  id: "/inbox",
-  path: "/inbox",
+  id: '/inbox',
+  path: '/inbox',
   getParentRoute: () => rootRouteImport,
 } as any)
 const DraftsRoute = DraftsRouteImport.update({
-  id: "/drafts",
-  path: "/drafts",
+  id: '/drafts',
+  path: '/drafts',
   getParentRoute: () => rootRouteImport,
 } as any)
 const BookmarksRoute = BookmarksRouteImport.update({
-  id: "/bookmarks",
-  path: "/bookmarks",
+  id: '/bookmarks',
+  path: '/bookmarks',
   getParentRoute: () => rootRouteImport,
 } as any)
 const AnalyticsRoute = AnalyticsRouteImport.update({
-  id: "/analytics",
-  path: "/analytics",
+  id: '/analytics',
+  path: '/analytics',
   getParentRoute: () => rootRouteImport,
 } as any)
 const AdminRoute = AdminRouteImport.update({
-  id: "/admin",
-  path: "/admin",
+  id: '/admin',
+  path: '/admin',
   getParentRoute: () => rootRouteImport,
 } as any)
 const HandleRoute = HandleRouteImport.update({
-  id: "/$handle",
-  path: "/$handle",
+  id: '/$handle',
+  path: '/$handle',
   getParentRoute: () => rootRouteImport,
 } as any)
 const IndexRoute = IndexRouteImport.update({
-  id: "/",
-  path: "/",
+  id: '/',
+  path: '/',
   getParentRoute: () => rootRouteImport,
 } as any)
 const ListsIndexRoute = ListsIndexRouteImport.update({
-  id: "/lists/",
-  path: "/lists/",
+  id: '/lists/',
+  path: '/lists/',
   getParentRoute: () => rootRouteImport,
 } as any)
 const InboxIndexRoute = InboxIndexRouteImport.update({
-  id: "/",
-  path: "/",
+  id: '/',
+  path: '/',
   getParentRoute: () => InboxRoute,
 } as any)
 const AdminIndexRoute = AdminIndexRouteImport.update({
-  id: "/",
-  path: "/",
+  id: '/',
+  path: '/',
   getParentRoute: () => AdminRoute,
 } as any)
 const HandleIndexRoute = HandleIndexRouteImport.update({
-  id: "/",
-  path: "/",
+  id: '/',
+  path: '/',
   getParentRoute: () => HandleRoute,
 } as any)
 const ListsIdRoute = ListsIdRouteImport.update({
-  id: "/lists/$id",
-  path: "/lists/$id",
+  id: '/lists/$id',
+  path: '/lists/$id',
   getParentRoute: () => rootRouteImport,
 } as any)
 const InviteTokenRoute = InviteTokenRouteImport.update({
-  id: "/invite/$token",
-  path: "/invite/$token",
+  id: '/invite/$token',
+  path: '/invite/$token',
   getParentRoute: () => rootRouteImport,
 } as any)
 const InboxNewRoute = InboxNewRouteImport.update({
-  id: "/new",
-  path: "/new",
+  id: '/new',
+  path: '/new',
   getParentRoute: () => InboxRoute,
 } as any)
 const InboxConversationIdRoute = InboxConversationIdRouteImport.update({
-  id: "/$conversationId",
-  path: "/$conversationId",
+  id: '/$conversationId',
+  path: '/$conversationId',
   getParentRoute: () => InboxRoute,
 } as any)
 const HashtagTagRoute = HashtagTagRouteImport.update({
-  id: "/hashtag/$tag",
-  path: "/hashtag/$tag",
+  id: '/hashtag/$tag',
+  path: '/hashtag/$tag',
   getParentRoute: () => rootRouteImport,
 } as any)
 const ArticlesNewRoute = ArticlesNewRouteImport.update({
-  id: "/articles/new",
-  path: "/articles/new",
+  id: '/articles/new',
+  path: '/articles/new',
   getParentRoute: () => rootRouteImport,
 } as any)
 const AdminUsersRoute = AdminUsersRouteImport.update({
-  id: "/users",
-  path: "/users",
+  id: '/users',
+  path: '/users',
   getParentRoute: () => AdminRoute,
 } as any)
 const AdminReportsRoute = AdminReportsRouteImport.update({
-  id: "/reports",
-  path: "/reports",
+  id: '/reports',
+  path: '/reports',
   getParentRoute: () => AdminRoute,
 } as any)
 const HandleFollowingRoute = HandleFollowingRouteImport.update({
-  id: "/following",
-  path: "/following",
+  id: '/following',
+  path: '/following',
   getParentRoute: () => HandleRoute,
 } as any)
 const HandleFollowersRoute = HandleFollowersRouteImport.update({
-  id: "/followers",
-  path: "/followers",
+  id: '/followers',
+  path: '/followers',
   getParentRoute: () => HandleRoute,
 } as any)
 const ArticlesIdEditRoute = ArticlesIdEditRouteImport.update({
-  id: "/articles/$id/edit",
-  path: "/articles/$id/edit",
+  id: '/articles/$id/edit',
+  path: '/articles/$id/edit',
   getParentRoute: () => rootRouteImport,
 } as any)
 const HandlePIdRoute = HandlePIdRouteImport.update({
-  id: "/p/$id",
-  path: "/p/$id",
+  id: '/p/$id',
+  path: '/p/$id',
   getParentRoute: () => HandleRoute,
 } as any)
 const HandleASlugRoute = HandleASlugRouteImport.update({
-  id: "/a/$slug",
-  path: "/a/$slug",
+  id: '/a/$slug',
+  path: '/a/$slug',
   getParentRoute: () => HandleRoute,
 } as any)
 
 export interface FileRoutesByFullPath {
-  "/": typeof IndexRoute
-  "/$handle": typeof HandleRouteWithChildren
-  "/admin": typeof AdminRouteWithChildren
-  "/analytics": typeof AnalyticsRoute
-  "/bookmarks": typeof BookmarksRoute
-  "/drafts": typeof DraftsRoute
-  "/inbox": typeof InboxRouteWithChildren
-  "/login": typeof LoginRoute
-  "/notifications": typeof NotificationsRoute
-  "/search": typeof SearchRoute
-  "/settings": typeof SettingsRoute
-  "/signup": typeof SignupRoute
-  "/$handle/followers": typeof HandleFollowersRoute
-  "/$handle/following": typeof HandleFollowingRoute
-  "/admin/reports": typeof AdminReportsRoute
-  "/admin/users": typeof AdminUsersRoute
-  "/articles/new": typeof ArticlesNewRoute
-  "/hashtag/$tag": typeof HashtagTagRoute
-  "/inbox/$conversationId": typeof InboxConversationIdRoute
-  "/inbox/new": typeof InboxNewRoute
-  "/invite/$token": typeof InviteTokenRoute
-  "/lists/$id": typeof ListsIdRoute
-  "/$handle/": typeof HandleIndexRoute
-  "/admin/": typeof AdminIndexRoute
-  "/inbox/": typeof InboxIndexRoute
-  "/lists/": typeof ListsIndexRoute
-  "/$handle/a/$slug": typeof HandleASlugRoute
-  "/$handle/p/$id": typeof HandlePIdRoute
-  "/articles/$id/edit": typeof ArticlesIdEditRoute
+  '/': typeof IndexRoute
+  '/$handle': typeof HandleRouteWithChildren
+  '/admin': typeof AdminRouteWithChildren
+  '/analytics': typeof AnalyticsRoute
+  '/bookmarks': typeof BookmarksRoute
+  '/drafts': typeof DraftsRoute
+  '/inbox': typeof InboxRouteWithChildren
+  '/login': typeof LoginRoute
+  '/notifications': typeof NotificationsRoute
+  '/search': typeof SearchRoute
+  '/settings': typeof SettingsRoute
+  '/signup': typeof SignupRoute
+  '/$handle/followers': typeof HandleFollowersRoute
+  '/$handle/following': typeof HandleFollowingRoute
+  '/admin/reports': typeof AdminReportsRoute
+  '/admin/users': typeof AdminUsersRoute
+  '/articles/new': typeof ArticlesNewRoute
+  '/hashtag/$tag': typeof HashtagTagRoute
+  '/inbox/$conversationId': typeof InboxConversationIdRoute
+  '/inbox/new': typeof InboxNewRoute
+  '/invite/$token': typeof InviteTokenRoute
+  '/lists/$id': typeof ListsIdRoute
+  '/$handle/': typeof HandleIndexRoute
+  '/admin/': typeof AdminIndexRoute
+  '/inbox/': typeof InboxIndexRoute
+  '/lists/': typeof ListsIndexRoute
+  '/$handle/a/$slug': typeof HandleASlugRoute
+  '/$handle/p/$id': typeof HandlePIdRoute
+  '/articles/$id/edit': typeof ArticlesIdEditRoute
 }
 export interface FileRoutesByTo {
-  "/": typeof IndexRoute
-  "/analytics": typeof AnalyticsRoute
-  "/bookmarks": typeof BookmarksRoute
-  "/drafts": typeof DraftsRoute
-  "/login": typeof LoginRoute
-  "/notifications": typeof NotificationsRoute
-  "/search": typeof SearchRoute
-  "/settings": typeof SettingsRoute
-  "/signup": typeof SignupRoute
-  "/$handle/followers": typeof HandleFollowersRoute
-  "/$handle/following": typeof HandleFollowingRoute
-  "/admin/reports": typeof AdminReportsRoute
-  "/admin/users": typeof AdminUsersRoute
-  "/articles/new": typeof ArticlesNewRoute
-  "/hashtag/$tag": typeof HashtagTagRoute
-  "/inbox/$conversationId": typeof InboxConversationIdRoute
-  "/inbox/new": typeof InboxNewRoute
-  "/invite/$token": typeof InviteTokenRoute
-  "/lists/$id": typeof ListsIdRoute
-  "/$handle": typeof HandleIndexRoute
-  "/admin": typeof AdminIndexRoute
-  "/inbox": typeof InboxIndexRoute
-  "/lists": typeof ListsIndexRoute
-  "/$handle/a/$slug": typeof HandleASlugRoute
-  "/$handle/p/$id": typeof HandlePIdRoute
-  "/articles/$id/edit": typeof ArticlesIdEditRoute
+  '/': typeof IndexRoute
+  '/analytics': typeof AnalyticsRoute
+  '/bookmarks': typeof BookmarksRoute
+  '/drafts': typeof DraftsRoute
+  '/login': typeof LoginRoute
+  '/notifications': typeof NotificationsRoute
+  '/search': typeof SearchRoute
+  '/settings': typeof SettingsRoute
+  '/signup': typeof SignupRoute
+  '/$handle/followers': typeof HandleFollowersRoute
+  '/$handle/following': typeof HandleFollowingRoute
+  '/admin/reports': typeof AdminReportsRoute
+  '/admin/users': typeof AdminUsersRoute
+  '/articles/new': typeof ArticlesNewRoute
+  '/hashtag/$tag': typeof HashtagTagRoute
+  '/inbox/$conversationId': typeof InboxConversationIdRoute
+  '/inbox/new': typeof InboxNewRoute
+  '/invite/$token': typeof InviteTokenRoute
+  '/lists/$id': typeof ListsIdRoute
+  '/$handle': typeof HandleIndexRoute
+  '/admin': typeof AdminIndexRoute
+  '/inbox': typeof InboxIndexRoute
+  '/lists': typeof ListsIndexRoute
+  '/$handle/a/$slug': typeof HandleASlugRoute
+  '/$handle/p/$id': typeof HandlePIdRoute
+  '/articles/$id/edit': typeof ArticlesIdEditRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
-  "/": typeof IndexRoute
-  "/$handle": typeof HandleRouteWithChildren
-  "/admin": typeof AdminRouteWithChildren
-  "/analytics": typeof AnalyticsRoute
-  "/bookmarks": typeof BookmarksRoute
-  "/drafts": typeof DraftsRoute
-  "/inbox": typeof InboxRouteWithChildren
-  "/login": typeof LoginRoute
-  "/notifications": typeof NotificationsRoute
-  "/search": typeof SearchRoute
-  "/settings": typeof SettingsRoute
-  "/signup": typeof SignupRoute
-  "/$handle/followers": typeof HandleFollowersRoute
-  "/$handle/following": typeof HandleFollowingRoute
-  "/admin/reports": typeof AdminReportsRoute
-  "/admin/users": typeof AdminUsersRoute
-  "/articles/new": typeof ArticlesNewRoute
-  "/hashtag/$tag": typeof HashtagTagRoute
-  "/inbox/$conversationId": typeof InboxConversationIdRoute
-  "/inbox/new": typeof InboxNewRoute
-  "/invite/$token": typeof InviteTokenRoute
-  "/lists/$id": typeof ListsIdRoute
-  "/$handle/": typeof HandleIndexRoute
-  "/admin/": typeof AdminIndexRoute
-  "/inbox/": typeof InboxIndexRoute
-  "/lists/": typeof ListsIndexRoute
-  "/$handle/a/$slug": typeof HandleASlugRoute
-  "/$handle/p/$id": typeof HandlePIdRoute
-  "/articles/$id/edit": typeof ArticlesIdEditRoute
+  '/': typeof IndexRoute
+  '/$handle': typeof HandleRouteWithChildren
+  '/admin': typeof AdminRouteWithChildren
+  '/analytics': typeof AnalyticsRoute
+  '/bookmarks': typeof BookmarksRoute
+  '/drafts': typeof DraftsRoute
+  '/inbox': typeof InboxRouteWithChildren
+  '/login': typeof LoginRoute
+  '/notifications': typeof NotificationsRoute
+  '/search': typeof SearchRoute
+  '/settings': typeof SettingsRoute
+  '/signup': typeof SignupRoute
+  '/$handle/followers': typeof HandleFollowersRoute
+  '/$handle/following': typeof HandleFollowingRoute
+  '/admin/reports': typeof AdminReportsRoute
+  '/admin/users': typeof AdminUsersRoute
+  '/articles/new': typeof ArticlesNewRoute
+  '/hashtag/$tag': typeof HashtagTagRoute
+  '/inbox/$conversationId': typeof InboxConversationIdRoute
+  '/inbox/new': typeof InboxNewRoute
+  '/invite/$token': typeof InviteTokenRoute
+  '/lists/$id': typeof ListsIdRoute
+  '/$handle/': typeof HandleIndexRoute
+  '/admin/': typeof AdminIndexRoute
+  '/inbox/': typeof InboxIndexRoute
+  '/lists/': typeof ListsIndexRoute
+  '/$handle/a/$slug': typeof HandleASlugRoute
+  '/$handle/p/$id': typeof HandlePIdRoute
+  '/articles/$id/edit': typeof ArticlesIdEditRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
   fullPaths:
-    | "/"
-    | "/$handle"
-    | "/admin"
-    | "/analytics"
-    | "/bookmarks"
-    | "/drafts"
-    | "/inbox"
-    | "/login"
-    | "/notifications"
-    | "/search"
-    | "/settings"
-    | "/signup"
-    | "/$handle/followers"
-    | "/$handle/following"
-    | "/admin/reports"
-    | "/admin/users"
-    | "/articles/new"
-    | "/hashtag/$tag"
-    | "/inbox/$conversationId"
-    | "/inbox/new"
-    | "/invite/$token"
-    | "/lists/$id"
-    | "/$handle/"
-    | "/admin/"
-    | "/inbox/"
-    | "/lists/"
-    | "/$handle/a/$slug"
-    | "/$handle/p/$id"
-    | "/articles/$id/edit"
+    | '/'
+    | '/$handle'
+    | '/admin'
+    | '/analytics'
+    | '/bookmarks'
+    | '/drafts'
+    | '/inbox'
+    | '/login'
+    | '/notifications'
+    | '/search'
+    | '/settings'
+    | '/signup'
+    | '/$handle/followers'
+    | '/$handle/following'
+    | '/admin/reports'
+    | '/admin/users'
+    | '/articles/new'
+    | '/hashtag/$tag'
+    | '/inbox/$conversationId'
+    | '/inbox/new'
+    | '/invite/$token'
+    | '/lists/$id'
+    | '/$handle/'
+    | '/admin/'
+    | '/inbox/'
+    | '/lists/'
+    | '/$handle/a/$slug'
+    | '/$handle/p/$id'
+    | '/articles/$id/edit'
   fileRoutesByTo: FileRoutesByTo
   to:
-    | "/"
-    | "/analytics"
-    | "/bookmarks"
-    | "/drafts"
-    | "/login"
-    | "/notifications"
-    | "/search"
-    | "/settings"
-    | "/signup"
-    | "/$handle/followers"
-    | "/$handle/following"
-    | "/admin/reports"
-    | "/admin/users"
-    | "/articles/new"
-    | "/hashtag/$tag"
-    | "/inbox/$conversationId"
-    | "/inbox/new"
-    | "/invite/$token"
-    | "/lists/$id"
-    | "/$handle"
-    | "/admin"
-    | "/inbox"
-    | "/lists"
-    | "/$handle/a/$slug"
-    | "/$handle/p/$id"
-    | "/articles/$id/edit"
+    | '/'
+    | '/analytics'
+    | '/bookmarks'
+    | '/drafts'
+    | '/login'
+    | '/notifications'
+    | '/search'
+    | '/settings'
+    | '/signup'
+    | '/$handle/followers'
+    | '/$handle/following'
+    | '/admin/reports'
+    | '/admin/users'
+    | '/articles/new'
+    | '/hashtag/$tag'
+    | '/inbox/$conversationId'
+    | '/inbox/new'
+    | '/invite/$token'
+    | '/lists/$id'
+    | '/$handle'
+    | '/admin'
+    | '/inbox'
+    | '/lists'
+    | '/$handle/a/$slug'
+    | '/$handle/p/$id'
+    | '/articles/$id/edit'
   id:
-    | "__root__"
-    | "/"
-    | "/$handle"
-    | "/admin"
-    | "/analytics"
-    | "/bookmarks"
-    | "/drafts"
-    | "/inbox"
-    | "/login"
-    | "/notifications"
-    | "/search"
-    | "/settings"
-    | "/signup"
-    | "/$handle/followers"
-    | "/$handle/following"
-    | "/admin/reports"
-    | "/admin/users"
-    | "/articles/new"
-    | "/hashtag/$tag"
-    | "/inbox/$conversationId"
-    | "/inbox/new"
-    | "/invite/$token"
-    | "/lists/$id"
-    | "/$handle/"
-    | "/admin/"
-    | "/inbox/"
-    | "/lists/"
-    | "/$handle/a/$slug"
-    | "/$handle/p/$id"
-    | "/articles/$id/edit"
+    | '__root__'
+    | '/'
+    | '/$handle'
+    | '/admin'
+    | '/analytics'
+    | '/bookmarks'
+    | '/drafts'
+    | '/inbox'
+    | '/login'
+    | '/notifications'
+    | '/search'
+    | '/settings'
+    | '/signup'
+    | '/$handle/followers'
+    | '/$handle/following'
+    | '/admin/reports'
+    | '/admin/users'
+    | '/articles/new'
+    | '/hashtag/$tag'
+    | '/inbox/$conversationId'
+    | '/inbox/new'
+    | '/invite/$token'
+    | '/lists/$id'
+    | '/$handle/'
+    | '/admin/'
+    | '/inbox/'
+    | '/lists/'
+    | '/$handle/a/$slug'
+    | '/$handle/p/$id'
+    | '/articles/$id/edit'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
@@ -390,208 +390,208 @@ export interface RootRouteChildren {
   ArticlesIdEditRoute: typeof ArticlesIdEditRoute
 }
 
-declare module "@tanstack/react-router" {
+declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
-    "/signup": {
-      id: "/signup"
-      path: "/signup"
-      fullPath: "/signup"
+    '/signup': {
+      id: '/signup'
+      path: '/signup'
+      fullPath: '/signup'
       preLoaderRoute: typeof SignupRouteImport
       parentRoute: typeof rootRouteImport
     }
-    "/settings": {
-      id: "/settings"
-      path: "/settings"
-      fullPath: "/settings"
+    '/settings': {
+      id: '/settings'
+      path: '/settings'
+      fullPath: '/settings'
       preLoaderRoute: typeof SettingsRouteImport
       parentRoute: typeof rootRouteImport
     }
-    "/search": {
-      id: "/search"
-      path: "/search"
-      fullPath: "/search"
+    '/search': {
+      id: '/search'
+      path: '/search'
+      fullPath: '/search'
       preLoaderRoute: typeof SearchRouteImport
       parentRoute: typeof rootRouteImport
     }
-    "/notifications": {
-      id: "/notifications"
-      path: "/notifications"
-      fullPath: "/notifications"
+    '/notifications': {
+      id: '/notifications'
+      path: '/notifications'
+      fullPath: '/notifications'
       preLoaderRoute: typeof NotificationsRouteImport
       parentRoute: typeof rootRouteImport
     }
-    "/login": {
-      id: "/login"
-      path: "/login"
-      fullPath: "/login"
+    '/login': {
+      id: '/login'
+      path: '/login'
+      fullPath: '/login'
       preLoaderRoute: typeof LoginRouteImport
       parentRoute: typeof rootRouteImport
     }
-    "/inbox": {
-      id: "/inbox"
-      path: "/inbox"
-      fullPath: "/inbox"
+    '/inbox': {
+      id: '/inbox'
+      path: '/inbox'
+      fullPath: '/inbox'
       preLoaderRoute: typeof InboxRouteImport
       parentRoute: typeof rootRouteImport
     }
-    "/drafts": {
-      id: "/drafts"
-      path: "/drafts"
-      fullPath: "/drafts"
+    '/drafts': {
+      id: '/drafts'
+      path: '/drafts'
+      fullPath: '/drafts'
       preLoaderRoute: typeof DraftsRouteImport
       parentRoute: typeof rootRouteImport
     }
-    "/bookmarks": {
-      id: "/bookmarks"
-      path: "/bookmarks"
-      fullPath: "/bookmarks"
+    '/bookmarks': {
+      id: '/bookmarks'
+      path: '/bookmarks'
+      fullPath: '/bookmarks'
       preLoaderRoute: typeof BookmarksRouteImport
       parentRoute: typeof rootRouteImport
     }
-    "/analytics": {
-      id: "/analytics"
-      path: "/analytics"
-      fullPath: "/analytics"
+    '/analytics': {
+      id: '/analytics'
+      path: '/analytics'
+      fullPath: '/analytics'
       preLoaderRoute: typeof AnalyticsRouteImport
       parentRoute: typeof rootRouteImport
     }
-    "/admin": {
-      id: "/admin"
-      path: "/admin"
-      fullPath: "/admin"
+    '/admin': {
+      id: '/admin'
+      path: '/admin'
+      fullPath: '/admin'
       preLoaderRoute: typeof AdminRouteImport
       parentRoute: typeof rootRouteImport
     }
-    "/$handle": {
-      id: "/$handle"
-      path: "/$handle"
-      fullPath: "/$handle"
+    '/$handle': {
+      id: '/$handle'
+      path: '/$handle'
+      fullPath: '/$handle'
       preLoaderRoute: typeof HandleRouteImport
       parentRoute: typeof rootRouteImport
     }
-    "/": {
-      id: "/"
-      path: "/"
-      fullPath: "/"
+    '/': {
+      id: '/'
+      path: '/'
+      fullPath: '/'
       preLoaderRoute: typeof IndexRouteImport
       parentRoute: typeof rootRouteImport
     }
-    "/lists/": {
-      id: "/lists/"
-      path: "/lists"
-      fullPath: "/lists/"
+    '/lists/': {
+      id: '/lists/'
+      path: '/lists'
+      fullPath: '/lists/'
       preLoaderRoute: typeof ListsIndexRouteImport
       parentRoute: typeof rootRouteImport
     }
-    "/inbox/": {
-      id: "/inbox/"
-      path: "/"
-      fullPath: "/inbox/"
+    '/inbox/': {
+      id: '/inbox/'
+      path: '/'
+      fullPath: '/inbox/'
       preLoaderRoute: typeof InboxIndexRouteImport
       parentRoute: typeof InboxRoute
     }
-    "/admin/": {
-      id: "/admin/"
-      path: "/"
-      fullPath: "/admin/"
+    '/admin/': {
+      id: '/admin/'
+      path: '/'
+      fullPath: '/admin/'
       preLoaderRoute: typeof AdminIndexRouteImport
       parentRoute: typeof AdminRoute
     }
-    "/$handle/": {
-      id: "/$handle/"
-      path: "/"
-      fullPath: "/$handle/"
+    '/$handle/': {
+      id: '/$handle/'
+      path: '/'
+      fullPath: '/$handle/'
       preLoaderRoute: typeof HandleIndexRouteImport
       parentRoute: typeof HandleRoute
     }
-    "/lists/$id": {
-      id: "/lists/$id"
-      path: "/lists/$id"
-      fullPath: "/lists/$id"
+    '/lists/$id': {
+      id: '/lists/$id'
+      path: '/lists/$id'
+      fullPath: '/lists/$id'
       preLoaderRoute: typeof ListsIdRouteImport
       parentRoute: typeof rootRouteImport
     }
-    "/invite/$token": {
-      id: "/invite/$token"
-      path: "/invite/$token"
-      fullPath: "/invite/$token"
+    '/invite/$token': {
+      id: '/invite/$token'
+      path: '/invite/$token'
+      fullPath: '/invite/$token'
       preLoaderRoute: typeof InviteTokenRouteImport
       parentRoute: typeof rootRouteImport
     }
-    "/inbox/new": {
-      id: "/inbox/new"
-      path: "/new"
-      fullPath: "/inbox/new"
+    '/inbox/new': {
+      id: '/inbox/new'
+      path: '/new'
+      fullPath: '/inbox/new'
       preLoaderRoute: typeof InboxNewRouteImport
       parentRoute: typeof InboxRoute
     }
-    "/inbox/$conversationId": {
-      id: "/inbox/$conversationId"
-      path: "/$conversationId"
-      fullPath: "/inbox/$conversationId"
+    '/inbox/$conversationId': {
+      id: '/inbox/$conversationId'
+      path: '/$conversationId'
+      fullPath: '/inbox/$conversationId'
       preLoaderRoute: typeof InboxConversationIdRouteImport
       parentRoute: typeof InboxRoute
     }
-    "/hashtag/$tag": {
-      id: "/hashtag/$tag"
-      path: "/hashtag/$tag"
-      fullPath: "/hashtag/$tag"
+    '/hashtag/$tag': {
+      id: '/hashtag/$tag'
+      path: '/hashtag/$tag'
+      fullPath: '/hashtag/$tag'
       preLoaderRoute: typeof HashtagTagRouteImport
       parentRoute: typeof rootRouteImport
     }
-    "/articles/new": {
-      id: "/articles/new"
-      path: "/articles/new"
-      fullPath: "/articles/new"
+    '/articles/new': {
+      id: '/articles/new'
+      path: '/articles/new'
+      fullPath: '/articles/new'
       preLoaderRoute: typeof ArticlesNewRouteImport
       parentRoute: typeof rootRouteImport
     }
-    "/admin/users": {
-      id: "/admin/users"
-      path: "/users"
-      fullPath: "/admin/users"
+    '/admin/users': {
+      id: '/admin/users'
+      path: '/users'
+      fullPath: '/admin/users'
       preLoaderRoute: typeof AdminUsersRouteImport
       parentRoute: typeof AdminRoute
     }
-    "/admin/reports": {
-      id: "/admin/reports"
-      path: "/reports"
-      fullPath: "/admin/reports"
+    '/admin/reports': {
+      id: '/admin/reports'
+      path: '/reports'
+      fullPath: '/admin/reports'
       preLoaderRoute: typeof AdminReportsRouteImport
       parentRoute: typeof AdminRoute
     }
-    "/$handle/following": {
-      id: "/$handle/following"
-      path: "/following"
-      fullPath: "/$handle/following"
+    '/$handle/following': {
+      id: '/$handle/following'
+      path: '/following'
+      fullPath: '/$handle/following'
       preLoaderRoute: typeof HandleFollowingRouteImport
       parentRoute: typeof HandleRoute
     }
-    "/$handle/followers": {
-      id: "/$handle/followers"
-      path: "/followers"
-      fullPath: "/$handle/followers"
+    '/$handle/followers': {
+      id: '/$handle/followers'
+      path: '/followers'
+      fullPath: '/$handle/followers'
       preLoaderRoute: typeof HandleFollowersRouteImport
       parentRoute: typeof HandleRoute
     }
-    "/articles/$id/edit": {
-      id: "/articles/$id/edit"
-      path: "/articles/$id/edit"
-      fullPath: "/articles/$id/edit"
+    '/articles/$id/edit': {
+      id: '/articles/$id/edit'
+      path: '/articles/$id/edit'
+      fullPath: '/articles/$id/edit'
       preLoaderRoute: typeof ArticlesIdEditRouteImport
       parentRoute: typeof rootRouteImport
     }
-    "/$handle/p/$id": {
-      id: "/$handle/p/$id"
-      path: "/p/$id"
-      fullPath: "/$handle/p/$id"
+    '/$handle/p/$id': {
+      id: '/$handle/p/$id'
+      path: '/p/$id'
+      fullPath: '/$handle/p/$id'
       preLoaderRoute: typeof HandlePIdRouteImport
       parentRoute: typeof HandleRoute
     }
-    "/$handle/a/$slug": {
-      id: "/$handle/a/$slug"
-      path: "/a/$slug"
-      fullPath: "/$handle/a/$slug"
+    '/$handle/a/$slug': {
+      id: '/$handle/a/$slug'
+      path: '/a/$slug'
+      fullPath: '/$handle/a/$slug'
       preLoaderRoute: typeof HandleASlugRouteImport
       parentRoute: typeof HandleRoute
     }
@@ -669,9 +669,9 @@ export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)
   ._addFileTypes<FileRouteTypes>()
 
-import type { getRouter } from "./router.tsx"
-import type { createStart } from "@tanstack/react-start"
-declare module "@tanstack/react-start" {
+import type { getRouter } from './router.tsx'
+import type { createStart } from '@tanstack/react-start'
+declare module '@tanstack/react-start' {
   interface Register {
     ssr: true
     router: Awaited<ReturnType<typeof getRouter>>

--- a/bun.lock
+++ b/bun.lock
@@ -54,6 +54,7 @@
         "@tanstack/react-router": "^1.132.0",
         "@tanstack/react-start": "^1.132.0",
         "@tanstack/react-table": "^8.21.3",
+        "@tanstack/react-virtual": "^3.13.24",
         "@tanstack/router-plugin": "^1.132.0",
         "@workspace/auth": "workspace:*",
         "@workspace/ui": "workspace:*",
@@ -1032,6 +1033,8 @@
 
     "@tanstack/react-table": ["@tanstack/react-table@8.21.3", "", { "dependencies": { "@tanstack/table-core": "8.21.3" }, "peerDependencies": { "react": ">=16.8", "react-dom": ">=16.8" } }, "sha512-5nNMTSETP4ykGegmVkhjcS8tTLW6Vl4axfEGQN3v0zdHYbK4UfoqfPChclTrJ4EoK9QynqAu9oUf8VEmrpZ5Ww=="],
 
+    "@tanstack/react-virtual": ["@tanstack/react-virtual@3.13.24", "", { "dependencies": { "@tanstack/virtual-core": "3.14.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-aIJvz5OSkhNIhZIpYivrxrPTKYsjW9Uzy+sP/mx0S3sev2HyvPb7xmjbYvokzEpfgYHy/HjzJ2zFAETuUfgCpg=="],
+
     "@tanstack/router-core": ["@tanstack/router-core@1.168.16", "", { "dependencies": { "@tanstack/history": "1.161.6", "cookie-es": "^3.0.0", "seroval": "^1.5.0", "seroval-plugins": "^1.5.0" }, "bin": { "intent": "bin/intent.js" } }, "sha512-2lkWNMzDWWxVqTf9Y54DH1ceZOrGrOGzx9CFVMq8gQSOxhr3x3+otjVei1Rlx4xmsCc4yCqccqjun5wDtE9MZA=="],
 
     "@tanstack/router-generator": ["@tanstack/router-generator@1.166.34", "", { "dependencies": { "@babel/types": "^7.28.5", "@tanstack/router-core": "1.168.16", "@tanstack/router-utils": "1.161.7", "@tanstack/virtual-file-routes": "1.161.7", "magic-string": "^0.30.21", "prettier": "^3.5.0", "tsx": "^4.19.2", "zod": "^3.24.2" } }, "sha512-VamHGCFqOntz9Ds6oOHtpzXLQg2yhOsXsCXSznLjoDzme3Rk69HvOzXkx9IIpDxo4v64QdvNjeV2IyfXuz5RFw=="],
@@ -1053,6 +1056,8 @@
     "@tanstack/store": ["@tanstack/store@0.9.3", "", {}, "sha512-8reSzl/qGWGGVKhBoxXPMWzATSbZLZFWhwBAFO9NAyp0TxzfBP0mIrGb8CP8KrQTmvzXlR/vFPPUrHTLBGyFyw=="],
 
     "@tanstack/table-core": ["@tanstack/table-core@8.21.3", "", {}, "sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg=="],
+
+    "@tanstack/virtual-core": ["@tanstack/virtual-core@3.14.0", "", {}, "sha512-JLANqGy/D6k4Ujmh8Tr25lGimuOXNiaVyXaCAZS0W+1390sADdGnyUdSWNIfd49gebtIxGMij4IktRVzrdr12Q=="],
 
     "@tanstack/virtual-file-routes": ["@tanstack/virtual-file-routes@1.161.7", "", { "bin": { "intent": "bin/intent.js" } }, "sha512-olW33+Cn+bsCsZKPwEGhlkqS6w3M2slFv11JIobdnCFKMLG97oAI2kWKdx5/zsywTL8flpnoIgaZZPlQTFYhdQ=="],
 


### PR DESCRIPTION
## Summary

- Implement virtual scrolling in the Feed component using `@tanstack/react-virtual` to improve performance when rendering large lists of posts
- Replace manual "load more" button with automatic pagination triggered by an IntersectionObserver sentinel
- Convert all double quotes to single quotes in `routeTree.gen.ts` for consistent code style

## Test plan

- [ ] `bun run typecheck` passes
- [ ] Manually scrolled through feed to verify posts render and load automatically as you approach the bottom
- [ ] No new console errors / network errors

## Notes

The Feed component now uses virtual scrolling to only render visible posts in the viewport, significantly improving performance for feeds with many posts. The automatic pagination via IntersectionObserver replaces the previous manual "load more" button. The component includes a fallback non-virtualized render for SSR/initial paint before the scroll parent is resolved.

https://claude.ai/code/session_017gXjTma429mHYUC7Ei3e1J