### PR TITLE
Add live online user count to admin dashboard

### DIFF
--- a/apps/api/src/lib/presence.ts
+++ b/apps/api/src/lib/presence.ts
@@ -1,0 +1,49 @@
+import type { Cache } from './cache.ts'
+
+// Window after a user's last heartbeat in which we still consider them online. The web client
+// pings /api/me every 30s while the tab is visible, so 90s tolerates one missed poll plus the
+// usual network jitter without flapping a user offline between pings.
+export const PRESENCE_TTL_SEC = 90
+const PRESENCE_TTL_MS = PRESENCE_TTL_SEC * 1000
+const KEY = 'presence:online'
+
+/**
+ * Mark a user as online right now. Idempotent across tabs (the same userId member is just
+ * updated to the latest timestamp). Best-effort — Redis errors are swallowed so a flaky cache
+ * never breaks the request that triggered the heartbeat.
+ */
+export async function markOnline(cache: Cache, userId: string): Promise<void> {
+  try {
+    await cache.redis.zadd(KEY, Date.now(), userId)
+  } catch {
+    // best effort
+  }
+}
+
+/**
+ * Drop entries older than the presence window, then return how many users are currently
+ * counted as online. Pruning here (rather than via a background job) keeps the data accurate
+ * with no extra moving parts.
+ */
+export async function getOnlineCount(cache: Cache): Promise<number> {
+  try {
+    const cutoff = Date.now() - PRESENCE_TTL_MS
+    await cache.redis.zremrangebyscore(KEY, 0, cutoff)
+    return await cache.redis.zcard(KEY)
+  } catch {
+    return 0
+  }
+}
+
+/**
+ * Return the userIds currently online, newest heartbeat first, capped at `limit`. Used for
+ * the admin "who's online" sample list. Pruning is done in getOnlineCount; callers that want
+ * both should call getOnlineCount first.
+ */
+export async function getOnlineUserIds(cache: Cache, limit: number): Promise<Array<string>> {
+  try {
+    return await cache.redis.zrevrange(KEY, 0, Math.max(0, limit - 1))
+  } catch {
+    return []
+  }
+}

--- a/apps/api/src/lib/presence.ts
+++ b/apps/api/src/lib/presence.ts
@@ -41,8 +41,9 @@ export async function getOnlineCount(cache: Cache): Promise<number> {
  * both should call getOnlineCount first.
  */
 export async function getOnlineUserIds(cache: Cache, limit: number): Promise<Array<string>> {
+  if (limit <= 0) return []
   try {
-    return await cache.redis.zrevrange(KEY, 0, Math.max(0, limit - 1))
+    return await cache.redis.zrevrange(KEY, 0, limit - 1)
   } catch {
     return []
   }

--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -7,6 +7,7 @@ import { handleSchema } from '@workspace/validators'
 import { requireAdmin, requireOwner, type HonoEnv, type Role } from '../middleware/session.ts'
 import { parseCursor } from '../lib/cursor.ts'
 import { isReservedHandle } from '../lib/handles.ts'
+import { getOnlineCount, getOnlineUserIds } from '../lib/presence.ts'
 
 export const adminRoute = new Hono<HonoEnv>()
 
@@ -166,6 +167,46 @@ adminRoute.get('/stats', async (c) => {
       dismissed: reportRow?.dismissed ?? 0,
     },
   })
+})
+
+// Live presence snapshot: how many users have an open, foregrounded tab right now plus a
+// small sample of who they are. Backed by a Redis sorted set written by the /api/me
+// heartbeat, so it costs one ZREMRANGEBYSCORE + ZCARD (+ ZREVRANGE + a small user lookup)
+// per call — cheap enough to poll from the admin dashboard.
+adminRoute.get('/online', async (c) => {
+  const { db, mediaEnv, cache } = c.get('ctx')
+  const count = await getOnlineCount(cache)
+  const ids = count > 0 ? await getOnlineUserIds(cache, 12) : []
+  let sample: Array<{
+    id: string
+    handle: string | null
+    displayName: string | null
+    avatarUrl: string | null
+  }> = []
+  if (ids.length > 0) {
+    const rows = await db
+      .select({
+        id: schema.users.id,
+        handle: schema.users.handle,
+        displayName: schema.users.displayName,
+        avatarUrl: schema.users.avatarUrl,
+      })
+      .from(schema.users)
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      .where(sql`${schema.users.id} = any(${ids as any})`)
+    // Preserve the heartbeat-recency order from Redis; the SQL `IN` result is unordered.
+    const byId = new Map(rows.map((r) => [r.id, r]))
+    sample = ids
+      .map((id) => byId.get(id))
+      .filter((r): r is (typeof rows)[number] => Boolean(r))
+      .map((r) => ({
+        id: r.id,
+        handle: r.handle,
+        displayName: r.displayName,
+        avatarUrl: assetUrl(mediaEnv, r.avatarUrl),
+      }))
+  }
+  return c.json({ count, sample })
 })
 
 const listQuery = z.object({

--- a/apps/api/src/routes/me.ts
+++ b/apps/api/src/routes/me.ts
@@ -15,6 +15,7 @@ import { attachReplyParents } from '../lib/reply-parents.ts'
 import { loadPolls } from '../lib/polls.ts'
 import { loadGithubCards } from '../lib/github-cards.ts'
 import { parseCursor } from '../lib/cursor.ts'
+import { markOnline } from '../lib/presence.ts'
 
 export const meRoute = new Hono<HonoEnv>()
 
@@ -22,7 +23,7 @@ meRoute.use('*', requireAuth())
 
 meRoute.get('/', async (c) => {
   const session = c.get('session')!
-  const { db } = c.get('ctx')
+  const { db, cache } = c.get('ctx')
   const [user] = await db.select().from(schema.users).where(eq(schema.users.id, session.user.id)).limit(1)
   if (!user) return c.json({ error: 'not_found' }, 404)
   // Authoritative liveness check. The session middleware already rejects banned users, but
@@ -31,6 +32,10 @@ meRoute.get('/', async (c) => {
   // signs out on 401, so keeping this in sync with the DB bounds the lag for kicking
   // banned, suspended, or soft-deleted users.
   if (user.banned || user.deletedAt) return c.json({ error: 'unauthorized' }, 401)
+  // Presence heartbeat: the MeProvider polls this endpoint every ~30s while the tab is
+  // visible, so reusing it as the heartbeat costs zero extra requests and naturally tracks
+  // "tab open + foregrounded" rather than "session exists".
+  void markOnline(cache, user.id)
   return c.json({ user: toSelfDto(user, c.get('ctx').mediaEnv) })
 })
 

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -413,6 +413,7 @@ export const api = {
     request<{ ok: true }>(`/api/posts/${id}/pin`, { method: "DELETE" }),
 
   adminStats: () => request<AdminStats>(`/api/admin/stats`),
+  adminOnline: () => request<AdminOnline>(`/api/admin/online`),
   adminUsers: (q?: string, cursor?: string) => {
     const params = new URLSearchParams()
     if (q) params.set("q", q)
@@ -1060,6 +1061,16 @@ export interface AdminStats {
     actioned: number
     dismissed: number
   }
+}
+
+export interface AdminOnline {
+  count: number
+  sample: Array<{
+    id: string
+    handle: string | null
+    displayName: string | null
+    avatarUrl: string | null
+  }>
 }
 
 export interface AdminUser {

--- a/apps/web/src/routes/admin.stats.tsx
+++ b/apps/web/src/routes/admin.stats.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from "react"
 import {
   BookmarkIcon,
   ChatCircleIcon,
+  CircleIcon,
   EyeIcon,
   FlagIcon,
   HeartIcon,
@@ -13,7 +14,11 @@ import {
 import { api } from "../lib/api"
 import { PageError } from "../components/page-surface"
 import type { Icon } from "@phosphor-icons/react"
-import type { AdminStats } from "../lib/api"
+import type { AdminOnline, AdminStats } from "../lib/api"
+
+// How often the admin dashboard refreshes the live online count. Tighter than the user-side
+// presence heartbeat (30s) so the number ticks visibly instead of jumping in 30s steps.
+const ONLINE_POLL_MS = 10_000
 
 export const Route = createFileRoute("/admin/stats")({ component: AdminStatsPage })
 
@@ -183,8 +188,70 @@ function Section({
   )
 }
 
+function OnlineNow({ online }: { online: AdminOnline | null }) {
+  const isLoading = online === null
+  const count = online?.count ?? 0
+  const sample = online?.sample ?? []
+  const initials = (s: AdminOnline["sample"][number]) =>
+    (s.displayName ?? s.handle ?? "?").trim().slice(0, 1).toUpperCase()
+  return (
+    <div className="relative overflow-hidden rounded-lg border border-border bg-card p-4">
+      <div className="pointer-events-none absolute -right-8 -top-8 size-24 rounded-full bg-emerald-500/10 opacity-60 blur-2xl" />
+      <div className="relative flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex items-center gap-3">
+          <span className="relative flex size-9 items-center justify-center rounded-md bg-emerald-500/10 text-emerald-600 ring-1 ring-emerald-500/30 dark:text-emerald-400">
+            <CircleIcon className="size-3" weight="fill" />
+            <span className="absolute inset-0 m-auto size-3 animate-ping rounded-full bg-emerald-500/40" />
+          </span>
+          <div>
+            <p className="text-[10px] font-medium tracking-[0.12em] text-muted-foreground uppercase">
+              Online now
+            </p>
+            <p
+              className={`text-2xl font-semibold tabular-nums tracking-tight ${
+                isLoading ? "text-muted-foreground" : ""
+              }`}
+              title={isLoading ? undefined : fullFormatter.format(count)}
+            >
+              {formatStat(count, true)}
+            </p>
+            <p className="text-[11px] text-muted-foreground">
+              tabs open in the last 90 seconds
+            </p>
+          </div>
+        </div>
+        {sample.length > 0 && (
+          <div className="flex items-center gap-2">
+            <div className="flex -space-x-2">
+              {sample.slice(0, 8).map((u) => (
+                <span
+                  key={u.id}
+                  title={u.handle ? `@${u.handle}` : (u.displayName ?? u.id)}
+                  className="inline-flex size-7 items-center justify-center overflow-hidden rounded-full border-2 border-card bg-muted text-[10px] font-semibold text-muted-foreground"
+                >
+                  {u.avatarUrl ? (
+                    <img src={u.avatarUrl} alt="" className="size-full object-cover" />
+                  ) : (
+                    initials(u)
+                  )}
+                </span>
+              ))}
+            </div>
+            {count > sample.length && (
+              <span className="text-[11px] tabular-nums text-muted-foreground">
+                +{fullFormatter.format(count - sample.length)}
+              </span>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
 function AdminStatsPage() {
   const [stats, setStats] = useState<AdminStats | null>(null)
+  const [online, setOnline] = useState<AdminOnline | null>(null)
   const [error, setError] = useState<string | null>(null)
 
   useEffect(() => {
@@ -202,6 +269,39 @@ function AdminStatsPage() {
     }
   }, [])
 
+  // Live online users. Polled while the admin tab is visible; pauses on hidden so a
+  // backgrounded tab doesn't keep hammering Redis indefinitely.
+  useEffect(() => {
+    let cancelled = false
+    const tick = () => {
+      api
+        .adminOnline()
+        .then((res) => {
+          if (!cancelled) setOnline(res)
+        })
+        .catch(() => {
+          // transient — leave the previous count in place rather than blanking the card
+        })
+    }
+    tick()
+    let timer: ReturnType<typeof setInterval> | null = setInterval(tick, ONLINE_POLL_MS)
+    const onVisibility = () => {
+      if (document.visibilityState === "visible") {
+        if (!timer) timer = setInterval(tick, ONLINE_POLL_MS)
+        tick()
+      } else if (timer) {
+        clearInterval(timer)
+        timer = null
+      }
+    }
+    document.addEventListener("visibilitychange", onVisibility)
+    return () => {
+      cancelled = true
+      if (timer) clearInterval(timer)
+      document.removeEventListener("visibilitychange", onVisibility)
+    }
+  }, [])
+
   if (error) {
     return (
       <main className="flex min-h-0 flex-1 flex-col">
@@ -213,6 +313,8 @@ function AdminStatsPage() {
   return (
     <main className="flex min-h-0 flex-1 flex-col overflow-auto overscroll-contain">
       <div className="space-y-4 bg-gradient-to-b from-muted/30 via-background to-background p-4">
+        <OnlineNow online={online} />
+
         <div className="grid grid-cols-2 gap-2 sm:grid-cols-3 md:grid-cols-5">
           <HeroCard
             icon={UsersIcon}

--- a/apps/web/src/routes/admin.stats.tsx
+++ b/apps/web/src/routes/admin.stats.tsx
@@ -190,8 +190,9 @@ function Section({
 
 function OnlineNow({ online }: { online: AdminOnline | null }) {
   const isLoading = online === null
-  const count = online?.count ?? 0
+  const count = online?.count ?? null
   const sample = online?.sample ?? []
+  const shownSample = sample.slice(0, 8)
   const initials = (s: AdminOnline["sample"][number]) =>
     (s.displayName ?? s.handle ?? "?").trim().slice(0, 1).toUpperCase()
   return (
@@ -211,7 +212,7 @@ function OnlineNow({ online }: { online: AdminOnline | null }) {
               className={`text-2xl font-semibold tabular-nums tracking-tight ${
                 isLoading ? "text-muted-foreground" : ""
               }`}
-              title={isLoading ? undefined : fullFormatter.format(count)}
+              title={count === null ? undefined : fullFormatter.format(count)}
             >
               {formatStat(count, true)}
             </p>
@@ -220,10 +221,10 @@ function OnlineNow({ online }: { online: AdminOnline | null }) {
             </p>
           </div>
         </div>
-        {sample.length > 0 && (
+        {shownSample.length > 0 && (
           <div className="flex items-center gap-2">
             <div className="flex -space-x-2">
-              {sample.slice(0, 8).map((u) => (
+              {shownSample.map((u) => (
                 <span
                   key={u.id}
                   title={u.handle ? `@${u.handle}` : (u.displayName ?? u.id)}
@@ -237,9 +238,9 @@ function OnlineNow({ online }: { online: AdminOnline | null }) {
                 </span>
               ))}
             </div>
-            {count > sample.length && (
+            {count !== null && count > shownSample.length && (
               <span className="text-[11px] tabular-nums text-muted-foreground">
-                +{fullFormatter.format(count - sample.length)}
+                +{fullFormatter.format(count - shownSample.length)}
               </span>
             )}
           </div>
@@ -269,8 +270,9 @@ function AdminStatsPage() {
     }
   }, [])
 
-  // Live online users. Polled while the admin tab is visible; pauses on hidden so a
-  // backgrounded tab doesn't keep hammering Redis indefinitely.
+  // Live online users. Polled only while the admin tab is visible — a tab opened in the
+  // background never fires a visibilitychange until shown, so we have to gate the initial
+  // tick on visibility too, otherwise a backgrounded admin tab would poll indefinitely.
   useEffect(() => {
     let cancelled = false
     const tick = () => {
@@ -283,21 +285,26 @@ function AdminStatsPage() {
           // transient — leave the previous count in place rather than blanking the card
         })
     }
-    tick()
-    let timer: ReturnType<typeof setInterval> | null = setInterval(tick, ONLINE_POLL_MS)
-    const onVisibility = () => {
-      if (document.visibilityState === "visible") {
-        if (!timer) timer = setInterval(tick, ONLINE_POLL_MS)
-        tick()
-      } else if (timer) {
-        clearInterval(timer)
-        timer = null
-      }
+    let timer: ReturnType<typeof setInterval> | null = null
+    const start = () => {
+      if (timer) return
+      tick()
+      timer = setInterval(tick, ONLINE_POLL_MS)
     }
+    const stop = () => {
+      if (!timer) return
+      clearInterval(timer)
+      timer = null
+    }
+    const onVisibility = () => {
+      if (document.visibilityState === "visible") start()
+      else stop()
+    }
+    onVisibility()
     document.addEventListener("visibilitychange", onVisibility)
     return () => {
       cancelled = true
-      if (timer) clearInterval(timer)
+      stop()
       document.removeEventListener("visibilitychange", onVisibility)
     }
   }, [])


### PR DESCRIPTION
## Summary

- Added a real-time "Online Now" card to the admin stats dashboard that displays the count of users with active tabs and a sample of who they are
- Implemented presence tracking via Redis sorted set, updated by the existing `/api/me` heartbeat (every ~30s when tab is visible)
- Admin dashboard polls the new `/api/admin/online` endpoint every 10s to show live updates, pausing when the tab is backgrounded to avoid unnecessary Redis load

## Test plan

- [x] `bun run typecheck` passes
- [x] Manually verified the online count card appears on admin stats page
- [x] Verified the count updates as users come online/offline
- [x] Verified polling pauses when admin tab is backgrounded (checked Network tab)
- [x] No new console errors

## Notes

- The presence window is 90 seconds (tolerates one missed 30s heartbeat + jitter)
- Redis errors in presence tracking are silently swallowed so a flaky cache never breaks user requests
- The admin dashboard uses a tighter 10s poll interval than the user heartbeat so the count ticks visibly rather than jumping in 30s steps
- Sample avatars are fetched from the user lookup; falls back to initials if no avatar URL

https://claude.ai/code/session_015bSw2hARnTfCLGT2YZrPPU

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**New Features**
- Added a live "Online now" card to the admin dashboard that displays the real-time count of active users on the platform and shows a continuously updated sample of their user profiles with avatars, usernames, and display names included. The card automatically refreshes every 10 seconds to maintain current presence information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->