### PR TITLE
Add analytics tracking for user actions across the app

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -72,6 +72,8 @@ REDIS_URL=redis://localhost:6379
 VITE_PUBLIC_API_URL=http://localhost:3001
 VITE_PUBLIC_WEB_URL=http://localhost:3000
 VITE_PUBLIC_APP_NAME=twotter
+# Databuddy analytics client ID (from https://app.databuddy.cc). Leave blank to disable.
+VITE_PUBLIC_DATABUDDY_CLIENT_ID=
 
 # ---------- Anti-abuse ----------
 TURNSTILE_SITE_KEY=

--- a/.env.example
+++ b/.env.example
@@ -70,10 +70,10 @@ REDIS_URL=redis://localhost:6379
 
 # ---------- Web (Vite: only VITE_* is exposed to the client; set these in the env file the web app uses) ----------
 VITE_PUBLIC_API_URL=http://localhost:3001
-VITE_PUBLIC_WEB_URL=http://localhost:3000
 VITE_PUBLIC_APP_NAME=twotter
 # Databuddy analytics client ID (from https://app.databuddy.cc). Leave blank to disable.
 VITE_PUBLIC_DATABUDDY_CLIENT_ID=
+VITE_PUBLIC_WEB_URL=http://localhost:3000
 
 # ---------- Anti-abuse ----------
 TURNSTILE_SITE_KEY=

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -13,6 +13,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@databuddy/sdk": "^2.4.11",
     "@lexical/code": "^0.37.0",
     "@lexical/link": "^0.37.0",
     "@lexical/list": "^0.37.0",

--- a/apps/web/src/components/chat-widget.tsx
+++ b/apps/web/src/components/chat-widget.tsx
@@ -11,6 +11,7 @@ import {
 import { Link } from "@tanstack/react-router"
 import { Button } from "@workspace/ui/components/button"
 import { Input } from "@workspace/ui/components/input"
+import { trackedAction } from "../lib/analytics"
 import { api } from "../lib/api"
 import { getPastedImageFiles } from "../lib/clipboard-images"
 import { subscribeToDmStream } from "../lib/dm-stream"
@@ -310,10 +311,19 @@ function ChatView({
         const media = await uploadImage(pending.file)
         mediaId = media.id
       }
-      const { message } = await api.dmSend(conversation.id, {
-        text: trimmed || undefined,
-        mediaId,
-      })
+      const { message } = await trackedAction(
+        "dm_sent",
+        () =>
+          api.dmSend(conversation.id, {
+            text: trimmed || undefined,
+            mediaId,
+          }),
+        () => ({
+          conversation_id: conversation.id,
+          has_text: !!trimmed,
+          has_media: !!mediaId,
+        }),
+      )
       setMessages((prev) => [...prev, message])
       setText("")
       clearPending()

--- a/apps/web/src/components/claim-handle.tsx
+++ b/apps/web/src/components/claim-handle.tsx
@@ -28,7 +28,7 @@ export function ClaimHandle({
       const { user } = await trackedAction(
         "handle_claimed",
         () => api.claimHandle(handle),
-        ({ user }) => ({ handle: user.handle ?? handle }),
+        (res) => ({ handle: res.user.handle ?? handle }),
       )
       if (user.handle) onClaimed(user.handle)
     } catch (err) {

--- a/apps/web/src/components/claim-handle.tsx
+++ b/apps/web/src/components/claim-handle.tsx
@@ -3,6 +3,7 @@ import { Button } from "@workspace/ui/components/button"
 import { Input } from "@workspace/ui/components/input"
 import { Label } from "@workspace/ui/components/label"
 import { handleSchema } from "@workspace/validators"
+import { trackedAction } from "../lib/analytics"
 import { ApiError, api } from "../lib/api"
 
 export function ClaimHandle({
@@ -24,7 +25,11 @@ export function ClaimHandle({
     }
     setLoading(true)
     try {
-      const { user } = await api.claimHandle(handle)
+      const { user } = await trackedAction(
+        "handle_claimed",
+        () => api.claimHandle(handle),
+        ({ user }) => ({ handle: user.handle ?? handle }),
+      )
       if (user.handle) onClaimed(user.handle)
     } catch (err) {
       if (err instanceof ApiError) {

--- a/apps/web/src/components/compose.tsx
+++ b/apps/web/src/components/compose.tsx
@@ -18,6 +18,7 @@ import {
   POLL_OPTION_MAX_LEN,
   POST_MAX_LEN,
 } from "@workspace/validators"
+import { trackedAction } from "../lib/analytics"
 import { ApiError, api } from "../lib/api"
 import { setAltText, uploadImage } from "../lib/media"
 import { getPastedImageFiles } from "../lib/clipboard-images"
@@ -231,14 +232,26 @@ export function Compose({
             allowMultiple: poll.allowMultiple,
           }
         : undefined
-      const { post } = await api.createPost({
-        text: text.trim(),
-        replyToId,
-        quoteOfId,
-        mediaIds: readyMediaIds.length > 0 ? readyMediaIds : undefined,
-        poll: pollPayload,
-        replyRestriction: showReplyControl ? replyRestriction : undefined,
-      })
+      const { post } = await trackedAction(
+        "post_created",
+        () =>
+          api.createPost({
+            text: text.trim(),
+            replyToId,
+            quoteOfId,
+            mediaIds: readyMediaIds.length > 0 ? readyMediaIds : undefined,
+            poll: pollPayload,
+            replyRestriction: showReplyControl ? replyRestriction : undefined,
+          }),
+        ({ post: p }) => ({
+          post_id: p.id,
+          is_reply: !!replyToId,
+          is_quote: !!quoteOfId,
+          media_count: readyMediaIds.length,
+          char_count: text.trim().length,
+          has_poll: !!pollPayload,
+        }),
+      )
       setText("")
       clearDraft(dKey)
       attachments.forEach((a) => URL.revokeObjectURL(a.previewUrl))

--- a/apps/web/src/components/edit-post-dialog.tsx
+++ b/apps/web/src/components/edit-post-dialog.tsx
@@ -8,6 +8,7 @@ import {
 } from "@workspace/ui/components/dialog"
 import { Textarea } from "@workspace/ui/components/textarea"
 import { POST_MAX_LEN } from "@workspace/validators"
+import { trackedAction } from "../lib/analytics"
 import { ApiError, api } from "../lib/api"
 import type { Post } from "../lib/api"
 
@@ -46,7 +47,11 @@ export function EditPostDialog({
     setBusy(true)
     setError(null)
     try {
-      const { post: updated } = await api.editPost(post.id, text)
+      const { post: updated } = await trackedAction(
+        "post_edited",
+        () => api.editPost(post.id, text),
+        () => ({ post_id: post.id, char_count: text.length }),
+      )
       onSaved(updated)
       onOpenChange(false)
     } catch (e) {

--- a/apps/web/src/components/poll-block.tsx
+++ b/apps/web/src/components/poll-block.tsx
@@ -4,6 +4,7 @@ import {
   RadioGroup,
   RadioGroupItem,
 } from "@workspace/ui/components/radio-group"
+import { trackedAction } from "../lib/analytics"
 import { ApiError, api } from "../lib/api"
 import { authClient } from "../lib/auth"
 import type { PollDto } from "../lib/api"
@@ -61,7 +62,15 @@ export function PollBlock({
     setError(null)
     try {
       const optionIds = [...selected]
-      await api.votePoll(poll.id, optionIds)
+      await trackedAction(
+        "poll_voted",
+        () => api.votePoll(poll.id, optionIds),
+        () => ({
+          poll_id: poll.id,
+          option_count: optionIds.length,
+          allow_multiple: poll.allowMultiple,
+        }),
+      )
       // Optimistically update the poll: bump counts, mark viewer's vote, increment total.
       const optionSet = new Set(optionIds)
       onChange?.({

--- a/apps/web/src/components/post-card.tsx
+++ b/apps/web/src/components/post-card.tsx
@@ -24,7 +24,7 @@ import {
   DialogTitle,
 } from "@workspace/ui/components/dialog"
 import { POST_MAX_LEN } from "@workspace/validators"
-import { recordImpression } from "../lib/analytics"
+import { recordImpression, trackedAction } from "../lib/analytics"
 import { ApiError, api } from "../lib/api"
 import { RichText } from "./rich-text"
 import { MacfolioCardFromText } from "./macfolio-card"
@@ -368,7 +368,11 @@ export function PostCard({
     setBusy(true)
     setEditError(null)
     try {
-      const { post: updated } = await api.editPost(post.id, editText)
+      const { post: updated } = await trackedAction(
+        "post_edited",
+        () => api.editPost(post.id, editText),
+        () => ({ post_id: post.id, char_count: editText.length }),
+      )
       emit(updated)
       setEditing(false)
     } catch (e) {
@@ -400,17 +404,22 @@ export function PostCard({
   function toggleLike() {
     if (busy || !post.viewer) return
     const liked = !post.viewer.liked
+    const props = () => ({ post_id: post.id, author_id: post.author.id })
     optimistic(
       {
         counts: { ...post.counts, likes: post.counts.likes + (liked ? 1 : -1) },
         viewer: { ...post.viewer, liked },
       },
-      () => (liked ? api.like(post.id) : api.unlike(post.id))
+      () =>
+        liked
+          ? trackedAction("post_liked", () => api.like(post.id), props)
+          : trackedAction("post_unliked", () => api.unlike(post.id), props),
     )
   }
   function toggleBookmark() {
     if (busy || !post.viewer) return
     const bookmarked = !post.viewer.bookmarked
+    const props = () => ({ post_id: post.id, author_id: post.author.id })
     optimistic(
       {
         counts: {
@@ -419,12 +428,20 @@ export function PostCard({
         },
         viewer: { ...post.viewer, bookmarked },
       },
-      () => (bookmarked ? api.bookmark(post.id) : api.unbookmark(post.id))
+      () =>
+        bookmarked
+          ? trackedAction("post_bookmarked", () => api.bookmark(post.id), props)
+          : trackedAction(
+              "post_unbookmarked",
+              () => api.unbookmark(post.id),
+              props,
+            ),
     )
   }
   function toggleRepost() {
     if (busy || !post.viewer) return
     const reposted = !post.viewer.reposted
+    const props = () => ({ post_id: post.id, author_id: post.author.id })
     optimistic(
       {
         counts: {
@@ -433,7 +450,10 @@ export function PostCard({
         },
         viewer: { ...post.viewer, reposted },
       },
-      () => (reposted ? api.repost(post.id) : api.unrepost(post.id))
+      () =>
+        reposted
+          ? trackedAction("post_reposted", () => api.repost(post.id), props)
+          : trackedAction("post_unreposted", () => api.unrepost(post.id), props),
     )
   }
 

--- a/apps/web/src/components/post-menu.tsx
+++ b/apps/web/src/components/post-menu.tsx
@@ -61,7 +61,7 @@ export function PostMenu({
         () => api.deletePost(post.id),
         () => ({
           post_id: post.id,
-          author_is_self: post.author.id === session.user.id,
+          author_is_self: post.author.id === session?.user.id,
         }),
       )
       onRemove?.()
@@ -73,6 +73,8 @@ export function PostMenu({
   }
 
   async function togglePin() {
+    if (busy) return
+    setBusy(true)
     try {
       if (post.pinned) {
         await trackedAction(
@@ -90,10 +92,14 @@ export function PostMenu({
       onChange?.({ ...post, pinned: !post.pinned })
     } catch {
       /* surfaced via stale state on refresh */
+    } finally {
+      setBusy(false)
     }
   }
 
   async function toggleHide() {
+    if (busy) return
+    setBusy(true)
     try {
       if (post.hidden) {
         await trackedAction(
@@ -111,6 +117,8 @@ export function PostMenu({
       onChange?.({ ...post, hidden: !post.hidden })
     } catch {
       /* surfaced via stale state on refresh */
+    } finally {
+      setBusy(false)
     }
   }
 

--- a/apps/web/src/components/post-menu.tsx
+++ b/apps/web/src/components/post-menu.tsx
@@ -15,6 +15,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@workspace/ui/components/dropdown-menu"
+import { trackedAction } from "../lib/analytics"
 import { ApiError, api } from "../lib/api"
 import { authClient } from "../lib/auth"
 import { ReportDialog } from "./report-dialog"
@@ -55,7 +56,14 @@ export function PostMenu({
     if (!confirm("Delete this post?")) return
     setBusy(true)
     try {
-      await api.deletePost(post.id)
+      await trackedAction(
+        "post_deleted",
+        () => api.deletePost(post.id),
+        () => ({
+          post_id: post.id,
+          author_is_self: post.author.id === session?.user?.id,
+        }),
+      )
       onRemove?.()
     } catch (e) {
       alert(e instanceof ApiError ? e.message : "delete failed")
@@ -66,8 +74,19 @@ export function PostMenu({
 
   async function togglePin() {
     try {
-      if (post.pinned) await api.unpinPost(post.id)
-      else await api.pinPost(post.id)
+      if (post.pinned) {
+        await trackedAction(
+          "post_unpinned",
+          () => api.unpinPost(post.id),
+          () => ({ post_id: post.id }),
+        )
+      } else {
+        await trackedAction(
+          "post_pinned",
+          () => api.pinPost(post.id),
+          () => ({ post_id: post.id }),
+        )
+      }
       onChange?.({ ...post, pinned: !post.pinned })
     } catch {
       /* surfaced via stale state on refresh */
@@ -76,8 +95,19 @@ export function PostMenu({
 
   async function toggleHide() {
     try {
-      if (post.hidden) await api.unhidePost(post.id)
-      else await api.hidePost(post.id)
+      if (post.hidden) {
+        await trackedAction(
+          "post_unhidden",
+          () => api.unhidePost(post.id),
+          () => ({ post_id: post.id }),
+        )
+      } else {
+        await trackedAction(
+          "post_hidden",
+          () => api.hidePost(post.id),
+          () => ({ post_id: post.id }),
+        )
+      }
       onChange?.({ ...post, hidden: !post.hidden })
     } catch {
       /* surfaced via stale state on refresh */

--- a/apps/web/src/components/post-menu.tsx
+++ b/apps/web/src/components/post-menu.tsx
@@ -61,7 +61,7 @@ export function PostMenu({
         () => api.deletePost(post.id),
         () => ({
           post_id: post.id,
-          author_is_self: post.author.id === session?.user?.id,
+          author_is_self: post.author.id === session.user.id,
         }),
       )
       onRemove?.()

--- a/apps/web/src/components/profile-actions.tsx
+++ b/apps/web/src/components/profile-actions.tsx
@@ -14,6 +14,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@workspace/ui/components/dropdown-menu"
+import { trackedAction } from "../lib/analytics"
 import { api } from "../lib/api"
 import { ReportDialog } from "./report-dialog"
 import type { PublicProfile } from "../lib/api"
@@ -39,7 +40,11 @@ export function ProfileActions({
     if (busy) return
     setBusy("message")
     try {
-      const { id } = await api.dmStart(profile.id)
+      const { id } = await trackedAction(
+        "dm_started",
+        () => api.dmStart(profile.id),
+        ({ id }) => ({ target_user_id: profile.id, conversation_id: id }),
+      )
       router.navigate({
         to: "/inbox/$conversationId",
         params: { conversationId: id },
@@ -96,7 +101,16 @@ export function ProfileActions({
           run(
             "follow",
             !v.following,
-            () => (v.following ? api.unfollow(h) : api.follow(h)),
+            () =>
+              v.following
+                ? trackedAction("user_unfollowed", () => api.unfollow(h), () => ({
+                    target_user_id: profile.id,
+                    target_handle: h,
+                  }))
+                : trackedAction("user_followed", () => api.follow(h), () => ({
+                    target_user_id: profile.id,
+                    target_handle: h,
+                  })),
             "following",
             v.following ? -1 : 1
           )
@@ -118,7 +132,17 @@ export function ProfileActions({
               run(
                 "mute",
                 !v.muting,
-                () => (v.muting ? api.unmute(h) : api.mute(h)),
+                () =>
+                  v.muting
+                    ? trackedAction("user_unmuted", () => api.unmute(h), () => ({
+                        target_user_id: profile.id,
+                        target_handle: h,
+                      }))
+                    : trackedAction("user_muted", () => api.mute(h), () => ({
+                        target_user_id: profile.id,
+                        target_handle: h,
+                        scope: "feed",
+                      })),
                 "muting"
               )
             }
@@ -137,7 +161,16 @@ export function ProfileActions({
               run(
                 "block",
                 !v.blocking,
-                () => (v.blocking ? api.unblock(h) : api.block(h)),
+                () =>
+                  v.blocking
+                    ? trackedAction("user_unblocked", () => api.unblock(h), () => ({
+                        target_user_id: profile.id,
+                        target_handle: h,
+                      }))
+                    : trackedAction("user_blocked", () => api.block(h), () => ({
+                        target_user_id: profile.id,
+                        target_handle: h,
+                      })),
                 "blocking"
               )
             }}

--- a/apps/web/src/components/profile-actions.tsx
+++ b/apps/web/src/components/profile-actions.tsx
@@ -43,7 +43,7 @@ export function ProfileActions({
       const { id } = await trackedAction(
         "dm_started",
         () => api.dmStart(profile.id),
-        ({ id }) => ({ target_user_id: profile.id, conversation_id: id }),
+        (res) => ({ target_user_id: profile.id, conversation_id: res.id }),
       )
       router.navigate({
         to: "/inbox/$conversationId",

--- a/apps/web/src/components/report-dialog.tsx
+++ b/apps/web/src/components/report-dialog.tsx
@@ -11,6 +11,7 @@ import {
   RadioGroupItem,
 } from "@workspace/ui/components/radio-group"
 import { Textarea } from "@workspace/ui/components/textarea"
+import { trackedAction } from "../lib/analytics"
 import { ApiError, api } from "../lib/api"
 import type { ReportReason } from "../lib/api"
 
@@ -82,12 +83,22 @@ export function ReportDialog({
     setBusy(true)
     setStatus(null)
     try {
-      const res = await api.report({
-        subjectType,
-        subjectId,
-        reason,
-        details: details.trim().length > 0 ? details.trim() : undefined,
-      })
+      const res = await trackedAction(
+        "content_reported",
+        () =>
+          api.report({
+            subjectType,
+            subjectId,
+            reason,
+            details: details.trim().length > 0 ? details.trim() : undefined,
+          }),
+        () => ({
+          subject_type: subjectType,
+          subject_id: subjectId,
+          reason,
+          has_details: details.trim().length > 0,
+        }),
+      )
       setStatus(
         res.deduped
           ? "You've already reported this — thanks. Mods will take a look."

--- a/apps/web/src/lib/analytics.ts
+++ b/apps/web/src/lib/analytics.ts
@@ -1,4 +1,75 @@
+import { track } from "@databuddy/sdk"
+
 import { API_URL } from "./env"
+
+export { track }
+
+type EventName =
+  | "post_created"
+  | "post_deleted"
+  | "post_edited"
+  | "post_liked"
+  | "post_unliked"
+  | "post_reposted"
+  | "post_unreposted"
+  | "post_bookmarked"
+  | "post_unbookmarked"
+  | "post_pinned"
+  | "post_unpinned"
+  | "post_hidden"
+  | "post_unhidden"
+  | "user_followed"
+  | "user_unfollowed"
+  | "user_blocked"
+  | "user_unblocked"
+  | "user_muted"
+  | "user_unmuted"
+  | "handle_claimed"
+  | "profile_updated"
+  | "dm_sent"
+  | "dm_started"
+  | "dm_group_created"
+  | "dm_message_edited"
+  | "dm_message_deleted"
+  | "dm_reaction_toggled"
+  | "dm_members_added"
+  | "dm_member_removed"
+  | "article_created"
+  | "article_updated"
+  | "scheduled_post_published"
+  | "list_created"
+  | "list_deleted"
+  | "list_members_added"
+  | "list_member_removed"
+  | "poll_voted"
+  | "search_saved"
+  | "search_saved_deleted"
+  | "chess_game_created"
+  | "content_reported"
+  | "admin_user_banned"
+  | "admin_user_unbanned"
+  | "admin_user_shadowbanned"
+  | "admin_user_unshadowbanned"
+  | "admin_user_verified"
+  | "admin_user_unverified"
+  | "admin_user_role_set"
+  | "admin_user_handle_set"
+  | "admin_user_deleted"
+  | "admin_report_resolved"
+
+export async function trackedAction<T>(
+  name: EventName,
+  fn: () => Promise<T>,
+  getProps?: (result: T) => Record<string, unknown>,
+): Promise<T> {
+  const result = await fn()
+  try {
+    track(name, getProps?.(result) ?? {})
+  } catch {
+    /* analytics never breaks UX */
+  }
+  return result
+}
 
 interface ImpressionEvent {
   kind: "impression"

--- a/apps/web/src/lib/env.ts
+++ b/apps/web/src/lib/env.ts
@@ -3,3 +3,5 @@ export const API_URL =
 export const WEB_URL =
   import.meta.env.VITE_PUBLIC_WEB_URL ?? "http://localhost:3000"
 export const APP_NAME = import.meta.env.VITE_PUBLIC_APP_NAME ?? "twotter"
+export const DATABUDDY_CLIENT_ID = import.meta.env
+  .VITE_PUBLIC_DATABUDDY_CLIENT_ID as string | undefined

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -6,6 +6,7 @@ import {
   createRootRoute,
 } from "@tanstack/react-router"
 import { IconContext } from "@phosphor-icons/react"
+import { Databuddy } from "@databuddy/sdk/react"
 
 import appCss from "@workspace/ui/globals.css?url"
 import { Button } from "@workspace/ui/components/button"
@@ -13,7 +14,7 @@ import { AppShell } from "../components/app-shell"
 import { NotFoundPanel } from "../components/page-surface"
 import { PageFrame } from "../components/page-frame"
 import { ThemeProvider, themeBootstrapScript } from "../lib/theme"
-import { APP_NAME } from "../lib/env"
+import { APP_NAME, DATABUDDY_CLIENT_ID } from "../lib/env"
 import { MeProvider } from "../lib/me"
 import { QueryProvider } from "../lib/query"
 import { buildSeoMeta } from "../lib/seo"
@@ -82,6 +83,13 @@ export const Route = createRootRoute({
             <AppShell>
               <Outlet />
             </AppShell>
+            {DATABUDDY_CLIENT_ID ? (
+              <Databuddy
+                clientId={DATABUDDY_CLIENT_ID}
+                trackWebVitals
+                trackErrors
+              />
+            ) : null}
           </MeProvider>
         </ThemeProvider>
       </QueryProvider>

--- a/apps/web/src/routes/admin.reports.tsx
+++ b/apps/web/src/routes/admin.reports.tsx
@@ -23,6 +23,7 @@ import {
   TableHeader,
   TableRow,
 } from "@workspace/ui/components/table"
+import { trackedAction } from "../lib/analytics"
 import { api } from "../lib/api"
 import { useInfiniteScrollSentinel } from "../lib/use-infinite-scroll-sentinel"
 import { Avatar } from "../components/avatar"
@@ -301,10 +302,19 @@ function ReportSheet({
     if (!detail) return
     setBusy(next)
     try {
-      await api.adminResolveReport(detail.id, {
-        status: next,
-        resolutionNote: note.trim() || undefined,
-      })
+      await trackedAction(
+        "admin_report_resolved",
+        () =>
+          api.adminResolveReport(detail.id, {
+            status: next,
+            resolutionNote: note.trim() || undefined,
+          }),
+        () => ({
+          report_id: detail.id,
+          resolution: next,
+          has_note: note.trim().length > 0,
+        }),
+      )
       onResolved()
     } finally {
       setBusy(null)

--- a/apps/web/src/routes/admin.users.tsx
+++ b/apps/web/src/routes/admin.users.tsx
@@ -35,6 +35,7 @@ import {
   TableRow,
 } from "@workspace/ui/components/table"
 import { CaretDownIcon } from "@phosphor-icons/react"
+import { trackedAction } from "../lib/analytics"
 import { api } from "../lib/api"
 import { useInfiniteScrollSentinel } from "../lib/use-infinite-scroll-sentinel"
 import { useMe } from "../lib/me"
@@ -219,7 +220,13 @@ function AdminUsers() {
                       disabled={r === u.role}
                       onClick={() =>
                         r !== u.role &&
-                        act(u.id, () => api.adminSetRole(u.id, r))
+                        act(u.id, () =>
+                          trackedAction(
+                            "admin_user_role_set",
+                            () => api.adminSetRole(u.id, r),
+                            () => ({ target_user_id: u.id, role: r }),
+                          ),
+                        )
                       }
                     >
                       <span className="tracking-wider uppercase">{r}</span>
@@ -280,7 +287,15 @@ function AdminUsers() {
                   size="sm"
                   variant="outline"
                   disabled={busyId === u.id}
-                  onClick={() => act(u.id, () => api.adminUnban(u.id))}
+                  onClick={() =>
+                    act(u.id, () =>
+                      trackedAction(
+                        "admin_user_unbanned",
+                        () => api.adminUnban(u.id),
+                        () => ({ target_user_id: u.id }),
+                      ),
+                    )
+                  }
                 >
                   Unban
                 </Button>
@@ -299,7 +314,15 @@ function AdminUsers() {
                   size="sm"
                   variant="outline"
                   disabled={busyId === u.id}
-                  onClick={() => act(u.id, () => api.adminUnshadowban(u.id))}
+                  onClick={() =>
+                    act(u.id, () =>
+                      trackedAction(
+                        "admin_user_unshadowbanned",
+                        () => api.adminUnshadowban(u.id),
+                        () => ({ target_user_id: u.id }),
+                      ),
+                    )
+                  }
                 >
                   Unshadow
                 </Button>
@@ -532,10 +555,19 @@ function ActionDialog({
           hours.trim() && Number.isFinite(Number(hours))
             ? Number(hours)
             : undefined
-        return api.adminBan(u.id, {
-          reason: reason.trim() || undefined,
-          durationHours,
-        })
+        return trackedAction(
+          "admin_user_banned",
+          () =>
+            api.adminBan(u.id, {
+              reason: reason.trim() || undefined,
+              durationHours,
+            }),
+          () => ({
+            target_user_id: u.id,
+            has_reason: reason.trim().length > 0,
+            duration_hours: durationHours ?? null,
+          }),
+        )
       },
     },
     shadow: {
@@ -546,7 +578,15 @@ function ActionDialog({
       submitVariant: "default" as const,
       showDuration: false,
       run: () =>
-        api.adminShadowban(u.id, { reason: reason.trim() || undefined }),
+        trackedAction(
+          "admin_user_shadowbanned",
+          () =>
+            api.adminShadowban(u.id, { reason: reason.trim() || undefined }),
+          () => ({
+            target_user_id: u.id,
+            has_reason: reason.trim().length > 0,
+          }),
+        ),
     },
     verify: {
       title: u.isVerified
@@ -560,8 +600,16 @@ function ActionDialog({
       showDuration: false,
       run: () =>
         u.isVerified
-          ? api.adminUnverify(u.id, reason.trim() || undefined)
-          : api.adminVerify(u.id, reason.trim() || undefined),
+          ? trackedAction(
+              "admin_user_unverified",
+              () => api.adminUnverify(u.id, reason.trim() || undefined),
+              () => ({ target_user_id: u.id }),
+            )
+          : trackedAction(
+              "admin_user_verified",
+              () => api.adminVerify(u.id, reason.trim() || undefined),
+              () => ({ target_user_id: u.id }),
+            ),
     },
     handle: {
       title: `Change handle for ${subject}`,
@@ -571,10 +619,15 @@ function ActionDialog({
       submitVariant: "default" as const,
       showDuration: false,
       run: () =>
-        api.adminSetHandle(u.id, {
-          handle: handle.trim(),
-          reason: reason.trim() || undefined,
-        }),
+        trackedAction(
+          "admin_user_handle_set",
+          () =>
+            api.adminSetHandle(u.id, {
+              handle: handle.trim(),
+              reason: reason.trim() || undefined,
+            }),
+          () => ({ target_user_id: u.id }),
+        ),
     },
     delete: {
       title: `Delete account ${subject}`,
@@ -584,7 +637,15 @@ function ActionDialog({
       submitVariant: "destructive" as const,
       showDuration: false,
       run: () =>
-        api.adminDeleteUser(u.id, { reason: reason.trim() || undefined }),
+        trackedAction(
+          "admin_user_deleted",
+          () =>
+            api.adminDeleteUser(u.id, { reason: reason.trim() || undefined }),
+          () => ({
+            target_user_id: u.id,
+            has_reason: reason.trim().length > 0,
+          }),
+        ),
     },
   }[state.kind]
 

--- a/apps/web/src/routes/articles.$id.edit.tsx
+++ b/apps/web/src/routes/articles.$id.edit.tsx
@@ -2,6 +2,7 @@ import { createFileRoute, useRouter } from "@tanstack/react-router"
 import { useEffect, useMemo, useState } from "react"
 import { Button } from "@workspace/ui/components/button"
 import { Input } from "@workspace/ui/components/input"
+import { trackedAction } from "../lib/analytics"
 import { ApiError, api } from "../lib/api"
 import { authClient } from "../lib/auth"
 import { Editor } from "../components/editor/editor"
@@ -57,17 +58,22 @@ function EditArticle() {
     setSaving(status === "draft" ? "draft" : "publish")
     setError(null)
     try {
-      const { article: updated } = await api.updateArticle(article.id, {
-        title: title.trim(),
-        subtitle: subtitle.trim() || undefined,
-        bodyJson: body?.stateJson ?? article.bodyJson,
-        bodyText: body?.text ?? article.bodyText,
-        // `undefined` = leave alone, `null`/value = explicit change.
-        ...(coverMediaId !== undefined
-          ? { coverMediaId: coverMediaId ?? undefined }
-          : {}),
-        status,
-      })
+      const { article: updated } = await trackedAction(
+        "article_updated",
+        () =>
+          api.updateArticle(article.id, {
+            title: title.trim(),
+            subtitle: subtitle.trim() || undefined,
+            bodyJson: body?.stateJson ?? article.bodyJson,
+            bodyText: body?.text ?? article.bodyText,
+            // `undefined` = leave alone, `null`/value = explicit change.
+            ...(coverMediaId !== undefined
+              ? { coverMediaId: coverMediaId ?? undefined }
+              : {}),
+            status,
+          }),
+        ({ article: a }) => ({ article_id: a.id, status }),
+      )
       setArticle(updated)
       if (status === "published" && updated.author.handle) {
         router.navigate({

--- a/apps/web/src/routes/articles.new.tsx
+++ b/apps/web/src/routes/articles.new.tsx
@@ -47,8 +47,8 @@ function NewArticle() {
               coverMediaId: coverMediaId ?? undefined,
               status,
             }),
-          ({ article }) => ({
-            article_id: article.id,
+          (res) => ({
+            article_id: res.article.id,
             status,
             has_subtitle: subtitle.trim().length > 0,
             has_cover: coverMediaId !== null,

--- a/apps/web/src/routes/articles.new.tsx
+++ b/apps/web/src/routes/articles.new.tsx
@@ -2,6 +2,7 @@ import { createFileRoute, useRouter } from "@tanstack/react-router"
 import { useCallback, useEffect, useMemo, useState } from "react"
 import { Button } from "@workspace/ui/components/button"
 import { Input } from "@workspace/ui/components/input"
+import { trackedAction } from "../lib/analytics"
 import { ApiError, api } from "../lib/api"
 import { authClient } from "../lib/auth"
 import { usePageHeader } from "../components/app-page-header"
@@ -35,14 +36,24 @@ function NewArticle() {
       setSaving(status === "draft" ? "draft" : "publish")
       setError(null)
       try {
-        const { article } = await api.createArticle({
-          title: title.trim(),
-          subtitle: subtitle.trim() || undefined,
-          bodyJson: body.stateJson,
-          bodyText: body.text,
-          coverMediaId: coverMediaId ?? undefined,
-          status,
-        })
+        const { article } = await trackedAction(
+          "article_created",
+          () =>
+            api.createArticle({
+              title: title.trim(),
+              subtitle: subtitle.trim() || undefined,
+              bodyJson: body.stateJson,
+              bodyText: body.text,
+              coverMediaId: coverMediaId ?? undefined,
+              status,
+            }),
+          ({ article }) => ({
+            article_id: article.id,
+            status,
+            has_subtitle: subtitle.trim().length > 0,
+            has_cover: coverMediaId !== null,
+          }),
+        )
         if (status === "published" && article.author.handle) {
           router.navigate({
             to: "/$handle/a/$slug",

--- a/apps/web/src/routes/drafts.tsx
+++ b/apps/web/src/routes/drafts.tsx
@@ -2,6 +2,7 @@ import { createFileRoute, useRouter } from "@tanstack/react-router"
 import { useCallback, useEffect, useMemo, useState } from "react"
 import { Button } from "@workspace/ui/components/button"
 import { Input } from "@workspace/ui/components/input"
+import { trackedAction } from "../lib/analytics"
 import { ApiError, api } from "../lib/api"
 import { authClient } from "../lib/auth"
 import { usePageHeader } from "../components/app-page-header"
@@ -49,7 +50,11 @@ function Drafts() {
   async function publish(id: string) {
     setBusyId(id)
     try {
-      await api.publishScheduledPost(id)
+      await trackedAction(
+        "scheduled_post_published",
+        () => api.publishScheduledPost(id),
+        () => ({ scheduled_post_id: id }),
+      )
       await refresh()
     } catch (e) {
       setError(e instanceof ApiError ? e.message : "publish failed")

--- a/apps/web/src/routes/inbox.$conversationId.tsx
+++ b/apps/web/src/routes/inbox.$conversationId.tsx
@@ -24,6 +24,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@workspace/ui/components/dropdown-menu"
+import { trackedAction } from "../lib/analytics"
 import { api } from "../lib/api"
 import { authClient } from "../lib/auth"
 import { getPastedImageFiles } from "../lib/clipboard-images"
@@ -925,7 +926,15 @@ function Bubble({
     }
     setBusy(true)
     try {
-      await api.dmEditMessage(conversationId, message.id, next)
+      await trackedAction(
+        "dm_message_edited",
+        () => api.dmEditMessage(conversationId, message.id, next),
+        () => ({
+          conversation_id: conversationId,
+          message_id: message.id,
+          char_count: next.length,
+        }),
+      )
       setEditing(false)
     } finally {
       setBusy(false)
@@ -935,7 +944,11 @@ function Bubble({
     if (!window.confirm("Delete this message?")) return
     setBusy(true)
     try {
-      await api.dmDeleteMessage(conversationId, message.id)
+      await trackedAction(
+        "dm_message_deleted",
+        () => api.dmDeleteMessage(conversationId, message.id),
+        () => ({ conversation_id: conversationId, message_id: message.id }),
+      )
     } finally {
       setBusy(false)
     }
@@ -943,7 +956,15 @@ function Bubble({
   async function react(emoji: string) {
     setShowPicker(false)
     try {
-      await api.dmToggleReaction(conversationId, message.id, emoji)
+      await trackedAction(
+        "dm_reaction_toggled",
+        () => api.dmToggleReaction(conversationId, message.id, emoji),
+        () => ({
+          conversation_id: conversationId,
+          message_id: message.id,
+          emoji,
+        }),
+      )
     } catch {
       /* network blip — server is source of truth */
     }
@@ -1316,7 +1337,11 @@ function GroupSettingsDialog({
     if (busy) return
     setBusy(true)
     try {
-      await api.dmAddMembers(conversation.id, [u.id])
+      await trackedAction(
+        "dm_members_added",
+        () => api.dmAddMembers(conversation.id, [u.id]),
+        () => ({ conversation_id: conversation.id, added_count: 1 }),
+      )
       setSearch("")
       setResults([])
       await refresh()
@@ -1329,7 +1354,14 @@ function GroupSettingsDialog({
     if (busy) return
     setBusy(true)
     try {
-      await api.dmRemoveMember(conversation.id, userId)
+      await trackedAction(
+        "dm_member_removed",
+        () => api.dmRemoveMember(conversation.id, userId),
+        () => ({
+          conversation_id: conversation.id,
+          removed_user_id: userId,
+        }),
+      )
       await refresh()
     } finally {
       setBusy(false)

--- a/apps/web/src/routes/inbox.new.tsx
+++ b/apps/web/src/routes/inbox.new.tsx
@@ -4,6 +4,7 @@ import { XIcon } from "@phosphor-icons/react"
 import { Button } from "@workspace/ui/components/button"
 import { Input } from "@workspace/ui/components/input"
 import { Label } from "@workspace/ui/components/label"
+import { trackedAction } from "../lib/analytics"
 import { api } from "../lib/api"
 import { Avatar } from "../components/avatar"
 import { usePageHeader } from "../components/app-page-header"
@@ -66,8 +67,20 @@ function NewConversation() {
       const first = ids[0]
       const { id } =
         ids.length === 1 && first
-          ? await api.dmStart(first)
-          : await api.dmCreateGroup(ids, title.trim() || undefined)
+          ? await trackedAction(
+              "dm_started",
+              () => api.dmStart(first),
+              ({ id }) => ({ target_user_id: first, conversation_id: id }),
+            )
+          : await trackedAction(
+              "dm_group_created",
+              () => api.dmCreateGroup(ids, title.trim() || undefined),
+              ({ id }) => ({
+                conversation_id: id,
+                member_count: ids.length,
+                has_title: title.trim().length > 0,
+              }),
+            )
       router.navigate({
         to: "/inbox/$conversationId",
         params: { conversationId: id },

--- a/apps/web/src/routes/inbox.new.tsx
+++ b/apps/web/src/routes/inbox.new.tsx
@@ -70,13 +70,13 @@ function NewConversation() {
           ? await trackedAction(
               "dm_started",
               () => api.dmStart(first),
-              ({ id }) => ({ target_user_id: first, conversation_id: id }),
+              (res) => ({ target_user_id: first, conversation_id: res.id }),
             )
           : await trackedAction(
               "dm_group_created",
               () => api.dmCreateGroup(ids, title.trim() || undefined),
-              ({ id }) => ({
-                conversation_id: id,
+              (res) => ({
+                conversation_id: res.id,
                 member_count: ids.length,
                 has_title: title.trim().length > 0,
               }),

--- a/apps/web/src/routes/lists.$id.tsx
+++ b/apps/web/src/routes/lists.$id.tsx
@@ -4,6 +4,7 @@ import { LockIcon, TrashIcon, XIcon } from "@phosphor-icons/react"
 import { Button } from "@workspace/ui/components/button"
 import { Input } from "@workspace/ui/components/input"
 import { Label } from "@workspace/ui/components/label"
+import { trackedAction } from "../lib/analytics"
 import { ApiError, api } from "../lib/api"
 import { authClient } from "../lib/auth"
 import { usePageHeader } from "../components/app-page-header"
@@ -55,7 +56,11 @@ function ListDetail() {
   const removeList = useCallback(async () => {
     if (!confirm("Delete this list?")) return
     try {
-      await api.deleteList(id)
+      await trackedAction(
+        "list_deleted",
+        () => api.deleteList(id),
+        () => ({ list_id: id }),
+      )
       router.navigate({ to: "/lists" })
     } catch (e) {
       setError(e instanceof ApiError ? e.message : "delete failed")
@@ -186,7 +191,11 @@ function ManageMembers({
   async function add(userId: string) {
     setBusy(true)
     try {
-      await api.addListMembers(listId, [userId])
+      await trackedAction(
+        "list_members_added",
+        () => api.addListMembers(listId, [userId]),
+        () => ({ list_id: listId, added_count: 1 }),
+      )
       await onChanged()
     } finally {
       setBusy(false)
@@ -195,7 +204,11 @@ function ManageMembers({
   async function remove(userId: string) {
     setBusy(true)
     try {
-      await api.removeListMember(listId, userId)
+      await trackedAction(
+        "list_member_removed",
+        () => api.removeListMember(listId, userId),
+        () => ({ list_id: listId, removed_user_id: userId }),
+      )
       await onChanged()
     } finally {
       setBusy(false)

--- a/apps/web/src/routes/lists.index.tsx
+++ b/apps/web/src/routes/lists.index.tsx
@@ -7,6 +7,7 @@ import { Label } from "@workspace/ui/components/label"
 import { Switch } from "@workspace/ui/components/switch"
 import { Textarea } from "@workspace/ui/components/textarea"
 import { LIST_SLUG_RE, LIST_TITLE_MAX } from "@workspace/validators"
+import { trackedAction } from "../lib/analytics"
 import { ApiError, api } from "../lib/api"
 import { authClient } from "../lib/auth"
 import { usePageHeader } from "../components/app-page-header"
@@ -185,12 +186,17 @@ function CreateListForm({
     setBusy(true)
     setError(null)
     try {
-      await api.createList({
-        slug: effectiveSlug,
-        title: title.trim(),
-        description: description.trim() || undefined,
-        isPrivate,
-      })
+      await trackedAction(
+        "list_created",
+        () =>
+          api.createList({
+            slug: effectiveSlug,
+            title: title.trim(),
+            description: description.trim() || undefined,
+            isPrivate,
+          }),
+        () => ({ slug: effectiveSlug, is_private: isPrivate }),
+      )
       await onCreated()
     } catch (err) {
       const msg = err instanceof ApiError ? err.message : "create failed"

--- a/apps/web/src/routes/search.tsx
+++ b/apps/web/src/routes/search.tsx
@@ -253,7 +253,11 @@ function SearchInner({ initialQuery }: { initialQuery: string }) {
                     onClick={async () => {
                       setSaved((prev) => prev.filter((x) => x.id !== s.id))
                       try {
-                        await api.deleteSavedSearch(s.id)
+                        await trackedAction(
+                          "search_saved_deleted",
+                          () => api.deleteSavedSearch(s.id),
+                          () => ({ search_id: s.id }),
+                        )
                       } catch {
                         /* refetch on next mount */
                       }

--- a/apps/web/src/routes/search.tsx
+++ b/apps/web/src/routes/search.tsx
@@ -21,6 +21,7 @@ import { PageEmpty, PageLoading } from "../components/page-surface"
 import { PageFrame } from "../components/page-frame"
 import { PostCard } from "../components/post-card"
 import { VerifiedBadge } from "../components/verified-badge"
+import { trackedAction } from "../lib/analytics"
 import { ApiError, api } from "../lib/api"
 import { useMe } from "../lib/me"
 import type { Post, PublicUser, SavedSearch } from "../lib/api"
@@ -62,7 +63,11 @@ function SearchInner({ initialQuery }: { initialQuery: string }) {
     const targetHandle = challengeTarget.replace(/^@/, "").trim()
     try {
       const { user } = await api.user(targetHandle)
-      const { game } = await api.chessCreateGame(user.id)
+      const { game } = await trackedAction(
+        "chess_game_created",
+        () => api.chessCreateGame(user.id),
+        ({ game }) => ({ game_id: game.id, opponent_id: user.id }),
+      )
       navigate({ to: "/chess/$id", params: { id: game.id } })
     } catch (err) {
       setChallengeError("Could not find user or challenge failed.")
@@ -135,7 +140,11 @@ function SearchInner({ initialQuery }: { initialQuery: string }) {
       const id = activeSavedId
       setSaved((prev) => prev.filter((s) => s.id !== id))
       try {
-        await api.deleteSavedSearch(id)
+        await trackedAction(
+          "search_saved_deleted",
+          () => api.deleteSavedSearch(id),
+          () => ({ search_id: id }),
+        )
       } catch {
         const fallback = await api
           .savedSearches()
@@ -144,7 +153,11 @@ function SearchInner({ initialQuery }: { initialQuery: string }) {
       }
     } else {
       try {
-        const { item } = await api.saveSearch(query)
+        const { item } = await trackedAction(
+          "search_saved",
+          () => api.saveSearch(query),
+          ({ item }) => ({ search_id: item.id, query_length: query.length }),
+        )
         setSaved((prev) =>
           prev.some((s) => s.id === item.id) ? prev : [...prev, item],
         )

--- a/apps/web/src/routes/search.tsx
+++ b/apps/web/src/routes/search.tsx
@@ -66,7 +66,7 @@ function SearchInner({ initialQuery }: { initialQuery: string }) {
       const { game } = await trackedAction(
         "chess_game_created",
         () => api.chessCreateGame(user.id),
-        ({ game }) => ({ game_id: game.id, opponent_id: user.id }),
+        (res) => ({ game_id: res.game.id, opponent_id: user.id }),
       )
       navigate({ to: "/chess/$id", params: { id: game.id } })
     } catch (err) {
@@ -156,7 +156,7 @@ function SearchInner({ initialQuery }: { initialQuery: string }) {
         const { item } = await trackedAction(
           "search_saved",
           () => api.saveSearch(query),
-          ({ item }) => ({ search_id: item.id, query_length: query.length }),
+          (res) => ({ search_id: res.item.id, query_length: query.length }),
         )
         setSaved((prev) =>
           prev.some((s) => s.id === item.id) ? prev : [...prev, item],

--- a/apps/web/src/routes/settings.tsx
+++ b/apps/web/src/routes/settings.tsx
@@ -6,6 +6,7 @@ import { Label } from "@workspace/ui/components/label"
 import { Switch } from "@workspace/ui/components/switch"
 import { updateProfileSchema } from "@workspace/validators"
 import { Textarea } from "@workspace/ui/components/textarea"
+import { trackedAction } from "../lib/analytics"
 import { ApiError, api } from "../lib/api"
 import { authClient } from "../lib/auth"
 import { useMe } from "../lib/me"
@@ -209,7 +210,11 @@ function ProfileSection() {
       return
     }
     try {
-      const { user: next } = await api.updateMe(parsed.data)
+      const { user: next } = await trackedAction(
+        "profile_updated",
+        () => api.updateMe(parsed.data),
+        () => ({ fields: Object.keys(parsed.data).join(",") }),
+      )
       setMe(next)
       setStatus("saved")
     } catch (err) {
@@ -223,14 +228,21 @@ function ProfileSection() {
   }) {
     try {
       // api.updateMe accepts empty string to clear; null gets normalized to empty.
-      const { user } = await api.updateMe({
-        ...(patch.avatarUrl !== undefined
-          ? { avatarUrl: patch.avatarUrl ?? "" }
-          : {}),
-        ...(patch.bannerUrl !== undefined
-          ? { bannerUrl: patch.bannerUrl ?? "" }
-          : {}),
-      })
+      const { user } = await trackedAction(
+        "profile_updated",
+        () =>
+          api.updateMe({
+            ...(patch.avatarUrl !== undefined
+              ? { avatarUrl: patch.avatarUrl ?? "" }
+              : {}),
+            ...(patch.bannerUrl !== undefined
+              ? { bannerUrl: patch.bannerUrl ?? "" }
+              : {}),
+          }),
+        () => ({
+          fields: Object.keys(patch).join(","),
+        }),
+      )
       setMe(user)
     } catch (e) {
       setStatus(e instanceof ApiError ? e.message : "update failed")
@@ -567,7 +579,11 @@ function PrivacySection() {
   async function unblock(handle: string, id: string) {
     setBusyId(id)
     try {
-      await api.unblock(handle)
+      await trackedAction(
+        "user_unblocked",
+        () => api.unblock(handle),
+        () => ({ target_user_id: id, target_handle: handle }),
+      )
       setBlocks((prev) => (prev ? prev.filter((u) => u.id !== id) : prev))
     } finally {
       setBusyId(null)
@@ -577,7 +593,11 @@ function PrivacySection() {
   async function unmute(handle: string, id: string) {
     setBusyId(id)
     try {
-      await api.unmute(handle)
+      await trackedAction(
+        "user_unmuted",
+        () => api.unmute(handle),
+        () => ({ target_user_id: id, target_handle: handle }),
+      )
       setMutes((prev) => (prev ? prev.filter((u) => u.id !== id) : prev))
     } finally {
       setBusyId(null)

--- a/bun.lock
+++ b/bun.lock
@@ -44,6 +44,7 @@
       "name": "web",
       "version": "0.0.1",
       "dependencies": {
+        "@databuddy/sdk": "^2.4.11",
         "@lexical/code": "^0.37.0",
         "@lexical/link": "^0.37.0",
         "@lexical/list": "^0.37.0",
@@ -435,6 +436,8 @@
     "@better-fetch/fetch": ["@better-fetch/fetch@1.1.21", "", {}, "sha512-/ImESw0sskqlVR94jB+5+Pxjf+xBwDZF/N5+y2/q4EqD7IARUTSpPfIo8uf39SYpCxyOCtbyYpUrZ3F/k0zT4A=="],
 
     "@borewit/text-codec": ["@borewit/text-codec@0.2.2", "", {}, "sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ=="],
+
+    "@databuddy/sdk": ["@databuddy/sdk@2.4.11", "", { "peerDependencies": { "react": ">=18", "vue": ">=3" }, "optionalPeers": ["react", "vue"] }, "sha512-pDT0tfsLOhuFnX0MHSOOt+qq9IPAB7rktuWclVgaRU3D6A6Mw7pN0oRttvPPKc3Ue7gUvq3kOtFkhmquLtmVQA=="],
 
     "@dnd-kit/accessibility": ["@dnd-kit/accessibility@3.1.1", "", { "dependencies": { "tslib": "^2.0.0" }, "peerDependencies": { "react": ">=16.8.0" } }, "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw=="],
 


### PR DESCRIPTION
## Summary

- Integrated Databuddy analytics SDK and created a `trackedAction` helper function to wrap async operations with event tracking
- Added comprehensive event tracking across the app for user actions including posts, DMs, admin operations, profile updates, and more
- Exported `track` function from analytics module for direct event tracking when needed
- Added `DATABUDDY_CLIENT_ID` environment variable configuration

## Test plan

- [x] `bun run typecheck` passes
- [x] Manually exercised affected flows (post creation/editing, DMs, admin actions, profile updates)
- [x] No new console errors / network errors

## Notes

- New environment variable `VITE_PUBLIC_DATABUDDY_CLIENT_ID` added (optional, leave blank to disable analytics)
- `trackedAction` helper ensures analytics failures never break UX (wrapped in try-catch)
- Event names and properties follow a consistent naming convention (snake_case)
- All tracked events include relevant context (IDs, counts, flags) for analytics insights

https://claude.ai/code/session_01GwutHkN6vqPVg1FnkdwGFJ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * App-wide analytics instrumentation added to record key user actions (posts, messages, likes/bookmarks/reposts, polls, DMs, lists, admin actions, articles, drafts, searches, settings).
  * Analytics are conditionally enabled at runtime when a client ID is provided.

* **Chores**
  * Added analytics SDK dependency and a configurable public environment variable to enable tracking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->