### PR TITLE
Fix Google Fonts font format parsing and add saves to OG image

### DIFF
--- a/apps/web/src/lib/og-image.tsx
+++ b/apps/web/src/lib/og-image.tsx
@@ -14,9 +14,9 @@ interface FontEntry {
 
 let fontsPromise: Promise<Array<FontEntry>> | null = null
 
-/** Google Fonts hands back TTF/OTF when called with an old-IE user-agent and woff2
- *  for modern browsers. Satori (under @vercel/og) cannot decode woff2, so we force
- *  the legacy path. The first request pays ~150ms; the result is cached per process. */
+/** Google Fonts serves woff2 to modern browsers — Satori (under @vercel/og) can't
+ *  decode that. The IE11 user-agent gets woff, which Satori 0.10+ handles. The first
+ *  request pays ~150ms; the result is cached per process. */
 async function fetchInterWeight(weight: FontWeight): Promise<ArrayBuffer> {
   const cssUrl = `https://fonts.googleapis.com/css2?family=Inter:wght@${weight}&display=swap`
   const css = await (
@@ -27,7 +27,7 @@ async function fetchInterWeight(weight: FontWeight): Promise<ArrayBuffer> {
       },
     })
   ).text()
-  const match = css.match(/src:\s*url\((https:\/\/[^)]+)\)\s*format\('(?:truetype|opentype)'\)/)
+  const match = css.match(/src:\s*url\((https:\/\/[^)]+)\)/)
   if (!match) throw new Error(`Inter ${weight}: could not parse font url from Google Fonts CSS`)
   return await (await fetch(match[1])).arrayBuffer()
 }

--- a/apps/web/src/routes/og.post.$id.tsx
+++ b/apps/web/src/routes/og.post.$id.tsx
@@ -99,6 +99,7 @@ function PostCard({ post }: { post: Post }) {
           { label: "likes", value: post.counts.likes },
           { label: "reposts", value: post.counts.reposts },
           { label: "replies", value: post.counts.replies },
+          { label: "saves", value: post.counts.bookmarks },
         ]}
       />
     </div>


### PR DESCRIPTION
## Summary

- Updated Google Fonts font format regex to handle woff format (used with IE11 user-agent) instead of truetype/opentype, since Satori 0.10+ supports woff decoding
- Added "saves" (bookmarks) metric to the OG image post card display
- Clarified comment explaining the font fetching strategy

## Test plan

- [ ] `bun run typecheck` passes
- [ ] Manually verified OG image generation works with updated font parsing
- [ ] No new console errors / network errors

## Notes

The regex change in `og-image.tsx` removes the format type matching since the actual font format returned depends on the user-agent string used in the request. The IE11 user-agent now returns woff format which Satori can handle natively.

https://claude.ai/code/session_013jHAzrr5D2WjDeLDKKvc1P