### PR TITLE
feat(admin): owner can change user handles

### DIFF
--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -584,6 +584,47 @@ adminRoute.delete('/posts/:id', async (c) => {
   return c.json({ ok: true })
 })
 
+const deleteUserSchema = z.object({
+  reason: z.string().trim().min(1).max(500).optional(),
+})
+
+// Owner-only: soft-delete a user account. Sets deletedAt so the user disappears from feeds,
+// profile lookups, and search (every read path filters on isNull(deletedAt)). Sessions are
+// wiped so the account is logged out everywhere on the next request. Reversible by clearing
+// deletedAt directly in the DB if needed.
+adminRoute.delete('/users/:id', requireOwner(), async (c) => {
+  const session = c.get('session')!
+  const { db } = c.get('ctx')
+  const id = c.req.param('id')
+  const body = deleteUserSchema.parse(await c.req.json().catch(() => ({})))
+
+  if (id === session.user.id) return c.json({ error: 'cannot_delete_self' }, 400)
+
+  const [target] = await db
+    .select({ deletedAt: schema.users.deletedAt })
+    .from(schema.users)
+    .where(eq(schema.users.id, id))
+    .limit(1)
+  if (!target) return c.json({ error: 'not_found' }, 404)
+  if (target.deletedAt) return c.json({ error: 'already_deleted' }, 409)
+
+  await db.transaction(async (tx) => {
+    await tx
+      .update(schema.users)
+      .set({ deletedAt: new Date(), updatedAt: new Date() })
+      .where(eq(schema.users.id, id))
+    await tx.delete(schema.sessions).where(eq(schema.sessions.userId, id))
+    await tx.insert(schema.moderationActions).values({
+      moderatorId: session.user.id,
+      subjectType: 'user',
+      subjectId: id,
+      action: 'delete',
+      publicReason: body.reason ?? null,
+    })
+  })
+  return c.json({ ok: true })
+})
+
 // Prevent admins from acting on other admins or owners. Owners can act on anyone (except self,
 // which is checked separately in the caller).
 async function guardTargetRank(c: Context<HonoEnv>, targetId: string) {

--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -3,8 +3,10 @@ import { z } from 'zod'
 import { and, desc, eq, ilike, or, sql } from '@workspace/db'
 import { schema } from '@workspace/db'
 import { assetUrl } from '@workspace/media/s3'
+import { handleSchema } from '@workspace/validators'
 import { requireAdmin, requireOwner, type HonoEnv, type Role } from '../middleware/session.ts'
 import { parseCursor } from '../lib/cursor.ts'
+import { isReservedHandle } from '../lib/handles.ts'
 
 export const adminRoute = new Hono<HonoEnv>()
 
@@ -502,6 +504,57 @@ adminRoute.post('/users/:id/unverify', async (c) => {
       subjectId: id,
       action: 'warn',
       privateNote: `verify_revoke${body.reason ? `: ${body.reason}` : ''}`,
+    })
+  })
+  return c.json({ ok: true })
+})
+
+const setHandleSchema = z.object({
+  handle: handleSchema,
+  reason: z.string().trim().min(1).max(500).optional(),
+})
+
+// Owner-only: forcibly reassign a user's handle. Useful for reclaiming squatted handles or
+// resolving impersonation reports. The handle is freed atomically — if the new handle is
+// taken or reserved we 4xx without touching the row.
+adminRoute.post('/users/:id/handle', requireOwner(), async (c) => {
+  const session = c.get('session')!
+  const { db } = c.get('ctx')
+  const id = c.req.param('id')
+  const { handle, reason } = setHandleSchema.parse(await c.req.json())
+  const normalized = handle.toLowerCase()
+
+  if (isReservedHandle(normalized)) return c.json({ error: 'reserved_handle' }, 400)
+
+  const [target] = await db
+    .select({ handle: schema.users.handle })
+    .from(schema.users)
+    .where(eq(schema.users.id, id))
+    .limit(1)
+  if (!target) return c.json({ error: 'not_found' }, 404)
+
+  // citext column ⇒ case-insensitive comparison. Allow rewriting to the same handle with a
+  // different case (e.g. fix capitalisation), but skip the conflict check in that case.
+  if (target.handle?.toLowerCase() !== normalized) {
+    const existing = await db
+      .select({ id: schema.users.id })
+      .from(schema.users)
+      .where(eq(schema.users.handle, handle))
+      .limit(1)
+    if (existing.length > 0) return c.json({ error: 'handle_taken' }, 409)
+  }
+
+  await db.transaction(async (tx) => {
+    await tx
+      .update(schema.users)
+      .set({ handle, updatedAt: new Date() })
+      .where(eq(schema.users.id, id))
+    await tx.insert(schema.moderationActions).values({
+      moderatorId: session.user.id,
+      subjectType: 'user',
+      subjectId: id,
+      action: 'warn',
+      privateNote: `handle_change: ${target.handle ?? '∅'} -> ${handle}${reason ? ` (${reason})` : ''}`,
     })
   })
   return c.json({ ok: true })

--- a/apps/api/src/routes/me.ts
+++ b/apps/api/src/routes/me.ts
@@ -23,6 +23,12 @@ meRoute.get('/', async (c) => {
   const { db } = c.get('ctx')
   const [user] = await db.select().from(schema.users).where(eq(schema.users.id, session.user.id)).limit(1)
   if (!user) return c.json({ error: 'not_found' }, 404)
+  // Authoritative liveness check. The session middleware already rejects banned users, but
+  // it reads `banned` from the (possibly cached) session payload, so a moderation action in
+  // the cache window can be missed. The frontend polls this endpoint periodically and force
+  // signs out on 401, so keeping this in sync with the DB bounds the lag for kicking
+  // banned, suspended, or soft-deleted users.
+  if (user.banned || user.deletedAt) return c.json({ error: 'unauthorized' }, 401)
   return c.json({ user: toSelfDto(user, c.get('ctx').mediaEnv) })
 })
 

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -439,6 +439,11 @@ export const api = {
       method: "POST",
       body: JSON.stringify({ role }),
     }),
+  adminSetHandle: (id: string, body: { handle: string; reason?: string }) =>
+    request<{ ok: true }>(`/api/admin/users/${id}/handle`, {
+      method: "POST",
+      body: JSON.stringify(body),
+    }),
   adminVerify: (id: string, reason?: string) =>
     request<{ ok: true }>(`/api/admin/users/${id}/verify`, {
       method: "POST",

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -444,6 +444,11 @@ export const api = {
       method: "POST",
       body: JSON.stringify(body),
     }),
+  adminDeleteUser: (id: string, body: { reason?: string } = {}) =>
+    request<{ ok: true }>(`/api/admin/users/${id}`, {
+      method: "DELETE",
+      body: JSON.stringify(body),
+    }),
   adminVerify: (id: string, reason?: string) =>
     request<{ ok: true }>(`/api/admin/users/${id}/verify`, {
       method: "POST",

--- a/apps/web/src/lib/me.tsx
+++ b/apps/web/src/lib/me.tsx
@@ -3,9 +3,10 @@ import {
   useCallback,
   useContext,
   useEffect,
+  useRef,
   useState,
 } from "react"
-import { api } from "./api"
+import { ApiError, api } from "./api"
 import { authClient } from "./auth"
 import type { ReactNode } from "react"
 import type { SelfUser } from "./api"
@@ -19,10 +20,33 @@ interface MeContextValue {
 
 const MeContext = createContext<MeContextValue | null>(null)
 
+// Re-check the session this often while the tab is visible. Bounds how long a
+// banned/suspended/deleted user can keep an idle tab open before being kicked.
+const POLL_INTERVAL_MS = 30_000
+
 export function MeProvider({ children }: { children: ReactNode }) {
   const { data: session, isPending } = authClient.useSession()
   const [me, setMe] = useState<SelfUser | null>(null)
   const [isLoading, setIsLoading] = useState(false)
+  // Guard against re-entrant signOut calls when both the poll and a parallel
+  // request both observe a 401.
+  const forcingOut = useRef(false)
+
+  const forceSignOut = useCallback(async () => {
+    if (forcingOut.current) return
+    forcingOut.current = true
+    setMe(null)
+    try {
+      await authClient.signOut()
+    } catch {
+      // Best-effort: even if the server-side signOut fails (already-revoked session,
+      // network blip), the local state is cleared and the redirect will land them on
+      // the public login page where they can re-auth.
+    }
+    if (typeof window !== "undefined" && window.location.pathname !== "/login") {
+      window.location.assign("/login")
+    }
+  }, [])
 
   const refresh = useCallback(async () => {
     if (!session) {
@@ -33,12 +57,18 @@ export function MeProvider({ children }: { children: ReactNode }) {
     try {
       const { user } = await api.me()
       setMe(user)
-    } catch {
+    } catch (e) {
       setMe(null)
+      // 401 here means the server has already invalidated the session (ban, delete,
+      // expired, etc.). Treat any other error as transient and leave the better-auth
+      // session alone so we don't bounce users on a network blip.
+      if (e instanceof ApiError && e.status === 401) {
+        await forceSignOut()
+      }
     } finally {
       setIsLoading(false)
     }
-  }, [session])
+  }, [session, forceSignOut])
 
   useEffect(() => {
     if (isPending) return
@@ -47,6 +77,41 @@ export function MeProvider({ children }: { children: ReactNode }) {
       return
     }
     refresh()
+  }, [isPending, session, refresh])
+
+  // Poll while authenticated + visible so users on idle tabs are kicked promptly
+  // after a moderation action. We also re-check on tab focus in case the OS
+  // throttled the interval while the tab was hidden.
+  useEffect(() => {
+    if (isPending || !session) return
+    let timer: ReturnType<typeof setInterval> | null = null
+
+    const start = () => {
+      if (timer) return
+      timer = setInterval(refresh, POLL_INTERVAL_MS)
+    }
+    const stop = () => {
+      if (!timer) return
+      clearInterval(timer)
+      timer = null
+    }
+    const onVisibility = () => {
+      if (document.visibilityState === "visible") {
+        refresh()
+        start()
+      } else {
+        stop()
+      }
+    }
+
+    if (document.visibilityState === "visible") start()
+    document.addEventListener("visibilitychange", onVisibility)
+    window.addEventListener("focus", refresh)
+    return () => {
+      stop()
+      document.removeEventListener("visibilitychange", onVisibility)
+      window.removeEventListener("focus", refresh)
+    }
   }, [isPending, session, refresh])
 
   return (

--- a/apps/web/src/routes/admin.users.tsx
+++ b/apps/web/src/routes/admin.users.tsx
@@ -49,6 +49,7 @@ type ActionDialogState =
   | { kind: "ban"; user: AdminUser }
   | { kind: "shadow"; user: AdminUser }
   | { kind: "verify"; user: AdminUser }
+  | { kind: "handle"; user: AdminUser }
   | null
 
 function AdminUsers() {
@@ -291,6 +292,16 @@ function AdminUsers() {
               >
                 {u.isVerified ? "Unverify" : "Verify"}
               </Button>
+              {me?.role === "owner" && (
+                <Button
+                  size="sm"
+                  variant="outline"
+                  disabled={busyId === u.id}
+                  onClick={() => setDialog({ kind: "handle", user: u })}
+                >
+                  Handle
+                </Button>
+              )}
             </div>
           )
         },
@@ -362,8 +373,14 @@ function AdminUsers() {
         onSubmit={async (run) => {
           if (!dialog) return
           const id = dialog.user.id
-          setDialog(null)
-          await act(id, run)
+          setBusyId(id)
+          try {
+            await run()
+            setDialog(null)
+            await load(q)
+          } finally {
+            setBusyId(null)
+          }
         }}
       />
     </main>
@@ -381,12 +398,16 @@ function ActionDialog({
 }) {
   const [reason, setReason] = useState("")
   const [hours, setHours] = useState("")
+  const [handle, setHandle] = useState("")
+  const [submitError, setSubmitError] = useState<string | null>(null)
   const [busy, setBusy] = useState(false)
 
   useEffect(() => {
     if (state) {
       setReason("")
       setHours("")
+      setHandle(state.kind === "handle" ? (state.user.handle ?? "") : "")
+      setSubmitError(null)
       setBusy(false)
     }
   }, [state])
@@ -446,12 +467,28 @@ function ActionDialog({
           ? api.adminUnverify(u.id, reason.trim() || undefined)
           : api.adminVerify(u.id, reason.trim() || undefined),
     },
+    handle: {
+      title: `Change handle for ${subject}`,
+      description:
+        "3–20 chars, letters/numbers/underscore. The previous handle is freed for reuse.",
+      submitLabel: "Save handle",
+      submitVariant: "default" as const,
+      showDuration: false,
+      run: () =>
+        api.adminSetHandle(u.id, {
+          handle: handle.trim(),
+          reason: reason.trim() || undefined,
+        }),
+    },
   }[state.kind]
 
   async function submit() {
     setBusy(true)
+    setSubmitError(null)
     try {
       await onSubmit(config.run)
+    } catch (e) {
+      setSubmitError(e instanceof Error ? e.message : "failed")
     } finally {
       setBusy(false)
     }
@@ -465,13 +502,27 @@ function ActionDialog({
           <DialogDescription>{config.description}</DialogDescription>
         </DialogHeader>
         <div className="flex flex-col gap-3">
+          {state.kind === "handle" && (
+            <label className="flex flex-col gap-1 text-xs">
+              <span className="text-muted-foreground">New handle</span>
+              <Input
+                value={handle}
+                onChange={(e) => setHandle(e.target.value)}
+                placeholder="newhandle"
+                autoCapitalize="none"
+                autoCorrect="off"
+                spellCheck={false}
+                autoFocus
+              />
+            </label>
+          )}
           <label className="flex flex-col gap-1 text-xs">
             <span className="text-muted-foreground">Reason (optional)</span>
             <Input
               value={reason}
               onChange={(e) => setReason(e.target.value)}
               placeholder="Reason"
-              autoFocus
+              autoFocus={state.kind !== "handle"}
             />
           </label>
           {config.showDuration && (
@@ -486,6 +537,9 @@ function ActionDialog({
                 inputMode="numeric"
               />
             </label>
+          )}
+          {submitError && (
+            <p className="text-xs text-destructive">{submitError}</p>
           )}
         </div>
         <DialogFooter>

--- a/apps/web/src/routes/admin.users.tsx
+++ b/apps/web/src/routes/admin.users.tsx
@@ -50,6 +50,7 @@ type ActionDialogState =
   | { kind: "shadow"; user: AdminUser }
   | { kind: "verify"; user: AdminUser }
   | { kind: "handle"; user: AdminUser }
+  | { kind: "delete"; user: AdminUser }
   | null
 
 function AdminUsers() {
@@ -302,6 +303,16 @@ function AdminUsers() {
                   Handle
                 </Button>
               )}
+              {me?.role === "owner" && !u.deletedAt && (
+                <Button
+                  size="sm"
+                  variant="destructive"
+                  disabled={busyId === u.id || u.id === me.id}
+                  onClick={() => setDialog({ kind: "delete", user: u })}
+                >
+                  Delete
+                </Button>
+              )}
             </div>
           )
         },
@@ -399,6 +410,7 @@ function ActionDialog({
   const [reason, setReason] = useState("")
   const [hours, setHours] = useState("")
   const [handle, setHandle] = useState("")
+  const [confirm, setConfirm] = useState("")
   const [submitError, setSubmitError] = useState<string | null>(null)
   const [busy, setBusy] = useState(false)
 
@@ -407,6 +419,7 @@ function ActionDialog({
       setReason("")
       setHours("")
       setHandle(state.kind === "handle" ? (state.user.handle ?? "") : "")
+      setConfirm("")
       setSubmitError(null)
       setBusy(false)
     }
@@ -422,6 +435,7 @@ function ActionDialog({
 
   const u = state.user
   const subject = `@${u.handle ?? u.email}`
+  const deleteConfirmText = u.handle ?? u.email
 
   const config = {
     ban: {
@@ -479,6 +493,16 @@ function ActionDialog({
           handle: handle.trim(),
           reason: reason.trim() || undefined,
         }),
+    },
+    delete: {
+      title: `Delete account ${subject}`,
+      description:
+        "Soft-deletes the account: removes them from feeds, profiles, and search, and signs them out everywhere. Reversible from the database.",
+      submitLabel: "Delete account",
+      submitVariant: "destructive" as const,
+      showDuration: false,
+      run: () =>
+        api.adminDeleteUser(u.id, { reason: reason.trim() || undefined }),
     },
   }[state.kind]
 
@@ -538,6 +562,21 @@ function ActionDialog({
               />
             </label>
           )}
+          {state.kind === "delete" && (
+            <label className="flex flex-col gap-1 text-xs">
+              <span className="text-muted-foreground">
+                Type <code className="rounded bg-muted px-1">{deleteConfirmText}</code> to confirm
+              </span>
+              <Input
+                value={confirm}
+                onChange={(e) => setConfirm(e.target.value)}
+                placeholder={deleteConfirmText}
+                autoCapitalize="none"
+                autoCorrect="off"
+                spellCheck={false}
+              />
+            </label>
+          )}
           {submitError && (
             <p className="text-xs text-destructive">{submitError}</p>
           )}
@@ -550,7 +589,7 @@ function ActionDialog({
             size="sm"
             variant={config.submitVariant}
             onClick={submit}
-            disabled={busy}
+            disabled={busy || (state.kind === "delete" && confirm !== deleteConfirmText)}
           >
             {busy ? "Working…" : config.submitLabel}
           </Button>

--- a/packages/auth/src/server.ts
+++ b/packages/auth/src/server.ts
@@ -40,7 +40,12 @@ export function createAuth(config: AuthConfig) {
     session: {
       expiresIn: 60 * 60 * 24 * 30, // 30 days
       updateAge: 60 * 60 * 24, // 1 day
-      cookieCache: { enabled: true, maxAge: 60 * 5 },
+      // Short TTL so admin actions that revoke a session (ban, delete, etc. — all of which
+      // wipe the row from `sessions`) take effect within ~30s instead of waiting up to the
+      // cache window. Better-auth caches the session in a signed cookie alongside the
+      // session token, and the cache cookie remains valid until it expires regardless of
+      // DB state, so this window is the worst-case lag for forced logout.
+      cookieCache: { enabled: true, maxAge: 30 },
     },
     advanced: {
       // Our auth tables use uuid PKs with defaultRandom() in Postgres.


### PR DESCRIPTION
Adds an owner-only endpoint and admin-panel dialog for reassigning a
user's handle, useful for reclaiming squatted handles or resolving
impersonation reports. Validates against the same handle schema and
reserved list as user-facing claim, checks for conflicts, and records
the change in moderation_actions for audit.