### PR TITLE
Refactor user stats queries to use gte operator

### DIFF
--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -1,6 +1,6 @@
 import { Hono, type Context } from 'hono'
 import { z } from 'zod'
-import { and, desc, eq, ilike, or, sql } from '@workspace/db'
+import { and, desc, eq, gte, ilike, or, sql } from '@workspace/db'
 import { schema } from '@workspace/db'
 import { assetUrl } from '@workspace/media/s3'
 import { handleSchema } from '@workspace/validators'
@@ -30,8 +30,8 @@ adminRoute.get('/stats', async (c) => {
       deleted: sql<number>`count(*) filter (where ${schema.users.deletedAt} is not null)::int`,
       verified: sql<number>`count(*) filter (where ${schema.users.isVerified} = true)::int`,
       admins: sql<number>`count(*) filter (where ${schema.users.role} in ('admin','owner'))::int`,
-      newToday: sql<number>`count(*) filter (where ${schema.users.createdAt} >= ${dayAgo})::int`,
-      newThisWeek: sql<number>`count(*) filter (where ${schema.users.createdAt} >= ${weekAgo})::int`,
+      newToday: sql<number>`count(*) filter (where ${gte(schema.users.createdAt, dayAgo)})::int`,
+      newThisWeek: sql<number>`count(*) filter (where ${gte(schema.users.createdAt, weekAgo)})::int`,
     })
     .from(schema.users)
 


### PR DESCRIPTION
## Summary

- Replaced inline SQL comparison operators (`>=`) with the `gte` operator from the database library in user stats queries
- Updated imports to include the `gte` operator
- Improves consistency with the codebase's query builder patterns for date comparisons

## Test plan

- [x] `bun run typecheck` passes
- [x] Existing stats endpoint tests cover this functionality

## Notes

This is a refactoring change that makes the date comparison queries more consistent with the codebase's use of the query builder API rather than raw SQL operators.

https://claude.ai/code/session_012V9BmYB2yneMFiwEn1vusE