### PR TITLE
Fix infinite scroll in admin reports with scrollable container

### DIFF
--- a/apps/web/src/lib/use-infinite-scroll-sentinel.ts
+++ b/apps/web/src/lib/use-infinite-scroll-sentinel.ts
@@ -11,21 +11,23 @@ export function useInfiniteScrollSentinel(
   const { root = null, rootMargin = "600px 0px" } = options
   const loadMoreRef = useRef(loadMore)
   loadMoreRef.current = loadMore
-  const loadingRef = useRef(loading)
-  loadingRef.current = loading
 
   useEffect(() => {
     const node = sentinelRef.current
-    if (!node || !hasNext) return
+    // Tear the observer down while a load is in flight and re-create it when
+    // loading flips back to false. Re-observing fires the initial intersection
+    // callback again, which is what keeps loading more pages when the new
+    // content is still short enough that the sentinel never left the viewport
+    // — a plain observer wouldn't re-fire because the intersection state
+    // didn't change between pages.
+    if (!node || !hasNext || loading) return
     const observer = new IntersectionObserver(
       (entries) => {
-        if (entries.some((e) => e.isIntersecting) && !loadingRef.current) {
-          loadMoreRef.current()
-        }
+        if (entries.some((e) => e.isIntersecting)) loadMoreRef.current()
       },
       { root, rootMargin }
     )
     observer.observe(node)
     return () => observer.disconnect()
-  }, [hasNext, sentinelRef, root, rootMargin])
+  }, [hasNext, loading, sentinelRef, root, rootMargin])
 }

--- a/apps/web/src/routes/admin.reports.tsx
+++ b/apps/web/src/routes/admin.reports.tsx
@@ -56,6 +56,7 @@ function AdminReports() {
   // status change are discarded instead of getting appended to the new list.
   const generationRef = useRef(0)
   const sentinelRef = useRef<HTMLDivElement | null>(null)
+  const [scrollRoot, setScrollRoot] = useState<HTMLDivElement | null>(null)
 
   const load = useCallback(async (s: ReportStatus) => {
     const gen = ++generationRef.current
@@ -88,7 +89,9 @@ function AdminReports() {
     }
   }, [cursor, loadingMore, status])
 
-  useInfiniteScrollSentinel(sentinelRef, !!cursor, loadingMore, loadMore)
+  useInfiniteScrollSentinel(sentinelRef, !!cursor, loadingMore, loadMore, {
+    root: scrollRoot,
+  })
 
   const columns = useMemo<Array<ColumnDef<AdminReport>>>(
     () => [
@@ -163,8 +166,8 @@ function AdminReports() {
   })
 
   return (
-    <main>
-      <div className="flex gap-2 border-b border-border px-4 py-3 text-sm">
+    <main className="flex min-h-0 flex-1 flex-col">
+      <div className="flex shrink-0 gap-2 border-b border-border px-4 py-3 text-sm">
         {STATUSES.map((s) => (
           <button
             key={s}
@@ -179,58 +182,66 @@ function AdminReports() {
           </button>
         ))}
       </div>
-      {loading && reports.length === 0 && (
-        <p className="p-4 text-sm text-muted-foreground">loading…</p>
-      )}
-      {!loading && reports.length === 0 && (
-        <p className="p-4 text-sm text-muted-foreground">
-          No {status} reports.
-        </p>
-      )}
-      {reports.length > 0 && (
-        <Table>
-          <TableHeader>
-            {table.getHeaderGroups().map((hg) => (
-              <TableRow key={hg.id}>
-                {hg.headers.map((header) => (
-                  <TableHead key={header.id}>
-                    {header.isPlaceholder
-                      ? null
-                      : flexRender(
-                          header.column.columnDef.header,
-                          header.getContext()
-                        )}
-                  </TableHead>
-                ))}
-              </TableRow>
-            ))}
-          </TableHeader>
-          <TableBody>
-            {table.getRowModel().rows.map((row) => (
-              <TableRow
-                key={row.id}
-                data-state={
-                  row.original.id === selectedId ? "selected" : undefined
-                }
-                onClick={() => setSelectedId(row.original.id)}
-                className="cursor-pointer"
-              >
-                {row.getVisibleCells().map((cell) => (
-                  <TableCell key={cell.id}>
-                    {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                  </TableCell>
-                ))}
-              </TableRow>
-            ))}
-          </TableBody>
-        </Table>
-      )}
-      <div ref={sentinelRef} aria-hidden className="h-px" />
-      {cursor && (
-        <div className="flex justify-center py-3 text-xs text-muted-foreground">
-          {loadingMore ? "loading…" : ""}
-        </div>
-      )}
+      <div
+        ref={setScrollRoot}
+        className="flex-1 overflow-auto overscroll-contain"
+      >
+        {loading && reports.length === 0 && (
+          <p className="p-4 text-sm text-muted-foreground">loading…</p>
+        )}
+        {!loading && reports.length === 0 && (
+          <p className="p-4 text-sm text-muted-foreground">
+            No {status} reports.
+          </p>
+        )}
+        {reports.length > 0 && (
+          <Table>
+            <TableHeader className="sticky top-0 z-10 bg-background">
+              {table.getHeaderGroups().map((hg) => (
+                <TableRow key={hg.id}>
+                  {hg.headers.map((header) => (
+                    <TableHead key={header.id}>
+                      {header.isPlaceholder
+                        ? null
+                        : flexRender(
+                            header.column.columnDef.header,
+                            header.getContext()
+                          )}
+                    </TableHead>
+                  ))}
+                </TableRow>
+              ))}
+            </TableHeader>
+            <TableBody>
+              {table.getRowModel().rows.map((row) => (
+                <TableRow
+                  key={row.id}
+                  data-state={
+                    row.original.id === selectedId ? "selected" : undefined
+                  }
+                  onClick={() => setSelectedId(row.original.id)}
+                  className="cursor-pointer"
+                >
+                  {row.getVisibleCells().map((cell) => (
+                    <TableCell key={cell.id}>
+                      {flexRender(
+                        cell.column.columnDef.cell,
+                        cell.getContext()
+                      )}
+                    </TableCell>
+                  ))}
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        )}
+        <div ref={sentinelRef} aria-hidden className="h-px" />
+        {cursor && (
+          <div className="flex justify-center py-3 text-xs text-muted-foreground">
+            {loadingMore ? "loading…" : ""}
+          </div>
+        )}
+      </div>
       <ReportSheet
         reportId={selectedId}
         onClose={() => setSelectedId(null)}

--- a/apps/web/src/routes/admin.tsx
+++ b/apps/web/src/routes/admin.tsx
@@ -31,8 +31,8 @@ function AdminLayout() {
   }
 
   return (
-    <div className="mx-auto w-full max-w-7xl border-x border-b">
-      <header className="sticky top-0 z-10 border-b border-border bg-background/80 px-4 py-3 backdrop-blur-sm">
+    <div className="mx-auto flex h-[calc(100svh-3rem)] w-full max-w-7xl flex-col overflow-hidden border-x border-b">
+      <header className="shrink-0 border-b border-border bg-background/80 px-4 py-3 backdrop-blur-sm">
         <div className="flex items-baseline justify-between">
           <h1 className="text-base font-semibold">Admin</h1>
           <span className="text-xs tracking-wider text-muted-foreground uppercase">

--- a/apps/web/src/routes/admin.users.tsx
+++ b/apps/web/src/routes/admin.users.tsx
@@ -366,7 +366,7 @@ function AdminUsers() {
   })
 
   return (
-    <main className="flex h-[calc(100dvh-5rem)] flex-col">
+    <main className="flex min-h-0 flex-1 flex-col">
       <div className="shrink-0 border-b border-border p-4">
         <Input
           value={q}
@@ -381,7 +381,7 @@ function AdminUsers() {
       {users.length > 0 && (
         <div
           ref={setScrollRoot}
-          className="flex-1 overflow-auto"
+          className="flex-1 overflow-auto overscroll-contain"
         >
           <Table>
             <TableHeader className="sticky top-0 z-10 bg-background">


### PR DESCRIPTION
## Summary

- Refactored admin reports layout to use a scrollable container with proper flex constraints, fixing infinite scroll behavior
- Updated `useInfiniteScrollSentinel` to accept a custom scroll root and improved loading state handling
- Made table headers sticky within the scrollable area and applied consistent layout patterns across admin pages

## Test plan

- [ ] `bun run typecheck` passes
- [ ] Manually exercised infinite scroll in admin reports page - verify loading more reports works when scrolling to bottom
- [ ] Verify table headers remain visible when scrolling through reports
- [ ] No new console errors / network errors

## Notes

The key fix is wrapping the reports table in a scrollable container (`overflow-auto`) with proper flex layout constraints (`flex-1 min-h-0`). This ensures the IntersectionObserver correctly detects when the sentinel element enters the viewport. The `useInfiniteScrollSentinel` hook was also improved to tear down and recreate the observer while loading is in flight, which re-fires the intersection callback when new content is added—this handles the case where the sentinel never leaves the viewport between page loads.

https://claude.ai/code/session_01YWHMVA7FkSHC9hUeMiWVgX