### PR TITLE
Replace native inputs with UI component library

### DIFF
--- a/apps/web/src/components/chat-widget.tsx
+++ b/apps/web/src/components/chat-widget.tsx
@@ -10,6 +10,7 @@ import {
 } from "@phosphor-icons/react"
 import { Link } from "@tanstack/react-router"
 import { Button } from "@workspace/ui/components/button"
+import { Input } from "@workspace/ui/components/input"
 import { api } from "../lib/api"
 import { getPastedImageFiles } from "../lib/clipboard-images"
 import { subscribeToDmStream } from "../lib/dm-stream"
@@ -451,7 +452,7 @@ function ChatView({
         >
           <ImageIcon size={18} />
         </Button>
-        <input
+        <Input
           ref={inputRef}
           type="text"
           value={text}
@@ -459,7 +460,7 @@ function ChatView({
           onPaste={onPaste}
           placeholder={pending ? "Add a caption…" : "Message..."}
           disabled={sending}
-          className="flex-1 bg-transparent px-2 py-1 text-sm placeholder:text-muted-foreground focus:outline-none"
+          className="flex-1 border-0 bg-transparent"
         />
         <Button
           type="submit"

--- a/apps/web/src/components/poll-block.tsx
+++ b/apps/web/src/components/poll-block.tsx
@@ -1,4 +1,9 @@
 import { useEffect, useState } from "react"
+import { Checkbox } from "@workspace/ui/components/checkbox"
+import {
+  RadioGroup,
+  RadioGroupItem,
+} from "@workspace/ui/components/radio-group"
 import { ApiError, api } from "../lib/api"
 import { authClient } from "../lib/auth"
 import type { PollDto } from "../lib/api"
@@ -75,59 +80,72 @@ export function PollBlock({
     }
   }
 
-  return (
-    <div className="mt-2 rounded-md border border-border p-3">
-      <ul className="space-y-1.5">
-        {poll.options.map((opt) => {
-          const pct =
-            poll.totalVotes > 0 ? (opt.voteCount / poll.totalVotes) * 100 : 0
-          const isViewerChoice =
-            poll.viewerVoteOptionIds?.includes(opt.id) ?? false
-          const isSelected = selected.has(opt.id)
-          if (showResults) {
-            return (
-              <li key={opt.id}>
-                <div className="relative overflow-hidden rounded-md border border-border">
-                  <div
-                    className={`absolute inset-y-0 left-0 ${isViewerChoice ? "bg-primary/30" : "bg-muted"}`}
-                    style={{ width: `${pct}%` }}
-                    aria-hidden
-                  />
-                  <div className="relative flex items-center justify-between gap-3 px-3 py-2 text-sm">
-                    <span className="flex items-center gap-2 font-medium">
-                      {isViewerChoice && (
-                        <span className="text-primary">✓</span>
-                      )}
-                      {opt.text}
-                    </span>
-                    <span className="text-xs text-muted-foreground tabular-nums">
-                      {pct.toFixed(0)}%
-                    </span>
-                  </div>
-                </div>
-              </li>
-            )
-          }
+  const optionsList = (
+    <ul className="space-y-1.5">
+      {poll.options.map((opt) => {
+        const pct =
+          poll.totalVotes > 0 ? (opt.voteCount / poll.totalVotes) * 100 : 0
+        const isViewerChoice =
+          poll.viewerVoteOptionIds?.includes(opt.id) ?? false
+        const isSelected = selected.has(opt.id)
+        if (showResults) {
           return (
             <li key={opt.id}>
-              <label
-                className={`flex cursor-pointer items-center gap-2 rounded-md border px-3 py-2 text-sm transition hover:bg-muted/40 ${
-                  isSelected ? "border-primary" : "border-border"
-                }`}
-              >
-                <input
-                  type={poll.allowMultiple ? "checkbox" : "radio"}
-                  name={`poll-${poll.id}`}
-                  checked={isSelected}
-                  onChange={() => toggle(opt.id)}
-                  className="size-4 accent-primary"
+              <div className="relative overflow-hidden rounded-md border border-border">
+                <div
+                  className={`absolute inset-y-0 left-0 ${isViewerChoice ? "bg-primary/30" : "bg-muted"}`}
+                  style={{ width: `${pct}%` }}
+                  aria-hidden
                 />
-                <span>{opt.text}</span>
-              </label>
+                <div className="relative flex items-center justify-between gap-3 px-3 py-2 text-sm">
+                  <span className="flex items-center gap-2 font-medium">
+                    {isViewerChoice && <span className="text-primary">✓</span>}
+                    {opt.text}
+                  </span>
+                  <span className="text-xs text-muted-foreground tabular-nums">
+                    {pct.toFixed(0)}%
+                  </span>
+                </div>
+              </div>
             </li>
           )
-        })}
-      </ul>
+        }
+        return (
+          <li key={opt.id}>
+            <label
+              className={`flex cursor-pointer items-center gap-2 rounded-md border px-3 py-2 text-sm transition hover:bg-muted/40 ${
+                isSelected ? "border-primary" : "border-border"
+              }`}
+            >
+              {poll.allowMultiple ? (
+                <Checkbox
+                  checked={isSelected}
+                  onCheckedChange={() => toggle(opt.id)}
+                />
+              ) : (
+                <RadioGroupItem value={opt.id} />
+              )}
+              <span>{opt.text}</span>
+            </label>
+          </li>
+        )
+      })}
+    </ul>
+  )
+
+  return (
+    <div className="mt-2 rounded-md border border-border p-3">
+      {!showResults && !poll.allowMultiple ? (
+        <RadioGroup
+          value={[...selected][0] ?? ""}
+          onValueChange={(value: string) => setSelected(new Set([value]))}
+          className="contents"
+        >
+          {optionsList}
+        </RadioGroup>
+      ) : (
+        optionsList
+      )}
       <div className="mt-2 flex items-center justify-between text-xs text-muted-foreground">
         <span>
           {poll.totalVotes} {poll.totalVotes === 1 ? "vote" : "votes"} ·{" "}

--- a/apps/web/src/components/report-dialog.tsx
+++ b/apps/web/src/components/report-dialog.tsx
@@ -6,6 +6,10 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@workspace/ui/components/dialog"
+import {
+  RadioGroup,
+  RadioGroupItem,
+} from "@workspace/ui/components/radio-group"
 import { Textarea } from "@workspace/ui/components/textarea"
 import { ApiError, api } from "../lib/api"
 import type { ReportReason } from "../lib/api"
@@ -113,28 +117,27 @@ export function ReportDialog({
           </DialogTitle>
         </DialogHeader>
         <div className="space-y-3">
-          <ul className="divide-y divide-border rounded-md border border-border">
-            {REASONS.map((r) => (
-              <li key={r.value}>
-                <label className="flex cursor-pointer items-start gap-3 px-3 py-2 text-sm transition hover:bg-muted/30">
-                  <input
-                    type="radio"
-                    name="reason"
-                    value={r.value}
-                    checked={reason === r.value}
-                    onChange={() => setReason(r.value)}
-                    className="mt-0.5"
-                  />
-                  <div className="min-w-0 flex-1">
-                    <div className="font-medium">{r.label}</div>
-                    <div className="text-xs text-muted-foreground">
-                      {r.help}
+          <RadioGroup<ReportReason | null>
+            value={reason}
+            onValueChange={(value) => setReason(value)}
+            className="contents"
+          >
+            <ul className="divide-y divide-border rounded-md border border-border">
+              {REASONS.map((r) => (
+                <li key={r.value}>
+                  <label className="flex cursor-pointer items-start gap-3 px-3 py-2 text-sm transition hover:bg-muted/30">
+                    <RadioGroupItem value={r.value} className="mt-0.5" />
+                    <div className="min-w-0 flex-1">
+                      <div className="font-medium">{r.label}</div>
+                      <div className="text-xs text-muted-foreground">
+                        {r.help}
+                      </div>
                     </div>
-                  </div>
-                </label>
-              </li>
-            ))}
-          </ul>
+                  </label>
+                </li>
+              ))}
+            </ul>
+          </RadioGroup>
           <Textarea
             value={details}
             onChange={(e) => setDetails(e.target.value)}

--- a/apps/web/src/routes/settings.tsx
+++ b/apps/web/src/routes/settings.tsx
@@ -3,6 +3,7 @@ import { useEffect, useMemo, useState } from "react"
 import { Button } from "@workspace/ui/components/button"
 import { Input } from "@workspace/ui/components/input"
 import { Label } from "@workspace/ui/components/label"
+import { Switch } from "@workspace/ui/components/switch"
 import { updateProfileSchema } from "@workspace/validators"
 import { Textarea } from "@workspace/ui/components/textarea"
 import { ApiError, api } from "../lib/api"
@@ -950,10 +951,9 @@ function ConnectionsSection() {
         </div>
         {state?.connected === true && (
           <label className="mt-3 flex items-center gap-2 text-xs">
-            <input
-              type="checkbox"
+            <Switch
               checked={state.showOnProfile}
-              onChange={(e) => toggleVisibility(e.target.checked)}
+              onCheckedChange={(checked) => toggleVisibility(checked)}
               disabled={busy !== null}
             />
             Show on my profile

--- a/packages/ui/src/components/checkbox.tsx
+++ b/packages/ui/src/components/checkbox.tsx
@@ -1,0 +1,32 @@
+"use client"
+
+import { Checkbox as CheckboxPrimitive } from "@base-ui/react/checkbox"
+import { CheckIcon, MinusIcon } from "@phosphor-icons/react"
+
+import { cn } from "@workspace/ui/lib/utils"
+
+function Checkbox({ className, ...props }: CheckboxPrimitive.Root.Props) {
+  return (
+    <CheckboxPrimitive.Root
+      data-slot="checkbox"
+      className={cn(
+        "peer size-4 shrink-0 rounded-sm border border-input bg-input/20 outline-none transition-colors focus-visible:border-ring focus-visible:ring-2 focus-visible:ring-ring/30 disabled:cursor-not-allowed disabled:opacity-50 data-checked:border-primary data-checked:bg-primary data-checked:text-primary-foreground data-indeterminate:border-primary data-indeterminate:bg-primary data-indeterminate:text-primary-foreground aria-invalid:border-destructive aria-invalid:ring-2 aria-invalid:ring-destructive/20 dark:bg-input/30 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40",
+        className
+      )}
+      {...props}
+    >
+      <CheckboxPrimitive.Indicator
+        data-slot="checkbox-indicator"
+        className="flex items-center justify-center text-current"
+      >
+        {props.indeterminate ? (
+          <MinusIcon className="size-3" weight="bold" />
+        ) : (
+          <CheckIcon className="size-3" weight="bold" />
+        )}
+      </CheckboxPrimitive.Indicator>
+    </CheckboxPrimitive.Root>
+  )
+}
+
+export { Checkbox }

--- a/packages/ui/src/components/radio-group.tsx
+++ b/packages/ui/src/components/radio-group.tsx
@@ -1,0 +1,42 @@
+"use client"
+
+import { Radio as RadioPrimitive } from "@base-ui/react/radio"
+import { RadioGroup as RadioGroupPrimitive } from "@base-ui/react/radio-group"
+
+import { cn } from "@workspace/ui/lib/utils"
+
+function RadioGroup<TValue>({
+  className,
+  ...props
+}: RadioGroupPrimitive.Props<TValue>) {
+  return (
+    <RadioGroupPrimitive
+      data-slot="radio-group"
+      className={cn("grid gap-2", className)}
+      {...props}
+    />
+  )
+}
+
+function RadioGroupItem<TValue>({
+  className,
+  ...props
+}: RadioPrimitive.Root.Props<TValue>) {
+  return (
+    <RadioPrimitive.Root
+      data-slot="radio-group-item"
+      className={cn(
+        "peer aspect-square size-4 shrink-0 rounded-full border border-input bg-input/20 outline-none transition-colors focus-visible:border-ring focus-visible:ring-2 focus-visible:ring-ring/30 disabled:cursor-not-allowed disabled:opacity-50 data-checked:border-primary aria-invalid:border-destructive aria-invalid:ring-2 aria-invalid:ring-destructive/20 dark:bg-input/30 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40",
+        className
+      )}
+      {...props}
+    >
+      <RadioPrimitive.Indicator
+        data-slot="radio-group-indicator"
+        className="flex items-center justify-center after:size-2 after:rounded-full after:bg-primary after:content-['']"
+      />
+    </RadioPrimitive.Root>
+  )
+}
+
+export { RadioGroup, RadioGroupItem }


### PR DESCRIPTION
## Summary

- Created new `Checkbox` and `RadioGroup` components in the UI library using Base UI primitives
- Replaced native HTML `<input>` elements with styled UI components across the app (poll-block, report-dialog, settings, chat-widget)
- Improved form control consistency and accessibility by using proper component abstractions

## Test plan

- [ ] `bun run typecheck` passes
- [ ] Manually tested poll voting with single and multiple choice options
- [ ] Manually tested report dialog reason selection
- [ ] Manually tested settings connection visibility toggle
- [ ] Manually tested chat input field
- [ ] No new console errors

## Notes

The new `Checkbox` and `RadioGroup` components are built on Base UI primitives and provide consistent styling with the existing design system. The `RadioGroup` component uses a generic type parameter to support different value types (e.g., `ReportReason | null`).

https://claude.ai/code/session_01FkFLxFjsxAog4GCDxdMQmQ