### PR TITLE
Increase sidebar trigger icon size

### DIFF
--- a/packages/ui/src/components/sidebar.tsx
+++ b/packages/ui/src/components/sidebar.tsx
@@ -270,7 +270,7 @@ function SidebarTrigger({
       }}
       {...props}
     >
-      <SidebarIcon />
+      <SidebarIcon className="size-4" />
       <span className="sr-only">Toggle Sidebar</span>
     </Button>
   )


### PR DESCRIPTION
## Summary
- The sidebar toggle button in the app header was overridden to 24px, but the icon inside was rendered at 10px from the Button `icon-sm` variant — leaving the icon visually undersized inside its button.
- Set an explicit `size-4` (16px) on the `SidebarIcon` so the icon stays proportional to the 24px button container in [app-header.tsx:9](apps/web/src/components/app-header.tsx).

## Why this works
The Button variant only sizes SVGs that don't already declare a size class (`[&_svg:not([class*='size-'])]:size-2.5`), so an explicit `size-4` cleanly overrides the variant's default without touching the variant system itself.

## Test plan
- [ ] Load `/` in the web app and confirm the sidebar toggle icon in the top-left header is visibly larger and proportional inside its button
- [ ] Confirm hover/focus states still look correct (button container size unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted the sidebar toggle button icon size to enhance visual consistency and improve the overall appearance of the interface, ensuring better design alignment throughout the application. This refinement contributes to a more cohesive and polished user experience with improved visual proportionality and clarity across all interface elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->