### PR TITLE
Implement infinite scroll for admin users and reports tables

### DIFF
--- a/apps/web/src/lib/use-infinite-scroll-sentinel.ts
+++ b/apps/web/src/lib/use-infinite-scroll-sentinel.ts
@@ -1,0 +1,31 @@
+import { useEffect, useRef } from "react"
+import type { RefObject } from "react"
+
+export function useInfiniteScrollSentinel(
+  sentinelRef: RefObject<HTMLDivElement | null>,
+  hasNext: boolean,
+  loading: boolean,
+  loadMore: () => void,
+  options: { root?: Element | null; rootMargin?: string } = {}
+) {
+  const { root = null, rootMargin = "600px 0px" } = options
+  const loadMoreRef = useRef(loadMore)
+  loadMoreRef.current = loadMore
+  const loadingRef = useRef(loading)
+  loadingRef.current = loading
+
+  useEffect(() => {
+    const node = sentinelRef.current
+    if (!node || !hasNext) return
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries.some((e) => e.isIntersecting) && !loadingRef.current) {
+          loadMoreRef.current()
+        }
+      },
+      { root, rootMargin }
+    )
+    observer.observe(node)
+    return () => observer.disconnect()
+  }, [hasNext, sentinelRef, root, rootMargin])
+}

--- a/apps/web/src/routes/admin.reports.tsx
+++ b/apps/web/src/routes/admin.reports.tsx
@@ -1,5 +1,5 @@
 import { Link, createFileRoute } from "@tanstack/react-router"
-import { useCallback, useEffect, useMemo, useState } from "react"
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import {
   flexRender,
   getCoreRowModel,
@@ -23,6 +23,7 @@ import {
   TableRow,
 } from "@workspace/ui/components/table"
 import { api } from "../lib/api"
+import { useInfiniteScrollSentinel } from "../lib/use-infinite-scroll-sentinel"
 import { Avatar } from "../components/avatar"
 import type { ColumnDef } from "@tanstack/react-table"
 import type {
@@ -49,16 +50,23 @@ function AdminReports() {
   const [reports, setReports] = useState<Array<AdminReport>>([])
   const [cursor, setCursor] = useState<string | null>(null)
   const [loading, setLoading] = useState(true)
+  const [loadingMore, setLoadingMore] = useState(false)
   const [selectedId, setSelectedId] = useState<string | null>(null)
+  // Bumped on every fresh load so in-flight loadMore results from a prior
+  // status change are discarded instead of getting appended to the new list.
+  const generationRef = useRef(0)
+  const sentinelRef = useRef<HTMLDivElement | null>(null)
 
   const load = useCallback(async (s: ReportStatus) => {
+    const gen = ++generationRef.current
     setLoading(true)
     try {
       const res = await api.adminReports(s)
+      if (generationRef.current !== gen) return
       setReports(res.reports)
       setCursor(res.nextCursor)
     } finally {
-      setLoading(false)
+      if (generationRef.current === gen) setLoading(false)
     }
   }, [])
 
@@ -66,12 +74,21 @@ function AdminReports() {
     load(status)
   }, [status, load])
 
-  async function loadMore() {
-    if (!cursor) return
-    const res = await api.adminReports(status, cursor)
-    setReports((prev) => [...prev, ...res.reports])
-    setCursor(res.nextCursor)
-  }
+  const loadMore = useCallback(async () => {
+    if (!cursor || loadingMore) return
+    const gen = generationRef.current
+    setLoadingMore(true)
+    try {
+      const res = await api.adminReports(status, cursor)
+      if (generationRef.current !== gen) return
+      setReports((prev) => [...prev, ...res.reports])
+      setCursor(res.nextCursor)
+    } finally {
+      setLoadingMore(false)
+    }
+  }, [cursor, loadingMore, status])
+
+  useInfiniteScrollSentinel(sentinelRef, !!cursor, loadingMore, loadMore)
 
   const columns = useMemo<Array<ColumnDef<AdminReport>>>(
     () => [
@@ -208,11 +225,10 @@ function AdminReports() {
           </TableBody>
         </Table>
       )}
+      <div ref={sentinelRef} aria-hidden className="h-px" />
       {cursor && (
-        <div className="flex justify-center py-3">
-          <Button variant="ghost" size="sm" onClick={loadMore}>
-            load more
-          </Button>
+        <div className="flex justify-center py-3 text-xs text-muted-foreground">
+          {loadingMore ? "loading…" : ""}
         </div>
       )}
       <ReportSheet

--- a/apps/web/src/routes/admin.users.tsx
+++ b/apps/web/src/routes/admin.users.tsx
@@ -35,6 +35,7 @@ import {
 } from "@workspace/ui/components/table"
 import { IconChevronDown } from "@tabler/icons-react"
 import { api } from "../lib/api"
+import { useInfiniteScrollSentinel } from "../lib/use-infinite-scroll-sentinel"
 import { useMe } from "../lib/me"
 import { Avatar } from "../components/avatar"
 import { VerifiedBadge } from "../components/verified-badge"
@@ -60,21 +61,29 @@ function AdminUsers() {
   const [users, setUsers] = useState<Array<AdminUser>>([])
   const [cursor, setCursor] = useState<string | null>(null)
   const [loading, setLoading] = useState(true)
+  const [loadingMore, setLoadingMore] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [busyId, setBusyId] = useState<string | null>(null)
   const [dialog, setDialog] = useState<ActionDialogState>(null)
+  // Bumped on every fresh load so in-flight loadMore results from a prior
+  // search/refresh are discarded instead of getting appended to the new list.
+  const generationRef = useRef(0)
+  const sentinelRef = useRef<HTMLDivElement | null>(null)
 
   const load = useCallback(async (search: string) => {
+    const gen = ++generationRef.current
     setLoading(true)
     setError(null)
     try {
       const res = await api.adminUsers(search || undefined)
+      if (generationRef.current !== gen) return
       setUsers(res.users)
       setCursor(res.nextCursor)
     } catch (e) {
+      if (generationRef.current !== gen) return
       setError(e instanceof Error ? e.message : "failed")
     } finally {
-      setLoading(false)
+      if (generationRef.current === gen) setLoading(false)
     }
   }, [])
 
@@ -83,12 +92,20 @@ function AdminUsers() {
     return () => clearTimeout(t)
   }, [q, load])
 
-  async function loadMore() {
-    if (!cursor) return
-    const res = await api.adminUsers(q || undefined, cursor)
-    setUsers((prev) => [...prev, ...res.users])
-    setCursor(res.nextCursor)
-  }
+  const loadMore = useCallback(async () => {
+    if (!cursor || loadingMore) return
+    const gen = generationRef.current
+    setLoadingMore(true)
+    try {
+      const res = await api.adminUsers(q || undefined, cursor)
+      if (generationRef.current !== gen) return
+      setUsers((prev) => [...prev, ...res.users])
+      setCursor(res.nextCursor)
+    } finally {
+      setLoadingMore(false)
+    }
+  }, [cursor, loadingMore, q])
+
 
   const act = useCallback(
     async (userId: string, op: () => Promise<unknown>) => {
@@ -329,11 +346,11 @@ function AdminUsers() {
   })
 
   const rows = table.getRowModel().rows
-  const tableContainerRef = useRef<HTMLDivElement>(null)
+  const [scrollRoot, setScrollRoot] = useState<HTMLDivElement | null>(null)
   const rowVirtualizer = useVirtualizer({
     count: rows.length,
     estimateSize: () => 64,
-    getScrollElement: () => tableContainerRef.current,
+    getScrollElement: () => scrollRoot,
     overscan: 8,
   })
   const virtualRows = rowVirtualizer.getVirtualItems()
@@ -343,6 +360,10 @@ function AdminUsers() {
     virtualRows.length > 0
       ? totalSize - virtualRows[virtualRows.length - 1].end
       : 0
+
+  useInfiniteScrollSentinel(sentinelRef, !!cursor, loadingMore, loadMore, {
+    root: scrollRoot,
+  })
 
   return (
     <main className="flex h-[calc(100dvh-5rem)] flex-col">
@@ -359,7 +380,7 @@ function AdminUsers() {
       )}
       {users.length > 0 && (
         <div
-          ref={tableContainerRef}
+          ref={setScrollRoot}
           className="flex-1 overflow-auto"
         >
           <Table>
@@ -416,13 +437,12 @@ function AdminUsers() {
               )}
             </TableBody>
           </Table>
-        </div>
-      )}
-      {cursor && (
-        <div className="shrink-0 border-t border-border flex justify-center py-3">
-          <Button variant="ghost" size="sm" onClick={loadMore}>
-            load more
-          </Button>
+          <div ref={sentinelRef} aria-hidden className="h-px" />
+          {cursor && (
+            <div className="flex justify-center py-3 text-xs text-muted-foreground">
+              {loadingMore ? "loading…" : ""}
+            </div>
+          )}
         </div>
       )}
       <ActionDialog


### PR DESCRIPTION
## Summary

- Replaced manual "load more" buttons with automatic infinite scroll pagination using Intersection Observer API
- Added `useInfiniteScrollSentinel` hook to detect when user scrolls near the end of the list and automatically load more items
- Added generation tracking to prevent stale requests from being appended when search/status filters change
- Applied changes to both admin users and admin reports pages for consistency

## Test plan

- [ ] `bun run typecheck` passes
- [ ] Manually scrolled through admin users and reports tables to verify infinite scroll triggers automatically
- [ ] Verified that changing search/status filters cancels in-flight requests and resets the list
- [ ] No new console errors / network errors

## Notes

The `useInfiniteScrollSentinel` hook uses a 600px bottom margin to trigger loading before the user reaches the absolute end of the list, providing a smoother experience. The generation ref pattern ensures that when filters change, any pending requests from the previous filter state are discarded rather than appended to the new results.

https://claude.ai/code/session_01EWEJPBbgheTV5hUYyx7VFs