### PR TITLE
Add dark mode background transparency to textarea components

### DIFF
--- a/apps/web/src/components/compose.tsx
+++ b/apps/web/src/components/compose.tsx
@@ -298,7 +298,7 @@ export function Compose({
           onPaste={onPaste}
           placeholder={placeholder}
           rows={expanded ? 3 : 1}
-          className="border-0 bg-transparent px-0 py-0 text-[15px] leading-relaxed shadow-none focus-visible:ring-0"
+          className="min-h-0 border-0 bg-transparent px-0 py-0 text-[15px] leading-relaxed shadow-none focus-visible:ring-0 md:text-[15px] dark:bg-transparent"
         />
 
         {quoted && (

--- a/apps/web/src/components/post-card.tsx
+++ b/apps/web/src/components/post-card.tsx
@@ -644,7 +644,7 @@ export function PostCard({
                 value={editText}
                 onChange={(e) => setEditText(e.target.value)}
                 rows={3}
-                className="min-h-20 border-0 bg-transparent px-0 py-0 text-sm shadow-none focus-visible:ring-0"
+                className="min-h-20 border-0 bg-transparent px-0 py-0 text-sm shadow-none focus-visible:ring-0 dark:bg-transparent"
                 maxLength={POST_MAX_LEN}
               />
               <div className="mt-1 flex items-center justify-between text-xs">

--- a/apps/web/src/routes/$handle.p.$id.tsx
+++ b/apps/web/src/routes/$handle.p.$id.tsx
@@ -741,7 +741,7 @@ function ReplyComposer({
             onFocus={() => setExpanded(true)}
             placeholder="Post your reply"
             rows={1}
-            className="min-h-0 border-0 bg-transparent px-1 py-1 text-[13px] leading-relaxed md:text-[13px]"
+            className="min-h-0 border-0 bg-transparent px-1 py-1 text-[13px] leading-relaxed md:text-[13px] dark:bg-transparent"
           />
 
           <div


### PR DESCRIPTION
## Summary

- Added `dark:bg-transparent` class to textarea elements in compose, post edit, and reply composer components
- Added `min-h-0` class to compose textarea for better height constraint handling
- Added responsive `md:text-[15px]` class to compose textarea for consistency

## Test plan

- [ ] `bun run typecheck` passes
- [ ] Manually exercised compose, post edit, and reply flows in dark mode to verify textarea backgrounds render correctly

## Notes

These changes ensure textarea components maintain transparent backgrounds in dark mode and have consistent sizing behavior across different screen sizes.

https://claude.ai/code/session_01PWJe9aPGRCyX7giy4Cs98p