### PR TITLE
Fix admin users table layout with fixed column widths

### DIFF
--- a/apps/web/src/routes/admin.users.tsx
+++ b/apps/web/src/routes/admin.users.tsx
@@ -55,6 +55,15 @@ type ActionDialogState =
   | { kind: "delete"; user: AdminUser }
   | null
 
+const COLUMN_WIDTHS: Record<string, string> = {
+  user: "280px",
+  email: "240px",
+  role: "120px",
+  status: "200px",
+  actions: "340px",
+}
+const TABLE_MIN_WIDTH = "1180px"
+
 function AdminUsers() {
   const { me } = useMe()
   const [q, setQ] = useState("")
@@ -166,7 +175,7 @@ function AdminUsers() {
         id: "email",
         header: "Email",
         cell: ({ row }) => (
-          <span className="truncate text-xs text-muted-foreground">
+          <span className="block truncate text-xs text-muted-foreground">
             {row.original.email}
           </span>
         ),
@@ -384,7 +393,15 @@ function AdminUsers() {
           ref={setScrollRoot}
           className="flex-1 overflow-auto overscroll-contain"
         >
-          <Table>
+          <Table
+            className="table-fixed"
+            style={{ minWidth: TABLE_MIN_WIDTH }}
+          >
+            <colgroup>
+              {table.getVisibleLeafColumns().map((col) => (
+                <col key={col.id} style={{ width: COLUMN_WIDTHS[col.id] }} />
+              ))}
+            </colgroup>
             <TableHeader className="sticky top-0 z-10 bg-background">
               {table.getHeaderGroups().map((hg) => (
                 <TableRow key={hg.id}>


### PR DESCRIPTION
## Summary

- Added fixed column widths to the admin users table to prevent layout shifts and improve readability
- Applied `table-fixed` layout mode with explicit `<colgroup>` definitions for consistent column sizing
- Changed email cell display from `inline` to `block` to properly respect truncation with fixed widths
- Set minimum table width to ensure all columns remain visible

## Test plan

- [ ] Manually exercised the admin users table in the browser to verify column widths are consistent
- [ ] Verified email addresses truncate properly with the new `block` display
- [ ] No new console errors / network errors

## Notes

The table now uses CSS `table-layout: fixed` which distributes column widths based on the `<colgroup>` definitions rather than content, providing a more stable and predictable layout. The email cell display change from implicit `inline` to explicit `block` ensures the truncation class works correctly with the fixed width constraint.

https://claude.ai/code/session_01LgF2N8Adz8CewmrdmgJXJc