### PR TITLE
Convert admin users table column widths to percentage-based layout

### DIFF
--- a/apps/web/src/routes/admin.users.tsx
+++ b/apps/web/src/routes/admin.users.tsx
@@ -56,13 +56,12 @@ type ActionDialogState =
   | null
 
 const COLUMN_WIDTHS: Record<string, string> = {
-  user: "280px",
-  email: "240px",
-  role: "120px",
-  status: "200px",
-  actions: "340px",
+  user: "25%",
+  email: "20%",
+  role: "10%",
+  status: "17%",
+  actions: "28%",
 }
-const TABLE_MIN_WIDTH = "1180px"
 
 function AdminUsers() {
   const { me } = useMe()
@@ -393,10 +392,7 @@ function AdminUsers() {
           ref={setScrollRoot}
           className="flex-1 overflow-auto overscroll-contain"
         >
-          <Table
-            className="table-fixed"
-            style={{ minWidth: TABLE_MIN_WIDTH }}
-          >
+          <Table className="table-fixed">
             <colgroup>
               {table.getVisibleLeafColumns().map((col) => (
                 <col key={col.id} style={{ width: COLUMN_WIDTHS[col.id] }} />


### PR DESCRIPTION
## Summary

- Changed admin users table column widths from fixed pixel values to percentage-based values for responsive layout
- Removed the `TABLE_MIN_WIDTH` constant and `minWidth` style prop, allowing the table to scale naturally with its container
- Updated column width distribution: user (25%), email (20%), role (10%), status (17%), actions (28%)

## Test plan

- [ ] `bun run typecheck` passes
- [ ] Manually exercised the admin users table in the browser at various viewport widths to verify columns scale properly
- [ ] No new console errors / network errors

## Notes

This change makes the admin users table more responsive by using percentage-based widths instead of fixed pixel values. The table will now adapt to different container sizes while maintaining the intended column proportions.

https://claude.ai/code/session_01LgF2N8Adz8CewmrdmgJXJc