### PR TITLE
Add reply parent context to feed posts

### DIFF
--- a/apps/api/src/lib/post-dto.ts
+++ b/apps/api/src/lib/post-dto.ts
@@ -76,6 +76,10 @@ export interface PostDto {
   /** Populated on quotes (rows where quoteOfId is set) — the embedded post rendered under the
    *  quoter's commentary. Not recursive: the embed's own quoteOf/repostOf stay undefined. */
   quoteOf?: PostDto
+  /** Populated on replies (rows where replyToId is set) — the parent post the row is replying
+   *  to, rendered as a small embed above the reply so feed readers have conversation context.
+   *  Attached by attachReplyParents() after the main DTOs are built; not recursive. */
+  replyParent?: PostDto
   /** Set when this row should render with a "Pinned" banner (profile feed first item). */
   pinned?: boolean
   /** Attached poll, if any. Renders below the post text. */

--- a/apps/api/src/lib/reply-parents.ts
+++ b/apps/api/src/lib/reply-parents.ts
@@ -1,0 +1,67 @@
+import { and, eq, inArray, isNull } from '@workspace/db'
+import type { Database } from '@workspace/db'
+import { schema } from '@workspace/db'
+import type { MediaEnv } from '@workspace/media/env'
+import { toPostDto, type PostDto } from './post-dto.ts'
+import { loadViewerFlags } from './viewer-flags.ts'
+import { loadPostMedia } from './post-media.ts'
+import { loadArticleCards } from './article-cards.ts'
+
+/**
+ * For a list of posts that may be replies, batch-load the parent post each one is replying to
+ * and attach it as `replyParent` on the displayed post (the inner `repostOf` for reposts, the
+ * row itself otherwise). Without this, replies surface in feeds with no conversation context.
+ *
+ * Mutates `posts` in place. We intentionally do NOT recurse: the parent is rendered as a small
+ * embed and doesn't itself carry a `replyParent`.
+ */
+export async function attachReplyParents(args: {
+  db: Database
+  viewerId: string | undefined
+  env: MediaEnv
+  posts: Array<PostDto>
+}): Promise<void> {
+  const { db, viewerId, env, posts } = args
+  const targets: Array<{ outer: PostDto; replyToId: string }> = []
+  for (const p of posts) {
+    const displayed = p.repostOf ?? p
+    if (displayed.replyToId) targets.push({ outer: p, replyToId: displayed.replyToId })
+  }
+  if (targets.length === 0) return
+
+  const parentIds = Array.from(new Set(targets.map((t) => t.replyToId)))
+
+  const joined = await db
+    .select({ post: schema.posts, author: schema.users })
+    .from(schema.posts)
+    .innerJoin(schema.users, eq(schema.users.id, schema.posts.authorId))
+    .where(and(inArray(schema.posts.id, parentIds), isNull(schema.posts.deletedAt)))
+
+  const [flags, mediaMap, articleMap] = await Promise.all([
+    loadViewerFlags(db, viewerId, parentIds),
+    loadPostMedia(db, parentIds),
+    loadArticleCards(db, parentIds),
+  ])
+
+  const dtoById = new Map<string, PostDto>()
+  for (const r of joined) {
+    dtoById.set(
+      r.post.id,
+      toPostDto(
+        r.post,
+        r.author,
+        flags.get(r.post.id),
+        mediaMap.get(r.post.id),
+        env,
+        articleMap.get(r.post.id),
+      ),
+    )
+  }
+
+  for (const t of targets) {
+    const parent = dtoById.get(t.replyToId)
+    if (!parent) continue
+    const displayed = t.outer.repostOf ?? t.outer
+    displayed.replyParent = parent
+  }
+}

--- a/apps/api/src/routes/feed.ts
+++ b/apps/api/src/routes/feed.ts
@@ -8,6 +8,7 @@ import { loadPostMedia } from '../lib/post-media.ts'
 import { loadArticleCards } from '../lib/article-cards.ts'
 import { loadRepostTargets } from '../lib/repost-targets.ts'
 import { loadQuoteTargets } from '../lib/quote-targets.ts'
+import { attachReplyParents } from '../lib/reply-parents.ts'
 import { loadPolls } from '../lib/polls.ts'
 import { loadGithubCards } from '../lib/github-cards.ts'
 import { parseCursor } from '../lib/cursor.ts'
@@ -101,6 +102,7 @@ feedRoute.get('/', requireAuth(), async (c) => {
       githubMap.get(r.post.id),
     ),
   )
+  await attachReplyParents({ db, viewerId: me, env: mediaEnv, posts })
   const nextCursor = posts.length === limit ? posts[posts.length - 1]!.createdAt : null
   const response = { posts, nextCursor }
 
@@ -309,6 +311,7 @@ feedRoute.get('/network', requireAuth(), async (c) => {
     networkActorTotal: r.actorIds.length,
     networkActivityAt: r.activityAt.toISOString(),
   }))
+  await attachReplyParents({ db, viewerId: me, env: mediaEnv, posts })
   const nextCursor =
     posts.length === limit ? merged[merged.length - 1]!.activityAt.toISOString() : null
   // Suppress unused TTL constant warning (kept for future caching hooks).

--- a/apps/api/src/routes/hashtags.ts
+++ b/apps/api/src/routes/hashtags.ts
@@ -8,6 +8,7 @@ import { loadPostMedia } from '../lib/post-media.ts'
 import { loadArticleCards } from '../lib/article-cards.ts'
 import { loadRepostTargets } from '../lib/repost-targets.ts'
 import { loadQuoteTargets } from '../lib/quote-targets.ts'
+import { attachReplyParents } from '../lib/reply-parents.ts'
 import { loadPolls } from '../lib/polls.ts'
 import { loadGithubCards } from '../lib/github-cards.ts'
 import { parseCursor } from '../lib/cursor.ts'
@@ -119,6 +120,7 @@ hashtagsRoute.get('/:tag/posts', async (c) => {
       githubMap.get(r.post.id),
     ),
   )
+  await attachReplyParents({ db, viewerId, env: mediaEnv, posts })
   const nextCursor = posts.length === limit ? posts[posts.length - 1]!.createdAt : null
   return c.json({ tag, posts, nextCursor })
 })

--- a/apps/api/src/routes/lists.ts
+++ b/apps/api/src/routes/lists.ts
@@ -9,6 +9,7 @@ import { loadPostMedia } from '../lib/post-media.ts'
 import { loadArticleCards } from '../lib/article-cards.ts'
 import { loadRepostTargets } from '../lib/repost-targets.ts'
 import { loadQuoteTargets } from '../lib/quote-targets.ts'
+import { attachReplyParents } from '../lib/reply-parents.ts'
 import { loadPolls } from '../lib/polls.ts'
 import { loadGithubCards } from '../lib/github-cards.ts'
 import { parseCursor } from '../lib/cursor.ts'
@@ -420,6 +421,7 @@ listsRoute.get('/:id/timeline', async (c) => {
       githubMap.get(r.post.id),
     ),
   )
+  await attachReplyParents({ db, viewerId, env: mediaEnv, posts })
   const nextCursor = posts.length === limit ? posts[posts.length - 1]!.createdAt : null
   return c.json({ posts, nextCursor })
 })

--- a/apps/api/src/routes/me.ts
+++ b/apps/api/src/routes/me.ts
@@ -11,6 +11,7 @@ import { loadPostMedia } from '../lib/post-media.ts'
 import { loadArticleCards } from '../lib/article-cards.ts'
 import { loadRepostTargets } from '../lib/repost-targets.ts'
 import { loadQuoteTargets } from '../lib/quote-targets.ts'
+import { attachReplyParents } from '../lib/reply-parents.ts'
 import { loadPolls } from '../lib/polls.ts'
 import { loadGithubCards } from '../lib/github-cards.ts'
 import { parseCursor } from '../lib/cursor.ts'
@@ -217,6 +218,7 @@ meRoute.get('/bookmarks', async (c) => {
       githubMap.get(r.post.id),
     ),
   )
+  await attachReplyParents({ db, viewerId: session.user.id, env: mediaEnv, posts })
   const nextCursor = rows.length === limit ? rows[rows.length - 1]!.bookmarkedAt.toISOString() : null
   return c.json({ posts, nextCursor })
 })

--- a/apps/api/src/routes/posts.ts
+++ b/apps/api/src/routes/posts.ts
@@ -10,6 +10,7 @@ import { loadPostMedia } from '../lib/post-media.ts'
 import { loadArticleCards } from '../lib/article-cards.ts'
 import { loadRepostTargets } from '../lib/repost-targets.ts'
 import { loadQuoteTargets } from '../lib/quote-targets.ts'
+import { attachReplyParents } from '../lib/reply-parents.ts'
 import { loadPolls } from '../lib/polls.ts'
 import { linkHashtags } from '../lib/hashtags.ts'
 import { linkMentions } from '../lib/mentions.ts'
@@ -257,23 +258,20 @@ postsRoute.post('/', requireAuth(), async (c) => {
     loadPolls(db, session.user.id, [result.post.id]),
     loadGithubCards(db, [result.post.id]),
   ])
-  return c.json(
-    {
-      post: toPostDto(
-        result.post,
-        result.author,
-        { liked: false, bookmarked: false, reposted: false },
-        mediaMap.get(result.post.id),
-        env,
-        articleMap.get(result.post.id),
-        repostMap.get(result.post.id),
-        quoteMap.get(result.post.id),
-        pollMap.get(result.post.id),
-        githubMap.get(result.post.id),
-      ),
-    },
-    201,
+  const dto = toPostDto(
+    result.post,
+    result.author,
+    { liked: false, bookmarked: false, reposted: false },
+    mediaMap.get(result.post.id),
+    env,
+    articleMap.get(result.post.id),
+    repostMap.get(result.post.id),
+    quoteMap.get(result.post.id),
+    pollMap.get(result.post.id),
+    githubMap.get(result.post.id),
   )
+  await attachReplyParents({ db, viewerId: session.user.id, env, posts: [dto] })
+  return c.json({ post: dto }, 201)
 })
 
 // Repost (creates a posts row with repostOfId set, empty text).
@@ -916,6 +914,7 @@ postsRoute.get('/', async (c) => {
       githubMap.get(r.post.id),
     ),
   )
+  await attachReplyParents({ db, viewerId, env: mediaEnv, posts })
   const nextCursor = posts.length === limit ? posts[posts.length - 1]!.createdAt : null
   return c.json({ posts, nextCursor })
 })

--- a/apps/api/src/routes/search.ts
+++ b/apps/api/src/routes/search.ts
@@ -10,6 +10,7 @@ import { loadPostMedia } from '../lib/post-media.ts'
 import { loadArticleCards } from '../lib/article-cards.ts'
 import { loadRepostTargets } from '../lib/repost-targets.ts'
 import { loadQuoteTargets } from '../lib/quote-targets.ts'
+import { attachReplyParents } from '../lib/reply-parents.ts'
 import { loadPolls } from '../lib/polls.ts'
 import { loadGithubCards } from '../lib/github-cards.ts'
 
@@ -297,6 +298,7 @@ searchRoute.get('/', async (c) => {
       githubMap.get(r.post.id),
     ),
   )
+  await attachReplyParents({ db, viewerId, env: mediaEnv, posts })
   return c.json({ users: usersDto, posts })
 })
 

--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -10,6 +10,7 @@ import { loadPostMedia } from '../lib/post-media.ts'
 import { loadArticleCards } from '../lib/article-cards.ts'
 import { loadRepostTargets } from '../lib/repost-targets.ts'
 import { loadQuoteTargets } from '../lib/quote-targets.ts'
+import { attachReplyParents } from '../lib/reply-parents.ts'
 import { notify, invalidateUnreadCounts } from '../lib/notify.ts'
 import { loadPolls } from '../lib/polls.ts'
 import { parseCursor } from '../lib/cursor.ts'
@@ -264,6 +265,7 @@ usersRoute.get('/:handle/posts', async (c) => {
       ...(poll ? { poll } : {}),
     }
   })
+  await attachReplyParents({ db, viewerId, env: mediaEnv, posts })
   return c.json({ posts, nextCursor: payload.nextCursor })
 })
 

--- a/apps/web/src/components/post-card.tsx
+++ b/apps/web/src/components/post-card.tsx
@@ -134,6 +134,51 @@ export function ArticleCardBlock({
   )
 }
 
+// Renders the parent of a reply as a compact embed at the top of the reply's
+// PostCard so feed readers have conversation context. Visually distinct from
+// QuoteEmbed (which is for explicit quotes) by using a subdued background and
+// a "Replying to" label.
+export function ReplyParentEmbed({ post }: { post: Post }) {
+  const handle = post.author.handle
+  const content = (
+    <div className="mb-2 overflow-hidden rounded-md border border-border/60 bg-muted/30 transition hover:bg-muted/50">
+      <div className="px-3 py-2">
+        <div className="flex items-center gap-1 text-xs text-muted-foreground">
+          <ChatCircleIcon size={12} />
+          <span>
+            Replying to{" "}
+            {handle ? (
+              <span className="font-medium text-foreground">@{handle}</span>
+            ) : (
+              <span className="font-medium text-foreground">unknown</span>
+            )}
+          </span>
+          <span>·</span>
+          <time dateTime={post.createdAt}>{relativeTime(post.createdAt)}</time>
+        </div>
+        {post.text && (
+          <p className="mt-1 line-clamp-3 text-sm leading-snug break-words whitespace-pre-wrap text-muted-foreground">
+            {post.text}
+          </p>
+        )}
+      </div>
+    </div>
+  )
+  if (handle) {
+    return (
+      <Link
+        to="/$handle/p/$id"
+        params={{ handle, id: post.id }}
+        className="block"
+        data-post-card-ignore-open
+      >
+        {content}
+      </Link>
+    )
+  }
+  return content
+}
+
 export function QuoteEmbed({ post }: { post: Post }) {
   const handle = post.author.handle
   const thumb = post.media?.find((m) => m.processingState === "ready")
@@ -679,9 +724,12 @@ export function PostCard({
               </div>
             </div>
           ) : post.articleCard ? null : (
-            <p className="wrap-break-words mt-1 text-[15px] leading-relaxed whitespace-pre-wrap">
-              <RichText text={post.text} />
-            </p>
+            <>
+              {post.replyParent && <ReplyParentEmbed post={post.replyParent} />}
+              <p className="wrap-break-words mt-1 text-[15px] leading-relaxed whitespace-pre-wrap">
+                <RichText text={post.text} />
+              </p>
+            </>
           )}
           {!editing && <MacfolioCardFromText text={post.text} />}
           {post.articleCard && <ArticleCardBlock card={post.articleCard} />}

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -603,6 +603,9 @@ export interface Post {
   repostOf?: Post
   /** Populated on quote rows: the post being quoted, rendered as a bordered embed below the text. */
   quoteOf?: Post
+  /** Populated on reply rows: the parent post this row is replying to, rendered as a small
+   *  embed above the post so feed readers have conversation context. Not recursive. */
+  replyParent?: Post
   /** Set when this row is the pinned post on a profile feed. */
   pinned?: boolean
   /** Optional poll attached to this post. */


### PR DESCRIPTION
## Summary

- Added `attachReplyParents()` function to batch-load and attach parent posts to replies, providing conversation context in feeds
- Created `ReplyParentEmbed` component to render parent posts as compact, visually distinct embeds above replies
- Integrated reply parent loading into all post feed endpoints (feed, posts, hashtags, lists, search, user profiles, bookmarks)

## Test plan

- [ ] `bun run typecheck` passes
- [ ] Manually verified replies display parent post context in feed
- [ ] Verified parent post embeds are clickable and navigate correctly
- [ ] Verified no console/network errors when viewing feeds with mixed reply and non-reply posts

## Notes

- Reply parents are not recursive: the embedded parent post does not itself carry a `replyParent`
- Parent posts that have been deleted are excluded from the embed (gracefully skipped)
- The feature integrates with existing repost/quote handling: for reposts of replies, the parent is attached to the inner post

https://claude.ai/code/session_01NqgvsXtsLeAFsrdAQCjCCk