### PR TITLE
Add admin posts management interface with search and filtering

### DIFF
--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -1,6 +1,6 @@
 import { Hono, type Context } from 'hono'
 import { z } from 'zod'
-import { and, desc, eq, gte, ilike, lt, or, sql } from '@workspace/db'
+import { and, asc, desc, eq, gt, gte, ilike, isNotNull, isNull, lt, or, sql } from '@workspace/db'
 import { schema } from '@workspace/db'
 import { assetUrl } from '@workspace/media/s3'
 import { handleSchema } from '@workspace/validators'
@@ -713,6 +713,189 @@ adminRoute.post('/users/:id/handle', requireOwner(), async (c) => {
     })
   })
   return c.json({ ok: true })
+})
+
+const POST_SORTS = [
+  'created',
+  'likes',
+  'reposts',
+  'replies',
+  'quotes',
+  'bookmarks',
+  'impressions',
+] as const
+type PostSort = (typeof POST_SORTS)[number]
+
+const postsListQuery = z.object({
+  q: z.string().trim().max(80).optional(),
+  cursor: z.string().max(80).optional(),
+  limit: z.coerce.number().min(1).max(100).default(40),
+  sort: z.enum(POST_SORTS).default('created'),
+  order: z.enum(['asc', 'desc']).default('desc'),
+  type: z.enum(['any', 'original', 'reply', 'repost', 'quote']).default('any'),
+  visibility: z.enum(['any', 'public', 'followers', 'unlisted']).default('any'),
+  status: z.enum(['any', 'active', 'deleted', 'sensitive']).default('any'),
+})
+
+// Stat columns are integers (impressionCount is a bigint stored as number) and tie often, so
+// the cursor encodes a `<value>~<uuid>` pair to give us a stable ordering. For the createdAt
+// sort the value is the ISO timestamp; for stat sorts it's the numeric value. The post UUID
+// is the deterministic tiebreaker.
+function parsePostCursor(raw: string | undefined, sort: PostSort) {
+  if (!raw) return undefined
+  const sep = raw.indexOf('~')
+  if (sep < 0) return undefined
+  const value = raw.slice(0, sep)
+  const id = raw.slice(sep + 1)
+  if (!/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(id)) return undefined
+  if (sort === 'created') {
+    const date = parseCursor(value)
+    if (!date) return undefined
+    return { kind: 'date' as const, date, id }
+  }
+  if (!/^\d{1,20}$/.test(value)) return undefined
+  const num = Number(value)
+  if (!Number.isFinite(num) || num < 0) return undefined
+  return { kind: 'number' as const, num, id }
+}
+
+// List/search posts with sort + filter for the admin panel. Joins author for the table cell.
+// Pagination uses a `<value>~<uuid>` cursor for stable ordering when stat values tie.
+adminRoute.get('/posts', async (c) => {
+  const { db, mediaEnv } = c.get('ctx')
+  const { q, cursor, limit, sort, order, type, visibility, status } = postsListQuery.parse(
+    c.req.query(),
+  )
+
+  const sortColumns = {
+    created: schema.posts.createdAt,
+    likes: schema.posts.likeCount,
+    reposts: schema.posts.repostCount,
+    replies: schema.posts.replyCount,
+    quotes: schema.posts.quoteCount,
+    bookmarks: schema.posts.bookmarkCount,
+    impressions: schema.posts.impressionCount,
+  } as const
+  const sortCol = sortColumns[sort]
+  const dir = order === 'asc' ? asc : desc
+  const cmp = order === 'asc' ? gt : lt
+
+  const filters: Array<unknown> = []
+
+  if (q) {
+    const like = `%${q.replace(/[\\%_]/g, (ch) => `\\${ch}`)}%`
+    filters.push(or(ilike(schema.posts.text, like), ilike(schema.users.handle, like)))
+  }
+
+  if (type === 'original') {
+    filters.push(
+      and(
+        isNull(schema.posts.replyToId),
+        isNull(schema.posts.repostOfId),
+        isNull(schema.posts.quoteOfId),
+      ),
+    )
+  } else if (type === 'reply') {
+    filters.push(isNotNull(schema.posts.replyToId))
+  } else if (type === 'repost') {
+    filters.push(isNotNull(schema.posts.repostOfId))
+  } else if (type === 'quote') {
+    filters.push(isNotNull(schema.posts.quoteOfId))
+  }
+
+  if (visibility !== 'any') filters.push(eq(schema.posts.visibility, visibility))
+
+  if (status === 'active') filters.push(isNull(schema.posts.deletedAt))
+  else if (status === 'deleted') filters.push(isNotNull(schema.posts.deletedAt))
+  else if (status === 'sensitive') filters.push(eq(schema.posts.sensitive, true))
+
+  const parsed = parsePostCursor(cursor, sort)
+  if (parsed) {
+    if (parsed.kind === 'date') {
+      filters.push(
+        or(
+          cmp(schema.posts.createdAt, parsed.date),
+          and(eq(schema.posts.createdAt, parsed.date), cmp(schema.posts.id, parsed.id)),
+        ),
+      )
+    } else {
+      filters.push(
+        or(
+          cmp(sortCol, parsed.num),
+          and(eq(sortCol, parsed.num), cmp(schema.posts.id, parsed.id)),
+        ),
+      )
+    }
+  }
+
+  const rows = await db
+    .select({ post: schema.posts, author: schema.users })
+    .from(schema.posts)
+    .leftJoin(schema.users, eq(schema.users.id, schema.posts.authorId))
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    .where(filters.length > 0 ? (and(...(filters as Array<any>)) as any) : undefined)
+    .orderBy(dir(sortCol), dir(schema.posts.id))
+    .limit(limit)
+
+  const items = rows.map((r) => {
+    const p = r.post
+    const postType: 'original' | 'reply' | 'repost' | 'quote' = p.repostOfId
+      ? 'repost'
+      : p.quoteOfId
+        ? 'quote'
+        : p.replyToId
+          ? 'reply'
+          : 'original'
+    return {
+      id: p.id,
+      authorId: p.authorId,
+      author: r.author
+        ? {
+            id: r.author.id,
+            handle: r.author.handle,
+            displayName: r.author.displayName,
+            avatarUrl: assetUrl(mediaEnv, r.author.avatarUrl),
+            isVerified: r.author.isVerified,
+            role: r.author.role as Role,
+          }
+        : null,
+      text: p.text,
+      postType,
+      visibility: p.visibility,
+      sensitive: p.sensitive,
+      likeCount: p.likeCount,
+      repostCount: p.repostCount,
+      replyCount: p.replyCount,
+      quoteCount: p.quoteCount,
+      bookmarkCount: p.bookmarkCount,
+      impressionCount: p.impressionCount,
+      editedAt: p.editedAt?.toISOString() ?? null,
+      deletedAt: p.deletedAt?.toISOString() ?? null,
+      createdAt: p.createdAt.toISOString(),
+    }
+  })
+
+  let nextCursor: string | null = null
+  if (rows.length === limit) {
+    const last = rows[rows.length - 1]!.post
+    const value =
+      sort === 'created'
+        ? last.createdAt.toISOString()
+        : sort === 'likes'
+          ? String(last.likeCount)
+          : sort === 'reposts'
+            ? String(last.repostCount)
+            : sort === 'replies'
+              ? String(last.replyCount)
+              : sort === 'quotes'
+                ? String(last.quoteCount)
+                : sort === 'bookmarks'
+                  ? String(last.bookmarkCount)
+                  : String(last.impressionCount)
+    nextCursor = `${value}~${last.id}`
+  }
+
+  return c.json({ posts: items, nextCursor })
 })
 
 // Soft-delete a post via mod action. Distinct from author delete: records who/why for audit.

--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -759,6 +759,36 @@ function parsePostCursor(raw: string | undefined, sort: PostSort) {
   return { kind: 'number' as const, num, id }
 }
 
+function getCursorValue(
+  sort: PostSort,
+  last: {
+    createdAt: Date
+    likeCount: number
+    repostCount: number
+    replyCount: number
+    quoteCount: number
+    bookmarkCount: number
+    impressionCount: number
+  },
+): string {
+  switch (sort) {
+    case 'created':
+      return last.createdAt.toISOString()
+    case 'likes':
+      return String(last.likeCount)
+    case 'reposts':
+      return String(last.repostCount)
+    case 'replies':
+      return String(last.replyCount)
+    case 'quotes':
+      return String(last.quoteCount)
+    case 'bookmarks':
+      return String(last.bookmarkCount)
+    case 'impressions':
+      return String(last.impressionCount)
+  }
+}
+
 // List/search posts with sort + filter for the admin panel. Joins author for the table cell.
 // Pagination uses a `<value>~<uuid>` cursor for stable ordering when stat values tie.
 adminRoute.get('/posts', async (c) => {
@@ -878,21 +908,7 @@ adminRoute.get('/posts', async (c) => {
   let nextCursor: string | null = null
   if (rows.length === limit) {
     const last = rows[rows.length - 1]!.post
-    const value =
-      sort === 'created'
-        ? last.createdAt.toISOString()
-        : sort === 'likes'
-          ? String(last.likeCount)
-          : sort === 'reposts'
-            ? String(last.repostCount)
-            : sort === 'replies'
-              ? String(last.replyCount)
-              : sort === 'quotes'
-                ? String(last.quoteCount)
-                : sort === 'bookmarks'
-                  ? String(last.bookmarkCount)
-                  : String(last.impressionCount)
-    nextCursor = `${value}~${last.id}`
+    nextCursor = `${getCursorValue(sort, last)}~${last.id}`
   }
 
   return c.json({ posts: items, nextCursor })

--- a/apps/web/src/lib/analytics.ts
+++ b/apps/web/src/lib/analytics.ts
@@ -55,6 +55,7 @@ type EventName =
   | "admin_user_role_set"
   | "admin_user_handle_set"
   | "admin_user_deleted"
+  | "admin_post_deleted"
   | "admin_report_resolved"
 
 export async function trackedAction<T>(

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -484,6 +484,28 @@ export const api = {
       method: "PATCH",
       body: JSON.stringify(body),
     }),
+  adminPosts: (params: {
+    q?: string
+    cursor?: string
+    sort?: AdminPostSort
+    order?: "asc" | "desc"
+    type?: AdminPostType | "any"
+    visibility?: "public" | "followers" | "unlisted" | "any"
+    status?: "active" | "deleted" | "sensitive" | "any"
+  } = {}) => {
+    const sp = new URLSearchParams()
+    if (params.q) sp.set("q", params.q)
+    if (params.cursor) sp.set("cursor", params.cursor)
+    if (params.sort) sp.set("sort", params.sort)
+    if (params.order) sp.set("order", params.order)
+    if (params.type && params.type !== "any") sp.set("type", params.type)
+    if (params.visibility && params.visibility !== "any")
+      sp.set("visibility", params.visibility)
+    if (params.status && params.status !== "any") sp.set("status", params.status)
+    return request<{ posts: Array<AdminPost>; nextCursor: string | null }>(
+      `/api/admin/posts${sp.toString() ? `?${sp.toString()}` : ""}`
+    )
+  },
   adminDeletePost: (
     id: string,
     body: { reason?: string; reportId?: string } = {}
@@ -1060,6 +1082,43 @@ export interface AdminStats {
     actioned: number
     dismissed: number
   }
+}
+
+export type AdminPostSort =
+  | "created"
+  | "likes"
+  | "reposts"
+  | "replies"
+  | "quotes"
+  | "bookmarks"
+  | "impressions"
+
+export type AdminPostType = "original" | "reply" | "repost" | "quote"
+
+export interface AdminPost {
+  id: string
+  authorId: string
+  author: {
+    id: string
+    handle: string | null
+    displayName: string | null
+    avatarUrl: string | null
+    isVerified: boolean
+    role: "user" | "admin" | "owner"
+  } | null
+  text: string
+  postType: AdminPostType
+  visibility: "public" | "followers" | "unlisted"
+  sensitive: boolean
+  likeCount: number
+  repostCount: number
+  replyCount: number
+  quoteCount: number
+  bookmarkCount: number
+  impressionCount: number
+  editedAt: string | null
+  deletedAt: string | null
+  createdAt: string
 }
 
 export interface AdminUser {

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -38,6 +38,7 @@ import { Route as ArticlesNewRouteImport } from './routes/articles.new'
 import { Route as AdminUsersRouteImport } from './routes/admin.users'
 import { Route as AdminStatsRouteImport } from './routes/admin.stats'
 import { Route as AdminReportsRouteImport } from './routes/admin.reports'
+import { Route as AdminPostsRouteImport } from './routes/admin.posts'
 import { Route as HandleFollowingRouteImport } from './routes/$handle.following'
 import { Route as HandleFollowersRouteImport } from './routes/$handle.followers'
 import { Route as OgUserHandleRouteImport } from './routes/og.user.$handle'
@@ -192,6 +193,11 @@ const AdminReportsRoute = AdminReportsRouteImport.update({
   path: '/reports',
   getParentRoute: () => AdminRoute,
 } as any)
+const AdminPostsRoute = AdminPostsRouteImport.update({
+  id: '/posts',
+  path: '/posts',
+  getParentRoute: () => AdminRoute,
+} as any)
 const HandleFollowingRoute = HandleFollowingRouteImport.update({
   id: '/following',
   path: '/following',
@@ -251,6 +257,7 @@ export interface FileRoutesByFullPath {
   '/sitemap.xml': typeof SitemapDotxmlRoute
   '/$handle/followers': typeof HandleFollowersRoute
   '/$handle/following': typeof HandleFollowingRoute
+  '/admin/posts': typeof AdminPostsRoute
   '/admin/reports': typeof AdminReportsRoute
   '/admin/stats': typeof AdminStatsRoute
   '/admin/users': typeof AdminUsersRoute
@@ -287,6 +294,7 @@ export interface FileRoutesByTo {
   '/sitemap.xml': typeof SitemapDotxmlRoute
   '/$handle/followers': typeof HandleFollowersRoute
   '/$handle/following': typeof HandleFollowingRoute
+  '/admin/posts': typeof AdminPostsRoute
   '/admin/reports': typeof AdminReportsRoute
   '/admin/stats': typeof AdminStatsRoute
   '/admin/users': typeof AdminUsersRoute
@@ -327,6 +335,7 @@ export interface FileRoutesById {
   '/sitemap.xml': typeof SitemapDotxmlRoute
   '/$handle/followers': typeof HandleFollowersRoute
   '/$handle/following': typeof HandleFollowingRoute
+  '/admin/posts': typeof AdminPostsRoute
   '/admin/reports': typeof AdminReportsRoute
   '/admin/stats': typeof AdminStatsRoute
   '/admin/users': typeof AdminUsersRoute
@@ -368,6 +377,7 @@ export interface FileRouteTypes {
     | '/sitemap.xml'
     | '/$handle/followers'
     | '/$handle/following'
+    | '/admin/posts'
     | '/admin/reports'
     | '/admin/stats'
     | '/admin/users'
@@ -404,6 +414,7 @@ export interface FileRouteTypes {
     | '/sitemap.xml'
     | '/$handle/followers'
     | '/$handle/following'
+    | '/admin/posts'
     | '/admin/reports'
     | '/admin/stats'
     | '/admin/users'
@@ -443,6 +454,7 @@ export interface FileRouteTypes {
     | '/sitemap.xml'
     | '/$handle/followers'
     | '/$handle/following'
+    | '/admin/posts'
     | '/admin/reports'
     | '/admin/stats'
     | '/admin/users'
@@ -695,6 +707,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AdminReportsRouteImport
       parentRoute: typeof AdminRoute
     }
+    '/admin/posts': {
+      id: '/admin/posts'
+      path: '/posts'
+      fullPath: '/admin/posts'
+      preLoaderRoute: typeof AdminPostsRouteImport
+      parentRoute: typeof AdminRoute
+    }
     '/$handle/following': {
       id: '/$handle/following'
       path: '/following'
@@ -774,6 +793,7 @@ const HandleRouteWithChildren =
   HandleRoute._addFileChildren(HandleRouteChildren)
 
 interface AdminRouteChildren {
+  AdminPostsRoute: typeof AdminPostsRoute
   AdminReportsRoute: typeof AdminReportsRoute
   AdminStatsRoute: typeof AdminStatsRoute
   AdminUsersRoute: typeof AdminUsersRoute
@@ -781,6 +801,7 @@ interface AdminRouteChildren {
 }
 
 const AdminRouteChildren: AdminRouteChildren = {
+  AdminPostsRoute: AdminPostsRoute,
   AdminReportsRoute: AdminReportsRoute,
   AdminStatsRoute: AdminStatsRoute,
   AdminUsersRoute: AdminUsersRoute,

--- a/apps/web/src/routes/admin.posts.tsx
+++ b/apps/web/src/routes/admin.posts.tsx
@@ -101,6 +101,42 @@ function formatRelative(iso: string): string {
   return new Date(iso).toLocaleDateString()
 }
 
+function StatHeader({
+  label,
+  sortKey,
+  icon,
+  currentSort,
+  currentOrder,
+  onSort,
+}: {
+  label: string
+  sortKey: AdminPostSort
+  icon?: React.ReactNode
+  currentSort: AdminPostSort
+  currentOrder: "asc" | "desc"
+  onSort: (next: AdminPostSort) => void
+}) {
+  const active = currentSort === sortKey
+  return (
+    <button
+      type="button"
+      onClick={() => onSort(sortKey)}
+      className={`flex items-center gap-1 text-xs ${
+        active ? "text-foreground" : "text-muted-foreground hover:text-foreground"
+      }`}
+    >
+      {icon}
+      <span>{label}</span>
+      {active &&
+        (currentOrder === "desc" ? (
+          <CaretDownIcon className="size-3" />
+        ) : (
+          <CaretUpIcon className="size-3" />
+        ))}
+    </button>
+  )
+}
+
 function AdminPosts() {
   const [q, setQ] = useState("")
   const [sort, setSort] = useState<AdminPostSort>("created")
@@ -156,14 +192,30 @@ function AdminPosts() {
     [],
   )
 
-  // Debounce text-search; filters & sort fire immediately.
+  // The two effects below split the load triggers: q is debounced so we don't fire a request
+  // on every keystroke, while filter/sort changes call load synchronously. Each effect reads
+  // the values it doesn't want to react to via a ref, so changing one set doesn't cancel or
+  // re-run the other.
+  const latestRef = useRef({ q, sort, order, typeFilter, visibility, status })
+  latestRef.current = { q, sort, order, typeFilter, visibility, status }
+
   useEffect(() => {
-    const t = setTimeout(
-      () => load(q, sort, order, typeFilter, visibility, status),
-      250,
-    )
+    const t = setTimeout(() => {
+      const v = latestRef.current
+      load(v.q, v.sort, v.order, v.typeFilter, v.visibility, v.status)
+    }, 250)
     return () => clearTimeout(t)
-  }, [q, sort, order, typeFilter, visibility, status, load])
+  }, [q, load])
+
+  const isFirstFilterRunRef = useRef(true)
+  useEffect(() => {
+    if (isFirstFilterRunRef.current) {
+      isFirstFilterRunRef.current = false
+      return
+    }
+    const v = latestRef.current
+    load(v.q, v.sort, v.order, v.typeFilter, v.visibility, v.status)
+  }, [sort, order, typeFilter, visibility, status, load])
 
   const loadMore = useCallback(async () => {
     if (!cursor || loadingMore) return
@@ -198,36 +250,6 @@ function AdminPosts() {
     },
     [sort],
   )
-
-  function StatHeader({
-    label,
-    sortKey,
-    icon,
-  }: {
-    label: string
-    sortKey: AdminPostSort
-    icon?: React.ReactNode
-  }) {
-    const active = sort === sortKey
-    return (
-      <button
-        type="button"
-        onClick={() => onHeaderSort(sortKey)}
-        className={`flex items-center gap-1 text-xs ${
-          active ? "text-foreground" : "text-muted-foreground hover:text-foreground"
-        }`}
-      >
-        {icon}
-        <span>{label}</span>
-        {active &&
-          (order === "desc" ? (
-            <CaretDownIcon className="size-3" />
-          ) : (
-            <CaretUpIcon className="size-3" />
-          ))}
-      </button>
-    )
-  }
 
   const columns = useMemo<Array<ColumnDef<AdminPost>>>(
     () => [
@@ -332,6 +354,9 @@ function AdminPosts() {
             label="Likes"
             sortKey="likes"
             icon={<HeartIcon className="size-3" />}
+            currentSort={sort}
+            currentOrder={order}
+            onSort={onHeaderSort}
           />
         ),
         cell: ({ row }) => (
@@ -347,6 +372,9 @@ function AdminPosts() {
             label="Reposts"
             sortKey="reposts"
             icon={<RepeatIcon className="size-3" />}
+            currentSort={sort}
+            currentOrder={order}
+            onSort={onHeaderSort}
           />
         ),
         cell: ({ row }) => (
@@ -362,6 +390,9 @@ function AdminPosts() {
             label="Replies"
             sortKey="replies"
             icon={<ChatCircleIcon className="size-3" />}
+            currentSort={sort}
+            currentOrder={order}
+            onSort={onHeaderSort}
           />
         ),
         cell: ({ row }) => (
@@ -377,6 +408,9 @@ function AdminPosts() {
             label="Saves"
             sortKey="bookmarks"
             icon={<QuotesIcon className="size-3" />}
+            currentSort={sort}
+            currentOrder={order}
+            onSort={onHeaderSort}
           />
         ),
         cell: ({ row }) => (
@@ -392,6 +426,9 @@ function AdminPosts() {
             label="Views"
             sortKey="impressions"
             icon={<EyeIcon className="size-3" />}
+            currentSort={sort}
+            currentOrder={order}
+            onSort={onHeaderSort}
           />
         ),
         cell: ({ row }) => (
@@ -402,7 +439,15 @@ function AdminPosts() {
       },
       {
         id: "created",
-        header: () => <StatHeader label="Created" sortKey="created" />,
+        header: () => (
+          <StatHeader
+            label="Created"
+            sortKey="created"
+            currentSort={sort}
+            currentOrder={order}
+            onSort={onHeaderSort}
+          />
+        ),
         cell: ({ row }) => {
           const p = row.original
           return (

--- a/apps/web/src/routes/admin.posts.tsx
+++ b/apps/web/src/routes/admin.posts.tsx
@@ -1,0 +1,765 @@
+import { Link, createFileRoute } from "@tanstack/react-router"
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
+import {
+  flexRender,
+  getCoreRowModel,
+  useReactTable,
+} from "@tanstack/react-table"
+import { useVirtualizer } from "@tanstack/react-virtual"
+import { Button } from "@workspace/ui/components/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@workspace/ui/components/dialog"
+import { Input } from "@workspace/ui/components/input"
+import { Label } from "@workspace/ui/components/label"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@workspace/ui/components/select"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@workspace/ui/components/table"
+import {
+  CaretDownIcon,
+  CaretUpIcon,
+  ChatCircleIcon,
+  EyeIcon,
+  HeartIcon,
+  QuotesIcon,
+  RepeatIcon,
+} from "@phosphor-icons/react"
+import { trackedAction } from "../lib/analytics"
+import { api } from "../lib/api"
+import { useInfiniteScrollSentinel } from "../lib/use-infinite-scroll-sentinel"
+import { Avatar } from "../components/avatar"
+import { PageError, PageLoading } from "../components/page-surface"
+import { VerifiedBadge } from "../components/verified-badge"
+import type { ColumnDef } from "@tanstack/react-table"
+import type { AdminPost, AdminPostSort, AdminPostType } from "../lib/api"
+
+export const Route = createFileRoute("/admin/posts")({ component: AdminPosts })
+
+type TypeFilter = AdminPostType | "any"
+type VisibilityFilter = "public" | "followers" | "unlisted" | "any"
+type StatusFilter = "active" | "deleted" | "sensitive" | "any"
+
+const COLUMN_WIDTHS: Record<string, string> = {
+  author: "16%",
+  text: "30%",
+  type: "8%",
+  likes: "7%",
+  reposts: "7%",
+  replies: "7%",
+  bookmarks: "7%",
+  impressions: "8%",
+  created: "10%",
+}
+
+const SORT_LABELS: Record<AdminPostSort, string> = {
+  created: "Newest",
+  likes: "Most likes",
+  reposts: "Most reposts",
+  replies: "Most replies",
+  quotes: "Most quotes",
+  bookmarks: "Most bookmarks",
+  impressions: "Most impressions",
+}
+
+function compactNumber(n: number): string {
+  if (!Number.isFinite(n)) return "0"
+  if (n < 1000) return String(n)
+  if (n < 1_000_000) return `${(n / 1000).toFixed(n < 10_000 ? 1 : 0).replace(/\.0$/, "")}k`
+  if (n < 1_000_000_000)
+    return `${(n / 1_000_000).toFixed(n < 10_000_000 ? 1 : 0).replace(/\.0$/, "")}M`
+  return `${(n / 1_000_000_000).toFixed(1).replace(/\.0$/, "")}B`
+}
+
+function formatRelative(iso: string): string {
+  const t = new Date(iso).getTime()
+  const diff = Date.now() - t
+  const s = Math.floor(diff / 1000)
+  if (s < 60) return `${s}s`
+  const m = Math.floor(s / 60)
+  if (m < 60) return `${m}m`
+  const h = Math.floor(m / 60)
+  if (h < 24) return `${h}h`
+  const d = Math.floor(h / 24)
+  if (d < 30) return `${d}d`
+  return new Date(iso).toLocaleDateString()
+}
+
+function AdminPosts() {
+  const [q, setQ] = useState("")
+  const [sort, setSort] = useState<AdminPostSort>("created")
+  const [order, setOrder] = useState<"asc" | "desc">("desc")
+  const [typeFilter, setTypeFilter] = useState<TypeFilter>("any")
+  const [visibility, setVisibility] = useState<VisibilityFilter>("any")
+  const [status, setStatus] = useState<StatusFilter>("any")
+
+  const [posts, setPosts] = useState<Array<AdminPost>>([])
+  const [cursor, setCursor] = useState<string | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [loadingMore, setLoadingMore] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [busyId, setBusyId] = useState<string | null>(null)
+  const [deleteTarget, setDeleteTarget] = useState<AdminPost | null>(null)
+
+  // Bumped on every fresh load so in-flight loadMore results from a stale set of filters are
+  // dropped instead of getting appended to the new list.
+  const generationRef = useRef(0)
+  const sentinelRef = useRef<HTMLDivElement | null>(null)
+
+  const load = useCallback(
+    async (
+      search: string,
+      s: AdminPostSort,
+      o: "asc" | "desc",
+      t: TypeFilter,
+      v: VisibilityFilter,
+      st: StatusFilter,
+    ) => {
+      const gen = ++generationRef.current
+      setLoading(true)
+      setError(null)
+      try {
+        const res = await api.adminPosts({
+          q: search || undefined,
+          sort: s,
+          order: o,
+          type: t,
+          visibility: v,
+          status: st,
+        })
+        if (generationRef.current !== gen) return
+        setPosts(res.posts)
+        setCursor(res.nextCursor)
+      } catch (e) {
+        if (generationRef.current !== gen) return
+        setError(e instanceof Error ? e.message : "failed")
+      } finally {
+        if (generationRef.current === gen) setLoading(false)
+      }
+    },
+    [],
+  )
+
+  // Debounce text-search; filters & sort fire immediately.
+  useEffect(() => {
+    const t = setTimeout(
+      () => load(q, sort, order, typeFilter, visibility, status),
+      250,
+    )
+    return () => clearTimeout(t)
+  }, [q, sort, order, typeFilter, visibility, status, load])
+
+  const loadMore = useCallback(async () => {
+    if (!cursor || loadingMore) return
+    const gen = generationRef.current
+    setLoadingMore(true)
+    try {
+      const res = await api.adminPosts({
+        q: q || undefined,
+        cursor,
+        sort,
+        order,
+        type: typeFilter,
+        visibility,
+        status,
+      })
+      if (generationRef.current !== gen) return
+      setPosts((prev) => [...prev, ...res.posts])
+      setCursor(res.nextCursor)
+    } finally {
+      setLoadingMore(false)
+    }
+  }, [cursor, loadingMore, q, sort, order, typeFilter, visibility, status])
+
+  const onHeaderSort = useCallback(
+    (next: AdminPostSort) => {
+      if (sort === next) {
+        setOrder((o) => (o === "desc" ? "asc" : "desc"))
+      } else {
+        setSort(next)
+        setOrder("desc")
+      }
+    },
+    [sort],
+  )
+
+  function StatHeader({
+    label,
+    sortKey,
+    icon,
+  }: {
+    label: string
+    sortKey: AdminPostSort
+    icon?: React.ReactNode
+  }) {
+    const active = sort === sortKey
+    return (
+      <button
+        type="button"
+        onClick={() => onHeaderSort(sortKey)}
+        className={`flex items-center gap-1 text-xs ${
+          active ? "text-foreground" : "text-muted-foreground hover:text-foreground"
+        }`}
+      >
+        {icon}
+        <span>{label}</span>
+        {active &&
+          (order === "desc" ? (
+            <CaretDownIcon className="size-3" />
+          ) : (
+            <CaretUpIcon className="size-3" />
+          ))}
+      </button>
+    )
+  }
+
+  const columns = useMemo<Array<ColumnDef<AdminPost>>>(
+    () => [
+      {
+        id: "author",
+        header: "Author",
+        cell: ({ row }) => {
+          const a = row.original.author
+          if (!a) {
+            return <span className="text-xs text-muted-foreground">(unknown)</span>
+          }
+          return (
+            <div className="flex min-w-0 items-center gap-2">
+              <Avatar
+                initial={(a.displayName || a.handle || "?").slice(0, 1).toUpperCase()}
+                src={a.avatarUrl}
+                className="size-7 shrink-0"
+              />
+              <div className="min-w-0">
+                {a.handle ? (
+                  <Link
+                    to="/$handle"
+                    params={{ handle: a.handle }}
+                    className="flex items-center gap-1 text-xs font-semibold hover:underline"
+                    onClick={(e) => e.stopPropagation()}
+                  >
+                    <span className="truncate">{a.displayName ?? a.handle}</span>
+                    {a.isVerified && <VerifiedBadge size={12} role={a.role} />}
+                  </Link>
+                ) : (
+                  <span className="text-xs font-semibold">
+                    {a.displayName ?? "—"}
+                  </span>
+                )}
+                {a.handle && (
+                  <p className="truncate text-[10px] text-muted-foreground">
+                    @{a.handle}
+                  </p>
+                )}
+              </div>
+            </div>
+          )
+        },
+      },
+      {
+        id: "text",
+        header: "Post",
+        cell: ({ row }) => {
+          const p = row.original
+          const author = p.author
+          return (
+            <div className="flex min-w-0 flex-col gap-0.5">
+              {author?.handle ? (
+                <Link
+                  to="/$handle/p/$id"
+                  params={{ handle: author.handle, id: p.id }}
+                  className="line-clamp-2 text-xs whitespace-pre-wrap hover:underline"
+                  onClick={(e) => e.stopPropagation()}
+                >
+                  {p.text || (
+                    <span className="text-muted-foreground">(no text)</span>
+                  )}
+                </Link>
+              ) : (
+                <span className="line-clamp-2 text-xs whitespace-pre-wrap">
+                  {p.text || (
+                    <span className="text-muted-foreground">(no text)</span>
+                  )}
+                </span>
+              )}
+              <div className="flex flex-wrap gap-1 text-[10px] text-muted-foreground">
+                {p.visibility !== "public" && (
+                  <span className="rounded bg-muted px-1">{p.visibility}</span>
+                )}
+                {p.sensitive && (
+                  <span className="rounded bg-muted px-1 text-destructive">
+                    sensitive
+                  </span>
+                )}
+                {p.editedAt && <span>edited</span>}
+                {p.deletedAt && (
+                  <span className="text-destructive">deleted</span>
+                )}
+              </div>
+            </div>
+          )
+        },
+      },
+      {
+        id: "type",
+        header: "Type",
+        cell: ({ row }) => (
+          <span className="text-[10px] tracking-wider text-muted-foreground uppercase">
+            {row.original.postType}
+          </span>
+        ),
+      },
+      {
+        id: "likes",
+        header: () => (
+          <StatHeader
+            label="Likes"
+            sortKey="likes"
+            icon={<HeartIcon className="size-3" />}
+          />
+        ),
+        cell: ({ row }) => (
+          <span className="text-xs tabular-nums">
+            {compactNumber(row.original.likeCount)}
+          </span>
+        ),
+      },
+      {
+        id: "reposts",
+        header: () => (
+          <StatHeader
+            label="Reposts"
+            sortKey="reposts"
+            icon={<RepeatIcon className="size-3" />}
+          />
+        ),
+        cell: ({ row }) => (
+          <span className="text-xs tabular-nums">
+            {compactNumber(row.original.repostCount)}
+          </span>
+        ),
+      },
+      {
+        id: "replies",
+        header: () => (
+          <StatHeader
+            label="Replies"
+            sortKey="replies"
+            icon={<ChatCircleIcon className="size-3" />}
+          />
+        ),
+        cell: ({ row }) => (
+          <span className="text-xs tabular-nums">
+            {compactNumber(row.original.replyCount)}
+          </span>
+        ),
+      },
+      {
+        id: "bookmarks",
+        header: () => (
+          <StatHeader
+            label="Saves"
+            sortKey="bookmarks"
+            icon={<QuotesIcon className="size-3" />}
+          />
+        ),
+        cell: ({ row }) => (
+          <span className="text-xs tabular-nums">
+            {compactNumber(row.original.bookmarkCount)}
+          </span>
+        ),
+      },
+      {
+        id: "impressions",
+        header: () => (
+          <StatHeader
+            label="Views"
+            sortKey="impressions"
+            icon={<EyeIcon className="size-3" />}
+          />
+        ),
+        cell: ({ row }) => (
+          <span className="text-xs tabular-nums">
+            {compactNumber(row.original.impressionCount)}
+          </span>
+        ),
+      },
+      {
+        id: "created",
+        header: () => <StatHeader label="Created" sortKey="created" />,
+        cell: ({ row }) => {
+          const p = row.original
+          return (
+            <div className="flex items-center justify-between gap-2">
+              <time
+                dateTime={p.createdAt}
+                title={new Date(p.createdAt).toLocaleString()}
+                className="text-xs text-muted-foreground"
+              >
+                {formatRelative(p.createdAt)}
+              </time>
+              {!p.deletedAt && (
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  className="h-7 px-2 text-xs text-destructive hover:text-destructive"
+                  disabled={busyId === p.id}
+                  onClick={(e) => {
+                    e.stopPropagation()
+                    setDeleteTarget(p)
+                  }}
+                >
+                  Delete
+                </Button>
+              )}
+            </div>
+          )
+        },
+      },
+    ],
+    [sort, order, busyId, onHeaderSort],
+  )
+
+  const table = useReactTable({
+    data: posts,
+    columns,
+    getCoreRowModel: getCoreRowModel(),
+  })
+
+  const rows = table.getRowModel().rows
+  const [scrollRoot, setScrollRoot] = useState<HTMLDivElement | null>(null)
+  const rowVirtualizer = useVirtualizer({
+    count: rows.length,
+    estimateSize: () => 72,
+    getScrollElement: () => scrollRoot,
+    overscan: 8,
+  })
+  const virtualRows = rowVirtualizer.getVirtualItems()
+  const totalSize = rowVirtualizer.getTotalSize()
+  const paddingTop = virtualRows.length > 0 ? virtualRows[0].start : 0
+  const paddingBottom =
+    virtualRows.length > 0
+      ? totalSize - virtualRows[virtualRows.length - 1].end
+      : 0
+
+  useInfiniteScrollSentinel(sentinelRef, !!cursor, loadingMore, loadMore, {
+    root: scrollRoot,
+  })
+
+  return (
+    <main className="flex min-h-0 flex-1 flex-col">
+      <div className="shrink-0 space-y-3 border-b border-border p-4">
+        <Input
+          value={q}
+          onChange={(e) => setQ(e.target.value)}
+          placeholder="search by post text or author handle…"
+        />
+        <div className="flex flex-wrap items-end gap-3">
+          <FilterField label="Sort">
+            <Select
+              value={sort}
+              onValueChange={(v) => setSort(v as AdminPostSort)}
+            >
+              <SelectTrigger size="sm" className="h-8 w-44">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {(Object.keys(SORT_LABELS) as Array<AdminPostSort>).map((k) => (
+                  <SelectItem key={k} value={k}>
+                    {SORT_LABELS[k]}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </FilterField>
+          <FilterField label="Direction">
+            <Select
+              value={order}
+              onValueChange={(v) => setOrder(v as "asc" | "desc")}
+            >
+              <SelectTrigger size="sm" className="h-8 w-32">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="desc">Descending</SelectItem>
+                <SelectItem value="asc">Ascending</SelectItem>
+              </SelectContent>
+            </Select>
+          </FilterField>
+          <FilterField label="Type">
+            <Select
+              value={typeFilter}
+              onValueChange={(v) => setTypeFilter(v as TypeFilter)}
+            >
+              <SelectTrigger size="sm" className="h-8 w-32">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="any">Any</SelectItem>
+                <SelectItem value="original">Original</SelectItem>
+                <SelectItem value="reply">Reply</SelectItem>
+                <SelectItem value="repost">Repost</SelectItem>
+                <SelectItem value="quote">Quote</SelectItem>
+              </SelectContent>
+            </Select>
+          </FilterField>
+          <FilterField label="Visibility">
+            <Select
+              value={visibility}
+              onValueChange={(v) => setVisibility(v as VisibilityFilter)}
+            >
+              <SelectTrigger size="sm" className="h-8 w-32">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="any">Any</SelectItem>
+                <SelectItem value="public">Public</SelectItem>
+                <SelectItem value="followers">Followers</SelectItem>
+                <SelectItem value="unlisted">Unlisted</SelectItem>
+              </SelectContent>
+            </Select>
+          </FilterField>
+          <FilterField label="Status">
+            <Select
+              value={status}
+              onValueChange={(v) => setStatus(v as StatusFilter)}
+            >
+              <SelectTrigger size="sm" className="h-8 w-32">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="any">Any</SelectItem>
+                <SelectItem value="active">Active</SelectItem>
+                <SelectItem value="deleted">Deleted</SelectItem>
+                <SelectItem value="sensitive">Sensitive</SelectItem>
+              </SelectContent>
+            </Select>
+          </FilterField>
+        </div>
+      </div>
+      {error && <PageError message={error} />}
+      {loading && posts.length === 0 && (
+        <PageLoading className="py-8" label="Loading…" />
+      )}
+      {!loading && posts.length === 0 && !error && (
+        <div className="py-8 text-center text-xs text-muted-foreground">
+          No posts match these filters.
+        </div>
+      )}
+      {posts.length > 0 && (
+        <div
+          ref={setScrollRoot}
+          className="flex-1 overflow-auto overscroll-contain"
+        >
+          <Table className="table-fixed">
+            <colgroup>
+              {table.getVisibleLeafColumns().map((col) => (
+                <col key={col.id} style={{ width: COLUMN_WIDTHS[col.id] }} />
+              ))}
+            </colgroup>
+            <TableHeader className="sticky top-0 z-10 bg-background">
+              {table.getHeaderGroups().map((hg) => (
+                <TableRow key={hg.id}>
+                  {hg.headers.map((header) => (
+                    <TableHead key={header.id}>
+                      {header.isPlaceholder
+                        ? null
+                        : flexRender(
+                            header.column.columnDef.header,
+                            header.getContext(),
+                          )}
+                    </TableHead>
+                  ))}
+                </TableRow>
+              ))}
+            </TableHeader>
+            <TableBody>
+              {paddingTop > 0 && (
+                <tr aria-hidden="true">
+                  <td colSpan={columns.length} style={{ height: paddingTop }} />
+                </tr>
+              )}
+              {virtualRows.map((virtualRow) => {
+                const row = rows[virtualRow.index]
+                return (
+                  <TableRow
+                    key={row.id}
+                    data-index={virtualRow.index}
+                    ref={(node: HTMLTableRowElement | null) =>
+                      rowVirtualizer.measureElement(node)
+                    }
+                  >
+                    {row.getVisibleCells().map((cell) => (
+                      <TableCell key={cell.id} className="align-top">
+                        {flexRender(
+                          cell.column.columnDef.cell,
+                          cell.getContext(),
+                        )}
+                      </TableCell>
+                    ))}
+                  </TableRow>
+                )
+              })}
+              {paddingBottom > 0 && (
+                <tr aria-hidden="true">
+                  <td
+                    colSpan={columns.length}
+                    style={{ height: paddingBottom }}
+                  />
+                </tr>
+              )}
+            </TableBody>
+          </Table>
+          <div ref={sentinelRef} aria-hidden className="h-px" />
+          {cursor && (
+            <div className="flex justify-center py-3 text-xs text-muted-foreground">
+              {loadingMore ? "loading…" : ""}
+            </div>
+          )}
+        </div>
+      )}
+      <DeletePostDialog
+        target={deleteTarget}
+        busy={busyId === deleteTarget?.id}
+        onClose={() => setDeleteTarget(null)}
+        onConfirm={async (reason) => {
+          if (!deleteTarget) return
+          const id = deleteTarget.id
+          setBusyId(id)
+          try {
+            await trackedAction(
+              "admin_post_deleted",
+              () => api.adminDeletePost(id, { reason: reason || undefined }),
+              () => ({ target_post_id: id }),
+            )
+            setDeleteTarget(null)
+            await load(q, sort, order, typeFilter, visibility, status)
+          } finally {
+            setBusyId(null)
+          }
+        }}
+      />
+    </main>
+  )
+}
+
+function FilterField({
+  label,
+  children,
+}: {
+  label: string
+  children: React.ReactNode
+}) {
+  return (
+    <div className="flex flex-col gap-1">
+      <span className="text-[10px] font-semibold tracking-wider text-muted-foreground uppercase">
+        {label}
+      </span>
+      {children}
+    </div>
+  )
+}
+
+function DeletePostDialog({
+  target,
+  busy,
+  onClose,
+  onConfirm,
+}: {
+  target: AdminPost | null
+  busy: boolean
+  onClose: () => void
+  onConfirm: (reason: string) => Promise<void>
+}) {
+  const [reason, setReason] = useState("")
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (target) {
+      setReason("")
+      setError(null)
+    }
+  }, [target])
+
+  const open = !!target
+
+  async function submit() {
+    setError(null)
+    try {
+      await onConfirm(reason.trim())
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "failed")
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={(next) => !next && onClose()}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Delete post</DialogTitle>
+          <DialogDescription>
+            Soft-deletes the post and records this action in the moderation log.
+          </DialogDescription>
+        </DialogHeader>
+        {target && (
+          <div className="rounded-md border border-border p-3 text-xs">
+            <p className="line-clamp-4 whitespace-pre-wrap">
+              {target.text || (
+                <span className="text-muted-foreground">(no text)</span>
+              )}
+            </p>
+            {target.author?.handle && (
+              <p className="mt-2 text-[10px] text-muted-foreground">
+                @{target.author.handle}
+              </p>
+            )}
+          </div>
+        )}
+        <div className="flex flex-col gap-1.5">
+          <Label
+            htmlFor="admin-post-delete-reason"
+            className="text-xs text-muted-foreground"
+          >
+            Reason (optional)
+          </Label>
+          <Input
+            id="admin-post-delete-reason"
+            value={reason}
+            onChange={(e) => setReason(e.target.value)}
+            placeholder="Reason"
+          />
+        </div>
+        {error && <p className="text-xs text-destructive">{error}</p>}
+        <DialogFooter>
+          <Button size="sm" variant="ghost" onClick={onClose} disabled={busy}>
+            Cancel
+          </Button>
+          <Button
+            size="sm"
+            variant="destructive"
+            onClick={submit}
+            disabled={busy}
+          >
+            {busy ? "Deleting…" : "Delete post"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/web/src/routes/admin.tsx
+++ b/apps/web/src/routes/admin.tsx
@@ -59,6 +59,12 @@ function AdminLayout() {
             Users
           </UnderlineTabLink>
           <UnderlineTabLink
+            to="/admin/posts"
+            active={path.startsWith("/admin/posts")}
+          >
+            Posts
+          </UnderlineTabLink>
+          <UnderlineTabLink
             to="/admin/reports"
             active={path.startsWith("/admin/reports")}
           >


### PR DESCRIPTION
## Summary

- Added a new admin posts page (`/admin/posts`) with a comprehensive table interface for browsing, searching, and managing posts
- Implemented backend API endpoint (`GET /api/admin/posts`) with support for sorting by multiple metrics (created date, likes, reposts, replies, quotes, bookmarks, impressions), filtering by post type/visibility/status, and text search
- Added virtualized table rendering with infinite scroll pagination for efficient handling of large post datasets
- Integrated post deletion functionality with optional reason tracking for moderation audit trail

## Test plan

- [x] `bun run typecheck` passes
- [x] Manually exercised the admin posts page with various filter/sort combinations
- [x] Verified pagination and infinite scroll loading works correctly
- [x] Tested post deletion dialog and moderation action tracking
- [x] No new console errors or network errors

## Notes

- Cursor-based pagination uses a `<value>~<uuid>` encoding to handle stable ordering when stat values tie
- Table uses React Virtual for efficient rendering of large datasets
- Post type detection is inferred from the presence of `replyToId`, `repostOfId`, or `quoteOfId` fields

https://claude.ai/code/session_019GEbKc2wWiEEJizeeqqCxA

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admin posts management page with search, filters (type/visibility/status), sorting, and virtualized table
  * Paginated, cursor-based admin posts API and client usage for efficient browsing and infinite scroll
  * Post soft-delete with confirmation modal and optional reason, plus tracking of deletions via analytics event
  * Admin navigation updated with a Posts tab linking to the new page
<!-- end of auto-generated comment: release notes by coderabbit.ai -->