### PR TITLE
Transcode remote avatars to PNG for OG image generation

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -39,6 +39,7 @@
     "nitro": "latest",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
+    "sharp": "^0.33.5",
     "tailwindcss": "^4.1.18",
     "vite-tsconfig-paths": "^5.1.4",
     "zod": "^3.25.76"

--- a/apps/web/src/lib/og-image.tsx
+++ b/apps/web/src/lib/og-image.tsx
@@ -3,6 +3,15 @@ import { APP_NAME } from "./env"
 /** Standard OG card aspect — what Twitter, Facebook, Slack, Discord etc. expect. */
 export const OG_SIZE = { width: 1200, height: 630 } as const
 
+/** Cap on how long we wait for a remote avatar before giving up and rendering the
+ *  initial chip instead. Unfurlers (Twitter, Slack, ...) tend to time us out around
+ *  10s so we need plenty of headroom. */
+const OG_IMAGE_FETCH_TIMEOUT_MS = 4000
+
+/** Hard ceiling on remote image bytes we'll decode. Avatars are normally <100KB; this
+ *  is just a guard against pathological inputs ballooning memory inside satori. */
+const OG_IMAGE_MAX_BYTES = 4 * 1024 * 1024
+
 type FontWeight = 400 | 500 | 600 | 800
 
 interface FontEntry {
@@ -52,6 +61,36 @@ export async function getOgFonts(): Promise<Array<FontEntry>> {
     })
   }
   return fontsPromise
+}
+
+/** Server-side image loader for OG cards. Satori (under @vercel/og) only decodes PNG
+ *  and JPEG — any webp/avif `<img src>` blows up with "Unsupported image type". We
+ *  fetch the bytes here, transcode to PNG via sharp, and hand satori a data URL it can
+ *  paint. Returns null on any error so callers fall back to the initial chip rather
+ *  than 500ing the unfurler. */
+export async function loadOgImage(
+  src: string | null | undefined,
+): Promise<string | null> {
+  if (!src) return null
+  // Pass data URLs straight through; nothing to fetch.
+  if (src.startsWith("data:")) return src
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), OG_IMAGE_FETCH_TIMEOUT_MS)
+  try {
+    const res = await fetch(src, { redirect: "follow", signal: controller.signal })
+    if (!res.ok) return null
+    const buf = Buffer.from(await res.arrayBuffer())
+    if (buf.byteLength === 0 || buf.byteLength > OG_IMAGE_MAX_BYTES) return null
+    // Dynamic import keeps sharp out of any client bundle that might transitively pull
+    // this module in (it's a native binary; bundlers choke on it).
+    const sharp = (await import("sharp")).default
+    const png = await sharp(buf).png().toBuffer()
+    return `data:image/png;base64,${png.toString("base64")}`
+  } catch {
+    return null
+  } finally {
+    clearTimeout(timeout)
+  }
 }
 
 export const OG_HEADERS = {

--- a/apps/web/src/routes/og.article.$handle.$slug.tsx
+++ b/apps/web/src/routes/og.article.$handle.$slug.tsx
@@ -11,11 +11,20 @@ import {
   OgAvatar,
   OgFrame,
   getOgFonts,
+  loadOgImage,
   truncate,
 } from "../lib/og-image"
 import type { ArticleDto } from "../lib/api"
 
-function ArticleCard({ article, handle }: { article: ArticleDto; handle: string }) {
+function ArticleCard({
+  article,
+  handle,
+  avatarSrc,
+}: {
+  article: ArticleDto
+  handle: string
+  avatarSrc: string | null
+}) {
   const author = article.author
   const display = author.displayName || `@${author.handle ?? handle}`
   const initial = (author.displayName ?? author.handle ?? handle).slice(0, 1)
@@ -64,7 +73,7 @@ function ArticleCard({ article, handle }: { article: ArticleDto; handle: string 
           marginTop: "auto",
         }}
       >
-        <OgAvatar src={author.avatarUrl} initial={initial} size={56} />
+        <OgAvatar src={avatarSrc} initial={initial} size={56} />
         <div
           style={{
             display: "flex",
@@ -114,6 +123,7 @@ export const Route = createFileRoute("/og/article/$handle/$slug")({
         } catch {
           // Fall through to placeholder card.
         }
+        const avatarSrc = await loadOgImage(article?.author.avatarUrl)
         return new ImageResponse(
           (
             <OgFrame
@@ -121,7 +131,11 @@ export const Route = createFileRoute("/og/article/$handle/$slug")({
               seed={`${params.handle}/${params.slug}`}
             >
               {article ? (
-                <ArticleCard article={article} handle={params.handle} />
+                <ArticleCard
+                  article={article}
+                  handle={params.handle}
+                  avatarSrc={avatarSrc}
+                />
               ) : (
                 <NotFoundCard />
               )}

--- a/apps/web/src/routes/og.post.$id.tsx
+++ b/apps/web/src/routes/og.post.$id.tsx
@@ -12,11 +12,12 @@ import {
   OgFrame,
   OgStats,
   getOgFonts,
+  loadOgImage,
   truncate,
 } from "../lib/og-image"
 import type { Post } from "../lib/api"
 
-function PostCard({ post }: { post: Post }) {
+function PostCard({ post, avatarSrc }: { post: Post; avatarSrc: string | null }) {
   const handle = post.author.handle ?? "user"
   const display = post.author.displayName || `@${handle}`
   const initial = (post.author.displayName ?? handle).slice(0, 1)
@@ -56,7 +57,7 @@ function PostCard({ post }: { post: Post }) {
           marginTop: "auto",
         }}
       >
-        <OgAvatar src={post.author.avatarUrl} initial={initial} size={64} />
+        <OgAvatar src={avatarSrc} initial={initial} size={64} />
         <div style={{ display: "flex", flexDirection: "column" }}>
           <div
             style={{
@@ -135,6 +136,9 @@ export const Route = createFileRoute("/og/post/$id")({
         } catch {
           // Falls through to NotFoundCard rather than 500ing the unfurler.
         }
+        // Resolve the avatar in parallel with anything else that might land here
+        // later. Satori can't decode webp, so we transcode server-side.
+        const avatarSrc = await loadOgImage(post?.author.avatarUrl)
         return new ImageResponse(
           (
             <OgFrame
@@ -143,7 +147,11 @@ export const Route = createFileRoute("/og/post/$id")({
               }
               seed={post?.id ?? params.id}
             >
-              {post ? <PostCard post={post} /> : <NotFoundCard />}
+              {post ? (
+                <PostCard post={post} avatarSrc={avatarSrc} />
+              ) : (
+                <NotFoundCard />
+              )}
             </OgFrame>
           ),
           {

--- a/apps/web/src/routes/og.user.$handle.tsx
+++ b/apps/web/src/routes/og.user.$handle.tsx
@@ -12,11 +12,18 @@ import {
   OgFrame,
   OgStats,
   getOgFonts,
+  loadOgImage,
   truncate,
 } from "../lib/og-image"
 import type { PublicProfile } from "../lib/api"
 
-function ProfileCard({ user }: { user: PublicProfile }) {
+function ProfileCard({
+  user,
+  avatarSrc,
+}: {
+  user: PublicProfile
+  avatarSrc: string | null
+}) {
   const display = user.displayName || `@${user.handle}`
   const initial = (user.displayName ?? user.handle ?? "·").slice(0, 1)
 
@@ -36,7 +43,7 @@ function ProfileCard({ user }: { user: PublicProfile }) {
           gap: 28,
         }}
       >
-        <OgAvatar src={user.avatarUrl} initial={initial} size={140} />
+        <OgAvatar src={avatarSrc} initial={initial} size={140} />
         <div
           style={{
             display: "flex",
@@ -137,6 +144,7 @@ export const Route = createFileRoute("/og/user/$handle")({
         } catch {
           // Fall through to placeholder card.
         }
+        const avatarSrc = await loadOgImage(user?.avatarUrl)
         return new ImageResponse(
           (
             <OgFrame
@@ -144,7 +152,7 @@ export const Route = createFileRoute("/og/user/$handle")({
               seed={params.handle}
             >
               {user ? (
-                <ProfileCard user={user} />
+                <ProfileCard user={user} avatarSrc={avatarSrc} />
               ) : (
                 <NotFoundCard handle={params.handle} />
               )}

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -17,9 +17,10 @@ const config = defineConfig({
   ],
   // @vercel/og ships its own Yoga + resvg WASM. Vite's pre-bundler cannot rewrite
   // those import.meta.url WASM references, so we keep the package external on the
-  // SSR side and let Node resolve it directly at runtime.
+  // SSR side and let Node resolve it directly at runtime. Sharp is a native module
+  // and must also stay external — Node loads its prebuilt binary; bundling breaks it.
   ssr: {
-    external: ["@vercel/og"],
+    external: ["@vercel/og", "sharp"],
   },
 })
 

--- a/bun.lock
+++ b/bun.lock
@@ -66,6 +66,7 @@
         "nitro": "latest",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
+        "sharp": "^0.33.5",
         "tailwindcss": "^4.1.18",
         "vite-tsconfig-paths": "^5.1.4",
         "zod": "^3.25.76",

--- a/packages/media/src/s3.ts
+++ b/packages/media/src/s3.ts
@@ -178,18 +178,44 @@ export function publicUrl(env: MediaEnv, key: string) {
   return `${env.S3_PUBLIC_URL.replace(/\/$/, '')}/${key}`
 }
 
+/** Returns the path portion of MEDIA_PROXY_BASE without leading or trailing slashes
+ *  (e.g. "api/m"). Empty string when the proxy isn't configured or its URL won't parse. */
+function proxyPathPrefix(env: MediaEnv): string {
+  if (!env.MEDIA_PROXY_BASE) return ''
+  try {
+    return new URL(env.MEDIA_PROXY_BASE).pathname.replace(/^\/+|\/+$/g, '')
+  } catch {
+    return ''
+  }
+}
+
+/** Strip a leading proxy-path prefix (e.g. "api/m/") off a key. Tolerates any number
+ *  of leading slashes and repeated prefixes — both have shown up in the wild from
+ *  legacy DB rows and host changes that confused earlier versions of extractKey. */
+function stripProxyPath(env: MediaEnv, key: string): string {
+  const prefix = proxyPathPrefix(env)
+  let out = key.replace(/^\/+/, '')
+  if (!prefix) return out
+  while (out.startsWith(`${prefix}/`)) {
+    out = out.slice(prefix.length + 1)
+  }
+  return out
+}
+
 /**
  * Best-effort key extraction for legacy DB rows that stored a full S3 URL (e.g. before we
- * switched to the proxy). Strips the host and an optional bucket prefix.
+ * switched to the proxy) or an already-proxied URL. Strips the host, an optional bucket
+ * prefix, and the proxy path prefix so the resulting key is always relative to the bucket
+ * root.
  */
 export function extractKey(env: MediaEnv, urlOrKey: string): string {
-  if (!urlOrKey.includes('://')) return urlOrKey.replace(/^\/+/, '')
+  if (!urlOrKey.includes('://')) return stripProxyPath(env, urlOrKey)
   try {
     const u = new URL(urlOrKey)
     const parts = u.pathname.replace(/^\/+/, '').split('/')
-    if (parts[0] === env.S3_BUCKET) return parts.slice(1).join('/')
-    if (parts[0]?.startsWith('bucket-')) return parts.slice(1).join('/')
-    return parts.join('/')
+    if (parts[0] === env.S3_BUCKET) return stripProxyPath(env, parts.slice(1).join('/'))
+    if (parts[0]?.startsWith('bucket-')) return stripProxyPath(env, parts.slice(1).join('/'))
+    return stripProxyPath(env, parts.join('/'))
   } catch {
     return urlOrKey
   }
@@ -203,7 +229,7 @@ export function extractKey(env: MediaEnv, urlOrKey: string): string {
 export function assetUrl(env: MediaEnv, stored: string | null | undefined): string | null {
   if (!stored) return null
   if (env.MEDIA_PROXY_BASE && stored.startsWith(env.MEDIA_PROXY_BASE)) return stored
-  if (!stored.includes('://')) return publicUrl(env, stored)
+  if (!stored.includes('://')) return publicUrl(env, stripProxyPath(env, stored))
   return publicUrl(env, extractKey(env, stored))
 }
 


### PR DESCRIPTION
## Summary

- Added `loadOgImage()` utility to fetch and transcode remote images (webp, avif, etc.) to PNG for use in OG cards, since Satori only supports PNG/JPEG
- Implemented timeout (4s) and size limits (4MB) to prevent unfurler timeouts and memory bloat
- Updated OG card routes (article, post, user) to pre-load and transcode avatars server-side before passing to Satori
- Added `stripProxyPath()` helper in media module to normalize keys from legacy proxied URLs
- Updated Vite config to keep `sharp` external (native binary) alongside `@vercel/og`

## Test plan

- [ ] `bun run typecheck` passes
- [ ] Manually verified OG cards render with transcoded avatars in article, post, and user routes
- [ ] No new console errors / network errors

## Notes

- `loadOgImage()` gracefully returns `null` on any error (timeout, fetch failure, oversized image), allowing fallback to initial chip rather than 500ing unfurlers
- Dynamic import of `sharp` keeps it out of client bundles
- Data URLs are passed through unchanged; only remote URLs are fetched and transcoded

https://claude.ai/code/session_015WrFaVQmChAvQHK2fSkKqX