### PR TITLE
Add juicy like button animation

### DIFF
--- a/apps/web/src/components/like-button-heart.tsx
+++ b/apps/web/src/components/like-button-heart.tsx
@@ -1,0 +1,97 @@
+import { HeartIcon } from "@phosphor-icons/react"
+import { useCallback, useEffect, useRef, useState } from "react"
+import type { CSSProperties } from "react"
+
+export function useLikeAnimation(durationMs = 600) {
+  const [animating, setAnimating] = useState(false)
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  useEffect(
+    () => () => {
+      if (timer.current) clearTimeout(timer.current)
+    },
+    []
+  )
+
+  const trigger = useCallback(() => {
+    if (timer.current) clearTimeout(timer.current)
+    setAnimating(true)
+    timer.current = setTimeout(() => setAnimating(false), durationMs)
+  }, [durationMs])
+
+  return { animating, trigger }
+}
+
+type Props = {
+  liked: boolean
+  animating: boolean
+  iconSize?: number
+  /** Number of particles in the burst (multiples of 8 look cleanest). */
+  particleCount?: number
+  className?: string
+}
+
+export function LikeIconBurst({
+  liked,
+  animating,
+  iconSize = 16,
+  particleCount = 8,
+  className = "",
+}: Props) {
+  const showBurst = animating && liked
+  const particleSize = Math.max(3, Math.round(iconSize * 0.22))
+  const particleTravel = Math.round(iconSize * 1.4)
+
+  // The className "size-[1em]" is intentional: the literal "size-" substring
+  // defeats shadcn Button's `[&_svg:not([class*='size-'])]:size-2.5` rule that
+  // would otherwise shrink the icon. The actual pixel size is set inline below.
+  const sizeClass = "size-[1em]"
+  const sizeStyle: CSSProperties = { width: iconSize, height: iconSize }
+
+  return (
+    <span
+      aria-hidden
+      className={`relative inline-flex shrink-0 items-center justify-center ${className}`}
+      style={sizeStyle}
+    >
+      <span
+        className={`relative inline-flex h-full w-full items-center justify-center ${
+          animating ? "animate-heart-pop" : ""
+        }`}
+      >
+        <HeartIcon
+          className={`${sizeClass} block transition-opacity duration-150 ${
+            liked ? "opacity-0" : "opacity-100"
+          }`}
+          style={sizeStyle}
+        />
+        <HeartIcon
+          weight="fill"
+          className={`${sizeClass} pointer-events-none absolute inset-0 m-auto text-rose-500 transition-opacity duration-150 ${
+            liked ? "opacity-100" : "opacity-0"
+          } ${showBurst ? "animate-heart-wave" : ""}`}
+          style={sizeStyle}
+        />
+      </span>
+
+      {showBurst && (
+        <span className="pointer-events-none absolute inset-0 overflow-visible">
+          {Array.from({ length: particleCount }).map((_, i) => (
+            <span
+              key={i}
+              className="animate-heart-particle absolute top-1/2 left-1/2 rounded-full bg-rose-500 shadow-[0_0_6px_1px_rgba(244,63,94,0.55)]"
+              style={
+                {
+                  width: particleSize,
+                  height: particleSize,
+                  "--particle-angle": `${(360 / particleCount) * i}deg`,
+                  "--particle-travel": `${particleTravel}px`,
+                } as CSSProperties
+              }
+            />
+          ))}
+        </span>
+      )}
+    </span>
+  )
+}

--- a/apps/web/src/components/post-card.tsx
+++ b/apps/web/src/components/post-card.tsx
@@ -13,7 +13,6 @@ import {
   RepeatIcon,
   TrashIcon,
 } from "@phosphor-icons/react"
-import { LikeIconBurst, useLikeAnimation } from "./like-button-heart"
 import { Button } from "@workspace/ui/components/button"
 import { Textarea } from "@workspace/ui/components/textarea"
 import {
@@ -32,6 +31,7 @@ import {
 import { POST_MAX_LEN } from "@workspace/validators"
 import { recordImpression, trackedAction } from "../lib/analytics"
 import { ApiError, api } from "../lib/api"
+import { LikeIconBurst, useLikeAnimation } from "./like-button-heart"
 import { RichText } from "./rich-text"
 import { MacfolioCardFromText } from "./macfolio-card"
 import { GithubCardBlock } from "./github-card"

--- a/apps/web/src/components/post-card.tsx
+++ b/apps/web/src/components/post-card.tsx
@@ -3,15 +3,9 @@ import { useEffect, useRef, useState } from "react"
 import {
   BookmarkIcon,
   ChatCircleIcon,
-  DotsThreeIcon,
-  EyeIcon,
-  EyeSlashIcon,
-  FlagIcon,
-  PencilIcon,
   PushPinIcon,
   QuotesIcon,
   RepeatIcon,
-  TrashIcon,
 } from "@phosphor-icons/react"
 import { Button } from "@workspace/ui/components/button"
 import { Textarea } from "@workspace/ui/components/textarea"
@@ -413,7 +407,6 @@ export function PostCard({
     const liked = !post.viewer.liked
     const props = () => ({ post_id: post.id, author_id: post.author.id })
     likeAnim.trigger()
-    const props = () => ({ post_id: post.id, author_id: post.author.id })
     optimistic(
       {
         counts: { ...post.counts, likes: post.counts.likes + (liked ? 1 : -1) },

--- a/apps/web/src/components/post-card.tsx
+++ b/apps/web/src/components/post-card.tsx
@@ -3,11 +3,17 @@ import { useEffect, useRef, useState } from "react"
 import {
   BookmarkIcon,
   ChatCircleIcon,
-  HeartIcon,
+  DotsThreeIcon,
+  EyeIcon,
+  EyeSlashIcon,
+  FlagIcon,
+  PencilIcon,
   PushPinIcon,
   QuotesIcon,
   RepeatIcon,
+  TrashIcon,
 } from "@phosphor-icons/react"
+import { LikeIconBurst, useLikeAnimation } from "./like-button-heart"
 import { Button } from "@workspace/ui/components/button"
 import { Textarea } from "@workspace/ui/components/textarea"
 import {
@@ -371,7 +377,7 @@ export function PostCard({
       const { post: updated } = await trackedAction(
         "post_edited",
         () => api.editPost(post.id, editText),
-        () => ({ post_id: post.id, char_count: editText.length }),
+        () => ({ post_id: post.id, char_count: editText.length })
       )
       emit(updated)
       setEditing(false)
@@ -401,9 +407,12 @@ export function PostCard({
     }
   }
 
+  const likeAnim = useLikeAnimation()
   function toggleLike() {
     if (busy || !post.viewer) return
     const liked = !post.viewer.liked
+    const props = () => ({ post_id: post.id, author_id: post.author.id })
+    likeAnim.trigger()
     const props = () => ({ post_id: post.id, author_id: post.author.id })
     optimistic(
       {
@@ -413,7 +422,7 @@ export function PostCard({
       () =>
         liked
           ? trackedAction("post_liked", () => api.like(post.id), props)
-          : trackedAction("post_unliked", () => api.unlike(post.id), props),
+          : trackedAction("post_unliked", () => api.unlike(post.id), props)
     )
   }
   function toggleBookmark() {
@@ -434,8 +443,8 @@ export function PostCard({
           : trackedAction(
               "post_unbookmarked",
               () => api.unbookmark(post.id),
-              props,
-            ),
+              props
+            )
     )
   }
   function toggleRepost() {
@@ -453,7 +462,7 @@ export function PostCard({
       () =>
         reposted
           ? trackedAction("post_reposted", () => api.repost(post.id), props)
-          : trackedAction("post_unreposted", () => api.unrepost(post.id), props),
+          : trackedAction("post_unreposted", () => api.unrepost(post.id), props)
     )
   }
 
@@ -518,7 +527,7 @@ export function PostCard({
         </div>
 
         <div
-          className={`min-w-0 flex-1${authorHandle ? " cursor-pointer" : ""}`}
+          className={`min-w-0 flex-1${authorHandle ? "cursor-pointer" : ""}`}
           onClick={(event) => {
             if (!authorHandle) return
             if (clickedInteractiveElement(event.target)) return
@@ -644,7 +653,10 @@ export function PostCard({
           {!editing && <MacfolioCardFromText text={post.text} />}
           {post.articleCard && <ArticleCardBlock card={post.articleCard} />}
           {post.githubCards?.map((card, i) => (
-            <GithubCardBlock key={`${card.kind}-${card.url}-${i}`} card={card} />
+            <GithubCardBlock
+              key={`${card.kind}-${card.url}-${i}`}
+              card={card}
+            />
           ))}
           {post.media && post.media.length > 0 && (
             <MediaGrid media={post.media} />
@@ -701,11 +713,11 @@ export function PostCard({
               className={`flex cursor-pointer items-center gap-2 transition hover:text-foreground ${post.viewer?.liked ? "text-foreground" : ""}`}
               aria-pressed={post.viewer?.liked}
             >
-              {post.viewer?.liked ? (
-                <HeartIcon className="size-4" weight="fill" />
-              ) : (
-                <HeartIcon className="size-4" />
-              )}
+              <LikeIconBurst
+                liked={!!post.viewer?.liked}
+                animating={likeAnim.animating}
+                iconSize={16}
+              />
               <span className="text-xs">{post.counts.likes}</span>
             </Button>
             <Button

--- a/apps/web/src/components/post-card.tsx
+++ b/apps/web/src/components/post-card.tsx
@@ -9,6 +9,7 @@ import {
 } from "@phosphor-icons/react"
 import { Button } from "@workspace/ui/components/button"
 import { Textarea } from "@workspace/ui/components/textarea"
+import { cn } from "@workspace/ui/lib/utils"
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -520,7 +521,7 @@ export function PostCard({
         </div>
 
         <div
-          className={`min-w-0 flex-1${authorHandle ? "cursor-pointer" : ""}`}
+          className={cn("min-w-0 flex-1", authorHandle && "cursor-pointer")}
           onClick={(event) => {
             if (!authorHandle) return
             if (clickedInteractiveElement(event.target)) return

--- a/apps/web/src/routes/$handle.p.$id.tsx
+++ b/apps/web/src/routes/$handle.p.$id.tsx
@@ -10,6 +10,7 @@ import {
   RepeatIcon,
 } from "@phosphor-icons/react"
 import { Textarea } from "@workspace/ui/components/textarea"
+import { cn } from "@workspace/ui/lib/utils"
 import {
   LikeIconBurst,
   useLikeAnimation,
@@ -901,7 +902,10 @@ function ReplyRow({
     // biome-ignore lint/a11y/useKeyWithClickEvents: row navigates on click; interactive children use clickedInteractiveElement to opt out
     <div
       onClick={openPost}
-      className={`block border-b border-border py-3 pr-4 pl-8 transition-colors${authorHandle ? "cursor-pointer hover:bg-muted/30" : ""}`}
+      className={cn(
+        "block border-b border-border py-3 pr-4 pl-8 transition-colors",
+        authorHandle && "cursor-pointer hover:bg-muted/30"
+      )}
     >
       <ReplyCard post={post} onChange={onChange} onRemove={onRemove} />
     </div>

--- a/apps/web/src/routes/$handle.p.$id.tsx
+++ b/apps/web/src/routes/$handle.p.$id.tsx
@@ -6,11 +6,14 @@ import {
   ChartBarIcon,
   ChatCircleIcon,
   HashIcon,
-  HeartIcon,
   ImageIcon,
   RepeatIcon,
 } from "@phosphor-icons/react"
 import { Textarea } from "@workspace/ui/components/textarea"
+import {
+  LikeIconBurst,
+  useLikeAnimation,
+} from "../components/like-button-heart"
 import { ApiError, api } from "../lib/api"
 import { useSubmitHotkey } from "../lib/hotkeys"
 import { Avatar } from "../components/avatar"
@@ -348,9 +351,11 @@ function AncestorPost({
     }
   }
 
+  const likeAnim = useLikeAnimation()
   function toggleLike() {
     if (busy || !post.viewer) return
     const liked = !post.viewer.liked
+    likeAnim.trigger()
     optimistic(
       {
         counts: { ...post.counts, likes: post.counts.likes + (liked ? 1 : -1) },
@@ -457,7 +462,10 @@ function AncestorPost({
           {post.articleCard && <ArticleCardBlock card={post.articleCard} />}
 
           {post.githubCards?.map((card, i) => (
-            <GithubCardBlock key={`${card.kind}-${card.url}-${i}`} card={card} />
+            <GithubCardBlock
+              key={`${card.kind}-${card.url}-${i}`}
+              card={card}
+            />
           ))}
 
           {post.poll && (
@@ -495,11 +503,11 @@ function AncestorPost({
               disabled={busy || !post.viewer}
               className={`flex items-center gap-1.5 py-0.5 text-[13px] tabular-nums transition-colors hover:text-foreground ${post.viewer?.liked ? "text-foreground" : ""}`}
             >
-              {post.viewer?.liked ? (
-                <HeartIcon size={16} weight="fill" />
-              ) : (
-                <HeartIcon size={16} />
-              )}
+              <LikeIconBurst
+                liked={!!post.viewer?.liked}
+                animating={likeAnim.animating}
+                iconSize={16}
+              />
               <span>{post.counts.likes}</span>
             </button>
             <button
@@ -558,9 +566,11 @@ function ParentPost({
     }
   }
 
+  const likeAnim = useLikeAnimation()
   function toggleLike() {
     if (busy || !post.viewer) return
     const liked = !post.viewer.liked
+    likeAnim.trigger()
     optimistic(
       {
         counts: { ...post.counts, likes: post.counts.likes + (liked ? 1 : -1) },
@@ -706,11 +716,11 @@ function ParentPost({
           disabled={busy || !post.viewer}
           className={`flex items-center gap-1.5 py-0.5 text-[13px] tabular-nums transition-colors hover:text-foreground ${post.viewer?.liked ? "text-foreground" : ""}`}
         >
-          {post.viewer?.liked ? (
-            <HeartIcon size={16} weight="fill" />
-          ) : (
-            <HeartIcon size={16} />
-          )}
+          <LikeIconBurst
+            liked={!!post.viewer?.liked}
+            animating={likeAnim.animating}
+            iconSize={16}
+          />
           <span>{post.counts.likes}</span>
         </button>
         <button
@@ -891,7 +901,7 @@ function ReplyRow({
     // biome-ignore lint/a11y/useKeyWithClickEvents: row navigates on click; interactive children use clickedInteractiveElement to opt out
     <div
       onClick={openPost}
-      className={`block border-b border-border py-3 pr-4 pl-8 transition-colors${authorHandle ? " cursor-pointer hover:bg-muted/30" : ""}`}
+      className={`block border-b border-border py-3 pr-4 pl-8 transition-colors${authorHandle ? "cursor-pointer hover:bg-muted/30" : ""}`}
     >
       <ReplyCard post={post} onChange={onChange} onRemove={onRemove} />
     </div>
@@ -927,9 +937,11 @@ function ReplyCard({
     }
   }
 
+  const likeAnim = useLikeAnimation()
   function toggleLike() {
     if (busy || !post.viewer) return
     const liked = !post.viewer.liked
+    likeAnim.trigger()
     optimistic(
       {
         counts: { ...post.counts, likes: post.counts.likes + (liked ? 1 : -1) },
@@ -1070,11 +1082,11 @@ function ReplyCard({
           disabled={busy || !post.viewer}
           className={`flex items-center gap-1.5 py-0.5 text-[13px] tabular-nums transition-colors hover:text-foreground ${post.viewer?.liked ? "text-foreground" : ""}`}
         >
-          {post.viewer?.liked ? (
-            <HeartIcon size={16} weight="fill" />
-          ) : (
-            <HeartIcon size={16} />
-          )}
+          <LikeIconBurst
+            liked={!!post.viewer?.liked}
+            animating={likeAnim.animating}
+            iconSize={16}
+          />
           <span>{post.counts.likes}</span>
         </button>
         <button

--- a/packages/ui/src/styles/globals.css
+++ b/packages/ui/src/styles/globals.css
@@ -162,3 +162,64 @@
 .macfolio-shimmer {
   animation: macfolio-shimmer 4.2s ease-in-out infinite;
 }
+
+@keyframes heart-pop {
+  0% {
+    transform: scale(1);
+  }
+  15% {
+    transform: scale(0.7);
+  }
+  45% {
+    transform: scale(1.7);
+  }
+  75% {
+    transform: scale(0.92);
+  }
+  100% {
+    transform: scale(1);
+  }
+}
+
+@keyframes heart-wave {
+  0% {
+    filter: brightness(1) saturate(1);
+  }
+  40% {
+    filter: brightness(1.25) saturate(1.4)
+      drop-shadow(0 0 6px rgba(244, 63, 94, 0.55));
+  }
+  100% {
+    filter: brightness(1) saturate(1);
+  }
+}
+
+@keyframes heart-particle {
+  0% {
+    opacity: 1;
+    transform: translate(-50%, -50%) rotate(var(--particle-angle)) translateY(0)
+      scale(0.4);
+  }
+  30% {
+    opacity: 1;
+    transform: translate(-50%, -50%) rotate(var(--particle-angle))
+      translateY(calc(var(--particle-travel, 22px) * -0.55)) scale(1);
+  }
+  100% {
+    opacity: 0;
+    transform: translate(-50%, -50%) rotate(var(--particle-angle))
+      translateY(calc(var(--particle-travel, 22px) * -1)) scale(0);
+  }
+}
+
+.animate-heart-pop {
+  animation: heart-pop 0.45s cubic-bezier(0.34, 1.56, 0.64, 1) both;
+}
+
+.animate-heart-wave {
+  animation: heart-wave 0.5s ease-out both;
+}
+
+.animate-heart-particle {
+  animation: heart-particle 0.6s cubic-bezier(0.2, 0.8, 0.3, 1) forwards;
+}


### PR DESCRIPTION
i feel juicy today

- New `LikeIconBurst` + `useLikeAnimation` in `apps/web/src/components/like-button-heart.tsx` (Phosphor `HeartIcon`, pop / wave / particle burst)
- Keyframes and utilities in `packages/ui/src/styles/globals.css`
- Wired into post card and post detail action rows

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Like button now shows an animated heart pop, wave, and outward-radiating particle burst when you like posts.
  * Animated feedback applied across post cards, parent/ancestor posts, and replies for immediate, consistent visual response.
  * Particle count, size, and travel are tuned for a more engaging touch interaction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->