### PR TITLE
Refactor feed virtualization to support window and container scroll

### DIFF
--- a/apps/web/src/components/feed.tsx
+++ b/apps/web/src/components/feed.tsx
@@ -1,6 +1,9 @@
-import { useEffect, useMemo, useRef, useState } from "react"
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react"
 import { useInfiniteQuery, useQueryClient } from "@tanstack/react-query"
-import { useVirtualizer } from "@tanstack/react-virtual"
+import {
+  useVirtualizer,
+  useWindowVirtualizer,
+} from "@tanstack/react-virtual"
 import { SkeletonPostCard } from "@workspace/ui/components/skeleton"
 import { PostCard } from "./post-card"
 import type { InfiniteData } from "@tanstack/react-query"
@@ -13,17 +16,32 @@ interface FeedLoaderPage {
   nextCursor: string | null
 }
 
-// Walk up the DOM to find the nearest ancestor that scrolls. Falls back to
-// document.scrollingElement for the page-level scroll case.
+// Walk up the DOM to find the nearest ancestor that scrolls. Returns null when
+// the page itself is the scroll container (the common case on mobile and on
+// routes that don't pin the feed column).
 function findScrollParent(el: HTMLElement | null): HTMLElement | null {
   let node: HTMLElement | null = el?.parentElement ?? null
   while (node) {
     const style = getComputedStyle(node)
-    if (/(auto|scroll|overlay)/.test(style.overflowY)) return node
+    const overflowY = style.overflowY || style.overflow
+    if (/(auto|scroll|overlay)/.test(overflowY)) {
+      // documentElement / body show up here with `overflow: visible` already
+      // filtered out, but guard anyway so we treat them as window scroll.
+      if (node === document.documentElement || node === document.body) {
+        return null
+      }
+      return node
+    }
     node = node.parentElement
   }
-  return (document.scrollingElement as HTMLElement | null) ?? document.documentElement
+  return null
 }
+
+// useSSR-safe layout effect: skip on the server to avoid the React warning.
+const useIsoLayoutEffect =
+  typeof window === "undefined" ? useEffect : useLayoutEffect
+
+const ESTIMATED_POST_HEIGHT = 280
 
 export function Feed({
   queryKey,
@@ -130,44 +148,6 @@ export function Feed({
     )
   }
 
-  const wrapperRef = useRef<HTMLDivElement>(null)
-  const sentinelRef = useRef<HTMLDivElement>(null)
-  const [scrollEl, setScrollEl] = useState<HTMLElement | null>(null)
-
-  useEffect(() => {
-    setScrollEl(findScrollParent(wrapperRef.current))
-  }, [])
-
-  const virtualizer = useVirtualizer({
-    count: posts.length,
-    getScrollElement: () => scrollEl,
-    estimateSize: () => 220,
-    overscan: 6,
-  })
-
-  // Auto-load the next page when the bottom sentinel approaches the viewport.
-  useEffect(() => {
-    const node = sentinelRef.current
-    if (!node || !hasNextPage) return
-    // IntersectionObserver only accepts an Element (not document.scrollingElement)
-    // as `root`; null falls back to the viewport, which is what we want for
-    // page-level scrolling.
-    const root =
-      scrollEl && scrollEl !== document.scrollingElement && scrollEl !== document.documentElement
-        ? scrollEl
-        : null
-    const observer = new IntersectionObserver(
-      (entries) => {
-        if (entries.some((e) => e.isIntersecting) && !isFetchingNextPage) {
-          fetchNextPage()
-        }
-      },
-      { root, rootMargin: "600px 0px" }
-    )
-    observer.observe(node)
-    return () => observer.disconnect()
-  }, [hasNextPage, isFetchingNextPage, fetchNextPage, scrollEl])
-
   if (isPending)
     return (
       <div>
@@ -187,6 +167,110 @@ export function Feed({
       </div>
     )
 
+  const renderRow = (post: Post) => {
+    const banner = renderActivityBanner?.(post)
+    return (
+      <>
+        {banner && (
+          <div className="border-b border-border/50 px-4 pt-2">{banner}</div>
+        )}
+        <PostCard
+          post={post}
+          onChange={replace}
+          onRemove={remove}
+          onOpenThread={onOpenThread}
+          active={
+            activePostId === post.id || activePostId === post.repostOf?.id
+          }
+        />
+      </>
+    )
+  }
+
+  return (
+    <FeedList
+      posts={posts}
+      renderRow={renderRow}
+      hasNextPage={!!hasNextPage}
+      isFetchingNextPage={isFetchingNextPage}
+      fetchNextPage={fetchNextPage}
+    />
+  )
+}
+
+interface FeedListProps {
+  posts: Array<Post>
+  renderRow: (post: Post) => React.ReactNode
+  hasNextPage: boolean
+  isFetchingNextPage: boolean
+  fetchNextPage: () => void
+}
+
+function FeedList(props: FeedListProps) {
+  const probeRef = useRef<HTMLDivElement>(null)
+  // null = window scroll, HTMLElement = contained scroll, undefined = unresolved
+  const [scrollEl, setScrollEl] = useState<HTMLElement | null | undefined>(
+    undefined
+  )
+
+  useIsoLayoutEffect(() => {
+    setScrollEl(findScrollParent(probeRef.current))
+  }, [])
+
+  // First paint (and SSR): render non-virtualized so the page isn't blank
+  // while the scroll container is being detected. This block also doubles as
+  // the no-JS / SSR fallback.
+  if (scrollEl === undefined) {
+    return (
+      <div ref={probeRef}>
+        {props.posts.map((post) => (
+          <div key={post.id}>{props.renderRow(post)}</div>
+        ))}
+        {props.hasNextPage && (
+          <div className="flex justify-center py-4 text-xs text-muted-foreground">
+            {props.isFetchingNextPage ? "loading…" : ""}
+          </div>
+        )}
+      </div>
+    )
+  }
+
+  if (scrollEl === null) {
+    return <WindowFeedList {...props} />
+  }
+  return <ContainerFeedList {...props} scrollEl={scrollEl} />
+}
+
+function WindowFeedList({
+  posts,
+  renderRow,
+  hasNextPage,
+  isFetchingNextPage,
+  fetchNextPage,
+}: FeedListProps) {
+  const wrapperRef = useRef<HTMLDivElement>(null)
+  const sentinelRef = useRef<HTMLDivElement>(null)
+  const [scrollMargin, setScrollMargin] = useState(0)
+
+  useIsoLayoutEffect(() => {
+    const node = wrapperRef.current
+    if (!node) return
+    // Distance from top of document to top of the list. Items are positioned
+    // relative to the list, so we offset by this amount.
+    const rect = node.getBoundingClientRect()
+    setScrollMargin(rect.top + window.scrollY)
+  }, [])
+
+  const virtualizer = useWindowVirtualizer({
+    count: posts.length,
+    estimateSize: () => ESTIMATED_POST_HEIGHT,
+    overscan: 6,
+    scrollMargin,
+    getItemKey: (i) => posts[i].id,
+  })
+
+  useInfiniteScroll(sentinelRef, null, hasNextPage, isFetchingNextPage, fetchNextPage)
+
   const virtualItems = virtualizer.getVirtualItems()
   const totalSize = virtualizer.getTotalSize()
 
@@ -195,70 +279,30 @@ export function Feed({
       <div
         ref={wrapperRef}
         style={{
-          height: scrollEl ? totalSize : undefined,
+          height: Math.max(0, totalSize - scrollMargin),
           position: "relative",
           width: "100%",
         }}
       >
-        {scrollEl
-          ? virtualItems.map((virtualItem) => {
-              const post = posts[virtualItem.index]
-              const banner = renderActivityBanner?.(post)
-              return (
-                <div
-                  key={post.id}
-                  ref={virtualizer.measureElement}
-                  data-index={virtualItem.index}
-                  style={{
-                    position: "absolute",
-                    top: 0,
-                    left: 0,
-                    width: "100%",
-                    transform: `translateY(${virtualItem.start}px)`,
-                  }}
-                >
-                  {banner && (
-                    <div className="border-b border-border/50 px-4 pt-2">
-                      {banner}
-                    </div>
-                  )}
-                  <PostCard
-                    post={post}
-                    onChange={replace}
-                    onRemove={remove}
-                    onOpenThread={onOpenThread}
-                    active={
-                      activePostId === post.id ||
-                      activePostId === post.repostOf?.id
-                    }
-                  />
-                </div>
-              )
-            })
-          : // Fallback render (used for the first paint before we resolve the
-            // scroll parent) so SSR/initial HTML still shows posts.
-            posts.map((post) => {
-              const banner = renderActivityBanner?.(post)
-              return (
-                <div key={post.id}>
-                  {banner && (
-                    <div className="border-b border-border/50 px-4 pt-2">
-                      {banner}
-                    </div>
-                  )}
-                  <PostCard
-                    post={post}
-                    onChange={replace}
-                    onRemove={remove}
-                    onOpenThread={onOpenThread}
-                    active={
-                      activePostId === post.id ||
-                      activePostId === post.repostOf?.id
-                    }
-                  />
-                </div>
-              )
-            })}
+        {virtualItems.map((vi) => {
+          const post = posts[vi.index]
+          return (
+            <div
+              key={vi.key}
+              ref={virtualizer.measureElement}
+              data-index={vi.index}
+              style={{
+                position: "absolute",
+                top: 0,
+                left: 0,
+                width: "100%",
+                transform: `translateY(${vi.start - scrollMargin}px)`,
+              }}
+            >
+              {renderRow(post)}
+            </div>
+          )
+        })}
       </div>
       <div ref={sentinelRef} aria-hidden className="h-px" />
       {hasNextPage && (
@@ -268,4 +312,101 @@ export function Feed({
       )}
     </div>
   )
+}
+
+function ContainerFeedList({
+  posts,
+  renderRow,
+  hasNextPage,
+  isFetchingNextPage,
+  fetchNextPage,
+  scrollEl,
+}: FeedListProps & { scrollEl: HTMLElement }) {
+  const wrapperRef = useRef<HTMLDivElement>(null)
+  const sentinelRef = useRef<HTMLDivElement>(null)
+
+  const virtualizer = useVirtualizer({
+    count: posts.length,
+    getScrollElement: () => scrollEl,
+    estimateSize: () => ESTIMATED_POST_HEIGHT,
+    overscan: 6,
+    getItemKey: (i) => posts[i].id,
+  })
+
+  useInfiniteScroll(
+    sentinelRef,
+    scrollEl,
+    hasNextPage,
+    isFetchingNextPage,
+    fetchNextPage
+  )
+
+  const virtualItems = virtualizer.getVirtualItems()
+  const totalSize = virtualizer.getTotalSize()
+
+  return (
+    <div>
+      <div
+        ref={wrapperRef}
+        style={{ height: totalSize, position: "relative", width: "100%" }}
+      >
+        {virtualItems.map((vi) => {
+          const post = posts[vi.index]
+          return (
+            <div
+              key={vi.key}
+              ref={virtualizer.measureElement}
+              data-index={vi.index}
+              style={{
+                position: "absolute",
+                top: 0,
+                left: 0,
+                width: "100%",
+                transform: `translateY(${vi.start}px)`,
+              }}
+            >
+              {renderRow(post)}
+            </div>
+          )
+        })}
+      </div>
+      <div ref={sentinelRef} aria-hidden className="h-px" />
+      {hasNextPage && (
+        <div className="flex justify-center py-4 text-xs text-muted-foreground">
+          {isFetchingNextPage ? "loading…" : ""}
+        </div>
+      )}
+    </div>
+  )
+}
+
+// Auto-load the next page when the bottom sentinel approaches the viewport.
+function useInfiniteScroll(
+  sentinelRef: React.RefObject<HTMLDivElement | null>,
+  root: HTMLElement | null,
+  hasNextPage: boolean,
+  isFetchingNextPage: boolean,
+  fetchNextPage: () => void
+) {
+  // Latest-callback ref so the observer effect doesn't re-create on every
+  // render (which would briefly disconnect/re-observe and miss intersections).
+  const fetchRef = useRef(fetchNextPage)
+  fetchRef.current = fetchNextPage
+  const fetchingRef = useRef(isFetchingNextPage)
+  fetchingRef.current = isFetchingNextPage
+
+  useEffect(() => {
+    const node = sentinelRef.current
+    if (!node || !hasNextPage) return
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries.some((e) => e.isIntersecting) && !fetchingRef.current) {
+          fetchRef.current()
+        }
+      },
+      { root, rootMargin: "600px 0px" }
+    )
+    observer.observe(node)
+    return () => observer.disconnect()
+  }, [hasNextPage, root, sentinelRef])
 }


### PR DESCRIPTION
## Summary

- Split feed virtualization logic into separate `WindowFeedList` and `ContainerFeedList` components to properly handle both window-level and container-level scrolling scenarios
- Replaced `useVirtualizer` with `useWindowVirtualizer` for window scroll cases, which correctly handles scroll margin calculations
- Improved scroll parent detection to distinguish between window scroll (returns `null`) and contained scroll (returns the scroll element), with better handling of `documentElement` and `body`
- Extracted infinite scroll logic into a reusable `useInfiniteScroll` hook with ref-based callbacks to avoid observer recreation
- Added SSR-safe layout effect (`useIsoLayoutEffect`) to prevent React warnings on the server
- Improved initial render by showing non-virtualized content until the scroll container is detected, ensuring the page isn't blank during hydration

## Test plan

- [ ] `bun run typecheck` passes
- [ ] Manually tested feed scrolling on routes with window-level scroll (mobile, non-pinned layouts)
- [ ] Manually tested feed scrolling on routes with container-level scroll (pinned feed column)
- [ ] Verified infinite scroll pagination triggers correctly in both scenarios
- [ ] No new console errors or warnings

## Notes

The refactor maintains backward compatibility while fixing virtualization behavior for different scroll container scenarios. The split into two specialized components allows each to use the appropriate virtualizer API (`useWindowVirtualizer` vs `useVirtualizer`) with correct scroll margin handling.

https://claude.ai/code/session_019vtRDYNXzichQEYv7MzCPE