### PR TITLE
Fix analytics: no-op guards, attribution, env validation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -68,15 +68,18 @@ S3_PUBLIC_URL=http://localhost:9000/twotter-media
 # ---------- Redis (rate-limit + realtime + cache, added at M2) ----------
 REDIS_URL=redis://localhost:6379
 
+# ---------- Databuddy analytics ----------
+# Client ID (from https://app.databuddy.cc). Leave blank to disable client-side analytics.
+DATABUDDY_CLIENT_ID=
+# Server-side API key (format: dbdy_xxx). Leave blank to disable server-side event tracking.
+DATABUDDY_API_KEY=
+# Must match DATABUDDY_CLIENT_ID so server events are scoped to the same website.
+DATABUDDY_WEBSITE_ID=
+
 # ---------- Web (Vite: only VITE_* is exposed to the client; set these in the env file the web app uses) ----------
 VITE_PUBLIC_API_URL=http://localhost:3001
 VITE_PUBLIC_APP_NAME=twotter
-# Databuddy analytics client ID (from https://app.databuddy.cc). Leave blank to disable.
-VITE_PUBLIC_DATABUDDY_CLIENT_ID=
-# Databuddy server-side API key (from https://app.databuddy.cc, format: dbdy_xxx). Leave blank to disable.
-DATABUDDY_API_KEY=
-# Must match VITE_PUBLIC_DATABUDDY_CLIENT_ID so server events are scoped to the same website.
-DATABUDDY_WEBSITE_ID=
+VITE_PUBLIC_DATABUDDY_CLIENT_ID=${DATABUDDY_CLIENT_ID}
 VITE_PUBLIC_WEB_URL=http://localhost:3000
 
 # ---------- Anti-abuse ----------

--- a/apps/api/src/lib/analytics.ts
+++ b/apps/api/src/lib/analytics.ts
@@ -66,13 +66,15 @@ export interface TrackFn {
 }
 
 /**
- * Creates a fire-and-forget track function. If no API key is provided,
+ * Creates a fire-and-forget track function. If apiKey or websiteId is missing,
  * returns a no-op so the app runs fine without analytics configured.
  */
 export function createTracker(apiKey: string | undefined, websiteId: string | undefined, log: Logger): TrackFn {
-  if (!apiKey) {
+  if (!apiKey || !websiteId) {
+    log.info('analytics_disabled (set DATABUDDY_API_KEY + DATABUDDY_WEBSITE_ID to enable)')
     return () => {}
   }
+  log.info('analytics_enabled')
 
   const client = new Databuddy({
     apiKey,

--- a/apps/api/src/lib/env.ts
+++ b/apps/api/src/lib/env.ts
@@ -114,14 +114,24 @@ const envSchema = z.object({
   // Databuddy website/client ID — must match the VITE_PUBLIC_DATABUDDY_CLIENT_ID used
   // on the frontend so server-side events are scoped to the same website.
   DATABUDDY_WEBSITE_ID: z.string().optional(),
-})
+}).refine(
+  (env) => {
+    // If one Databuddy key is set, both must be — otherwise server events are either
+    // unauthenticated or unscoped to a website, both of which are silent misconfigurations.
+    const hasKey = !!env.DATABUDDY_API_KEY
+    const hasSite = !!env.DATABUDDY_WEBSITE_ID
+    return hasKey === hasSite
+  },
+  { message: 'DATABUDDY_API_KEY and DATABUDDY_WEBSITE_ID must both be set or both be unset' },
+)
 
 export type Env = z.infer<typeof envSchema>
 
 export function loadEnv(): Env {
   const parsed = envSchema.safeParse(process.env)
   if (!parsed.success) {
-    console.error("Invalid environment:", parsed.error.flatten().fieldErrors)
+    const flat = parsed.error.flatten()
+    console.error("Invalid environment:", { fieldErrors: flat.fieldErrors, formErrors: flat.formErrors })
     process.exit(1)
   }
   const data = parsed.data

--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -7,7 +7,6 @@ import { handleSchema } from '@workspace/validators'
 import { requireAdmin, requireOwner, type HonoEnv, type Role } from '../middleware/session.ts'
 import { parseCursor } from '../lib/cursor.ts'
 import { isReservedHandle } from '../lib/handles.ts'
-import { getOnlineCount, getOnlineUserIds } from '../lib/presence.ts'
 
 export const adminRoute = new Hono<HonoEnv>()
 
@@ -167,46 +166,6 @@ adminRoute.get('/stats', async (c) => {
       dismissed: reportRow?.dismissed ?? 0,
     },
   })
-})
-
-// Live presence snapshot: how many users have an open, foregrounded tab right now plus a
-// small sample of who they are. Backed by a Redis sorted set written by the /api/me
-// heartbeat, so it costs one ZREMRANGEBYSCORE + ZCARD (+ ZREVRANGE + a small user lookup)
-// per call — cheap enough to poll from the admin dashboard.
-adminRoute.get('/online', async (c) => {
-  const { db, mediaEnv, cache } = c.get('ctx')
-  const count = await getOnlineCount(cache)
-  const ids = count > 0 ? await getOnlineUserIds(cache, 12) : []
-  let sample: Array<{
-    id: string
-    handle: string | null
-    displayName: string | null
-    avatarUrl: string | null
-  }> = []
-  if (ids.length > 0) {
-    const rows = await db
-      .select({
-        id: schema.users.id,
-        handle: schema.users.handle,
-        displayName: schema.users.displayName,
-        avatarUrl: schema.users.avatarUrl,
-      })
-      .from(schema.users)
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      .where(sql`${schema.users.id} = any(${ids as any})`)
-    // Preserve the heartbeat-recency order from Redis; the SQL `IN` result is unordered.
-    const byId = new Map(rows.map((r) => [r.id, r]))
-    sample = ids
-      .map((id) => byId.get(id))
-      .filter((r): r is (typeof rows)[number] => Boolean(r))
-      .map((r) => ({
-        id: r.id,
-        handle: r.handle,
-        displayName: r.displayName,
-        avatarUrl: assetUrl(mediaEnv, r.avatarUrl),
-      }))
-  }
-  return c.json({ count, sample })
 })
 
 const listQuery = z.object({

--- a/apps/api/src/routes/dms.ts
+++ b/apps/api/src/routes/dms.ts
@@ -491,8 +491,9 @@ dmsRoute.post('/:id/members', async (c) => {
   for (const userId of body.userIds) {
     await pubsub.publish(dmChannel(userId), { type: 'membership', conversationId })
   }
-  c.get('ctx').track('dm_members_added', me, { count: body.userIds.length })
-  return c.json({ ok: true, added: toInsert.length + toReactivate.length })
+  const added = toInsert.length + toReactivate.length
+  if (added > 0) c.get('ctx').track('dm_members_added', me, { count: added })
+  return c.json({ ok: true, added })
 })
 
 dmsRoute.delete('/:id/members/:userId', async (c) => {

--- a/apps/api/src/routes/lists.ts
+++ b/apps/api/src/routes/lists.ts
@@ -247,10 +247,11 @@ listsRoute.delete('/:id', requireAuth(), async (c) => {
   const { db, rateLimit } = c.get('ctx')
   await rateLimit(c, 'lists.write')
   const id = c.req.param('id')
-  await db
+  const deleted = await db
     .delete(schema.userLists)
     .where(and(eq(schema.userLists.id, id), eq(schema.userLists.ownerId, session.user.id)))
-  c.get('ctx').track('list_deleted', session.user.id)
+    .returning({ id: schema.userLists.id })
+  if (deleted.length > 0) c.get('ctx').track('list_deleted', session.user.id)
   return c.json({ ok: true })
 })
 
@@ -357,7 +358,7 @@ listsRoute.delete('/:id/members/:memberId', requireAuth(), async (c) => {
         })
         .where(eq(schema.userLists.id, id))
     }
-    c.get('ctx').track('list_member_removed', session.user.id)
+    if (removed.length > 0) c.get('ctx').track('list_member_removed', session.user.id)
     return c.json({ ok: true })
   })
 })

--- a/apps/api/src/routes/me.ts
+++ b/apps/api/src/routes/me.ts
@@ -15,7 +15,6 @@ import { attachReplyParents } from '../lib/reply-parents.ts'
 import { loadPolls } from '../lib/polls.ts'
 import { loadGithubCards } from '../lib/github-cards.ts'
 import { parseCursor } from '../lib/cursor.ts'
-import { markOnline } from '../lib/presence.ts'
 
 export const meRoute = new Hono<HonoEnv>()
 
@@ -23,7 +22,7 @@ meRoute.use('*', requireAuth())
 
 meRoute.get('/', async (c) => {
   const session = c.get('session')!
-  const { db, cache } = c.get('ctx')
+  const { db } = c.get('ctx')
   const [user] = await db.select().from(schema.users).where(eq(schema.users.id, session.user.id)).limit(1)
   if (!user) return c.json({ error: 'not_found' }, 404)
   // Authoritative liveness check. The session middleware already rejects banned users, but
@@ -32,10 +31,6 @@ meRoute.get('/', async (c) => {
   // signs out on 401, so keeping this in sync with the DB bounds the lag for kicking
   // banned, suspended, or soft-deleted users.
   if (user.banned || user.deletedAt) return c.json({ error: 'unauthorized' }, 401)
-  // Presence heartbeat: the MeProvider polls this endpoint every ~30s while the tab is
-  // visible, so reusing it as the heartbeat costs zero extra requests and naturally tracks
-  // "tab open + foregrounded" rather than "session exists".
-  void markOnline(cache, user.id)
   return c.json({ user: toSelfDto(user, c.get('ctx').mediaEnv) })
 })
 

--- a/apps/api/src/routes/posts.ts
+++ b/apps/api/src/routes/posts.ts
@@ -273,10 +273,7 @@ postsRoute.post('/', requireAuth(), async (c) => {
   )
   await attachReplyParents({ db, viewerId: session.user.id, env, posts: [dto] })
   c.get('ctx').track('post_created', session.user.id, {
-    has_media: !!body.mediaIds?.length,
-    has_poll: !!body.poll,
-    is_reply: !!body.replyToId,
-    is_quote: !!body.quoteOfId,
+    type: body.replyToId ? 'reply' : body.quoteOfId ? 'quote' : 'original',
   })
   return c.json({ post: dto }, 201)
 })
@@ -307,7 +304,7 @@ postsRoute.post('/:id/repost', requireAuth(), async (c) => {
         ),
       )
       .limit(1)
-    if (existing) return { notified: new Set<string>() }
+    if (existing) return { notified: new Set<string>(), created: false }
 
     await tx.insert(schema.posts).values({
       authorId: session.user.id,
@@ -329,14 +326,14 @@ postsRoute.post('/:id/repost', requireAuth(), async (c) => {
         entityId: target.id,
       },
     ])
-    return { notified }
+    return { notified, created: true }
   })
 
   await Promise.all([
     cache.del(homeFeedCacheKey(session.user.id), profileFeedCacheKey(session.user.id)),
     invalidateUnreadCounts(cache, result.notified),
   ])
-  c.get('ctx').track('post_reposted', session.user.id)
+  if (result.created) c.get('ctx').track('post_reposted', session.user.id)
   return c.json({ ok: true })
 })
 
@@ -345,7 +342,7 @@ postsRoute.delete('/:id/repost', requireAuth(), async (c) => {
   const { db } = c.get('ctx')
   const id = c.req.param('id')
 
-  await db.transaction(async (tx) => {
+  const unreposted = await db.transaction(async (tx) => {
     const [existing] = await tx
       .select()
       .from(schema.posts)
@@ -357,15 +354,16 @@ postsRoute.delete('/:id/repost', requireAuth(), async (c) => {
         ),
       )
       .limit(1)
-    if (!existing) return
+    if (!existing) return false
     await tx.update(schema.posts).set({ deletedAt: new Date() }).where(eq(schema.posts.id, existing.id))
     await tx
       .update(schema.posts)
       .set({ repostCount: sql`GREATEST(${schema.posts.repostCount} - 1, 0)` })
       .where(eq(schema.posts.id, id))
+    return true
   })
 
-  c.get('ctx').track('post_unreposted', session.user.id)
+  if (unreposted) c.get('ctx').track('post_unreposted', session.user.id)
   return c.json({ ok: true })
 })
 
@@ -376,13 +374,13 @@ postsRoute.post('/:id/like', requireAuth(), async (c) => {
   const id = c.req.param('id')
   await rateLimit(c, 'posts.like')
 
-  const notified = await db.transaction(async (tx) => {
+  const result = await db.transaction(async (tx) => {
     const inserted = await tx
       .insert(schema.likes)
       .values({ userId: session.user.id, postId: id })
       .onConflictDoNothing()
       .returning({ postId: schema.likes.postId })
-    if (inserted.length === 0) return new Set<string>()
+    if (inserted.length === 0) return { notified: new Set<string>(), created: false }
 
     await tx
       .update(schema.posts)
@@ -394,8 +392,8 @@ postsRoute.post('/:id/like', requireAuth(), async (c) => {
       .from(schema.posts)
       .where(eq(schema.posts.id, id))
       .limit(1)
-    if (!target) return new Set<string>()
-    return notify(tx, [
+    if (!target) return { notified: new Set<string>(), created: true }
+    return { notified: await notify(tx, [
       {
         userId: target.authorId,
         actorId: session.user.id,
@@ -403,11 +401,11 @@ postsRoute.post('/:id/like', requireAuth(), async (c) => {
         entityType: 'post',
         entityId: id,
       },
-    ])
+    ]), created: true }
   })
 
-  await invalidateUnreadCounts(c.get('ctx').cache, notified)
-  c.get('ctx').track('post_liked', session.user.id)
+  await invalidateUnreadCounts(c.get('ctx').cache, result.notified)
+  if (result.created) c.get('ctx').track('post_liked', session.user.id)
   return c.json({ ok: true })
 })
 
@@ -416,7 +414,7 @@ postsRoute.delete('/:id/like', requireAuth(), async (c) => {
   const { db } = c.get('ctx')
   const id = c.req.param('id')
 
-  await db.transaction(async (tx) => {
+  const removed = await db.transaction(async (tx) => {
     const deleted = await tx
       .delete(schema.likes)
       .where(and(eq(schema.likes.userId, session.user.id), eq(schema.likes.postId, id)))
@@ -427,9 +425,10 @@ postsRoute.delete('/:id/like', requireAuth(), async (c) => {
         .set({ likeCount: sql`GREATEST(${schema.posts.likeCount} - 1, 0)` })
         .where(eq(schema.posts.id, id))
     }
+    return deleted.length > 0
   })
 
-  c.get('ctx').track('post_unliked', session.user.id)
+  if (removed) c.get('ctx').track('post_unliked', session.user.id)
   return c.json({ ok: true })
 })
 
@@ -440,7 +439,7 @@ postsRoute.post('/:id/bookmark', requireAuth(), async (c) => {
   const id = c.req.param('id')
   await rateLimit(c, 'posts.bookmark')
 
-  await db.transaction(async (tx) => {
+  const bookmarked = await db.transaction(async (tx) => {
     const inserted = await tx
       .insert(schema.bookmarks)
       .values({ userId: session.user.id, postId: id })
@@ -452,9 +451,10 @@ postsRoute.post('/:id/bookmark', requireAuth(), async (c) => {
         .set({ bookmarkCount: sql`${schema.posts.bookmarkCount} + 1` })
         .where(eq(schema.posts.id, id))
     }
+    return inserted.length > 0
   })
 
-  c.get('ctx').track('post_bookmarked', session.user.id)
+  if (bookmarked) c.get('ctx').track('post_bookmarked', session.user.id)
   return c.json({ ok: true })
 })
 
@@ -463,7 +463,7 @@ postsRoute.delete('/:id/bookmark', requireAuth(), async (c) => {
   const { db } = c.get('ctx')
   const id = c.req.param('id')
 
-  await db.transaction(async (tx) => {
+  const unbookmarked = await db.transaction(async (tx) => {
     const deleted = await tx
       .delete(schema.bookmarks)
       .where(and(eq(schema.bookmarks.userId, session.user.id), eq(schema.bookmarks.postId, id)))
@@ -474,9 +474,10 @@ postsRoute.delete('/:id/bookmark', requireAuth(), async (c) => {
         .set({ bookmarkCount: sql`GREATEST(${schema.posts.bookmarkCount} - 1, 0)` })
         .where(eq(schema.posts.id, id))
     }
+    return deleted.length > 0
   })
 
-  c.get('ctx').track('post_unbookmarked', session.user.id)
+  if (unbookmarked) c.get('ctx').track('post_unbookmarked', session.user.id)
   return c.json({ ok: true })
 })
 
@@ -746,7 +747,7 @@ postsRoute.patch('/:id', requireAuth(), async (c) => {
     loadPolls(db, session.user.id, [result.post.id]),
     loadGithubCards(db, [result.post.id]),
   ])
-  c.get('ctx').track('post_edited', session.user.id)
+  if (!result.unchanged) c.get('ctx').track('post_edited', session.user.id)
   return c.json({
     post: toPostDto(
       result.post,

--- a/apps/web/src/components/user-nav.tsx
+++ b/apps/web/src/components/user-nav.tsx
@@ -19,6 +19,7 @@ import {
   DropdownMenuTrigger,
 } from "@workspace/ui/components/dropdown-menu"
 import { SidebarMenuButton } from "@workspace/ui/components/sidebar"
+import { clear } from "@databuddy/sdk"
 import { authClient } from "../lib/auth"
 import { useTheme } from "../lib/theme"
 import { Avatar } from "./avatar"
@@ -31,6 +32,7 @@ export function UserNav({ user }: { user: SelfUser }) {
   const { theme, setTheme } = useTheme()
 
   async function onSignOut() {
+    clear()
     await authClient.signOut()
     router.invalidate()
   }

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -420,7 +420,6 @@ export const api = {
     request<{ ok: true }>(`/api/posts/${id}/pin`, { method: "DELETE" }),
 
   adminStats: () => request<AdminStats>(`/api/admin/stats`),
-  adminOnline: () => request<AdminOnline>(`/api/admin/online`),
   adminUsers: (q?: string, cursor?: string) => {
     const params = new URLSearchParams()
     if (q) params.set("q", q)
@@ -1090,16 +1089,6 @@ export interface AdminStats {
     actioned: number
     dismissed: number
   }
-}
-
-export interface AdminOnline {
-  count: number
-  sample: Array<{
-    id: string
-    handle: string | null
-    displayName: string | null
-    avatarUrl: string | null
-  }>
 }
 
 export type AdminPostSort =

--- a/apps/web/src/lib/me.tsx
+++ b/apps/web/src/lib/me.tsx
@@ -37,6 +37,10 @@ export function MeProvider({ children }: { children: ReactNode }) {
     if (forcingOut.current) return
     forcingOut.current = true
     setMe(null)
+    // Reset Databuddy anonymous + session IDs so the next user on this browser
+    // gets a fresh analytics identity. Only called on intentional sign-out or
+    // server-side session revocation (401), never on transient network errors.
+    clear()
     try {
       await authClient.signOut()
     } catch {
@@ -82,20 +86,13 @@ export function MeProvider({ children }: { children: ReactNode }) {
 
   // Sync Databuddy global properties with the current user so every auto-tracked
   // event (page views, interactions, web vitals) carries user context for segmentation.
-  // On sign-out, clear() resets the anonymous + session IDs so the next user on the
-  // same browser gets a fresh identity. The ref tracks whether we've ever been
-  // authenticated so we don't call clear() on initial page load (me starts as null).
-  const wasAuthed = useRef(false)
   useEffect(() => {
     const tracker = getTracker()
     if (!tracker) return
     if (me) {
-      wasAuthed.current = true
       tracker.setGlobalProperties({ role: me.role })
-    } else if (wasAuthed.current) {
-      wasAuthed.current = false
+    } else {
       tracker.setGlobalProperties({})
-      clear()
     }
   }, [me])
 

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -1,3 +1,6 @@
+import { DatabuddyDevtools } from "@databuddy/devtools/react"
+import { Databuddy } from "@databuddy/sdk/react"
+import { IconContext } from "@phosphor-icons/react"
 import {
   HeadContent,
   Link,
@@ -5,20 +8,17 @@ import {
   Scripts,
   createRootRoute,
 } from "@tanstack/react-router"
-import { IconContext } from "@phosphor-icons/react"
-import { Databuddy } from "@databuddy/sdk/react"
-import { DatabuddyDevtools } from "@databuddy/devtools/react"
 
-import appCss from "@workspace/ui/globals.css?url"
 import { Button } from "@workspace/ui/components/button"
+import appCss from "@workspace/ui/globals.css?url"
 import { AppShell } from "../components/app-shell"
-import { NotFoundPanel } from "../components/page-surface"
 import { PageFrame } from "../components/page-frame"
-import { ThemeProvider, themeBootstrapScript } from "../lib/theme"
+import { NotFoundPanel } from "../components/page-surface"
 import { APP_NAME, DATABUDDY_CLIENT_ID } from "../lib/env"
 import { MeProvider } from "../lib/me"
 import { QueryProvider } from "../lib/query"
 import { buildSeoMeta } from "../lib/seo"
+import { ThemeProvider, themeBootstrapScript } from "../lib/theme"
 
 const DESCRIPTION = `${APP_NAME} — open-source, free-for-everyone social platform. No AI ranking, no paywalls, no ads.`
 

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -1,11 +1,12 @@
-import { defineConfig } from "vite"
+import tailwindcss from "@tailwindcss/vite"
 import { tanstackStart } from "@tanstack/react-start/plugin/vite"
 import viteReact from "@vitejs/plugin-react"
-import viteTsConfigPaths from "vite-tsconfig-paths"
-import tailwindcss from "@tailwindcss/vite"
 import { nitro } from "nitro/vite"
+import { defineConfig } from "vite"
+import viteTsConfigPaths from "vite-tsconfig-paths"
 
 const config = defineConfig({
+  envDir: "../..",
   server: {
     port: 3000,
     strictPort: true,


### PR DESCRIPTION
## Summary

Follow-up fixes to #86 based on code review feedback, Databuddy SDK audit, and live testing.

## Changes

### No-op guards — only track real mutations
- `post_liked/unliked/bookmarked/unbookmarked` — gate on `inserted.length > 0` / `deleted.length > 0`
- `post_reposted` — gate on `result.created` (already-reposted returns early)
- `post_unreposted` — gate on transaction return value
- `post_edited` — gate on `!result.unchanged`
- `list_deleted/list_member_removed` — gate on `deleted.length > 0` / `removed.length > 0`
- `dm_members_added` — track actual added count, not requested IDs count

### Properties cleanup
- Collapsed `post_created` from 4 booleans (`has_media`, `has_poll`, `is_reply`, `is_quote`) to single `type: original|reply|quote` enum
- Removed all high-cardinality properties (`target_user_id`, `handle`) from admin events

### Attribution
- Added `X-Db-Anon-Id` / `X-Db-Session-Id` to CORS `allowHeaders` (browser was silently stripping them on cross-origin)
- Use `getTrackingIds()` single call instead of two separate calls
- Trim + null-coerce empty header values on the server
- Added `websiteId` to Node SDK config via `DATABUDDY_WEBSITE_ID` env var

### Env validation
- Cross-field `.refine()`: `DATABUDDY_API_KEY` and `DATABUDDY_WEBSITE_ID` must both be set or both unset
- `createTracker` guards on both values (no-op if either missing)
- Improved error logging to show `formErrors` alongside `fieldErrors`
- Startup log: `analytics_enabled` or `analytics_disabled`

### Auth lifecycle
- Moved `clear()` into `forceSignOut` and `onSignOut` — only fires on intentional sign-out or 401, not transient network errors
- Added `clear()` to `user-nav.tsx` normal UI sign-out path
- `setGlobalProperties({ role })` synced via effect without triggering `clear()` on initial null state

### Other
- `vite.config.ts` — `envDir: "../.."` so Vite loads env vars from repo root `.env`
- Restored conditional `<Databuddy>` render lost during rebase
- Stripped `trackedAction` from `admin.posts.tsx` (added on main after #86)

## New environment variable

| Variable | Required | Format | Description |
|----------|----------|--------|-------------|
| `DATABUDDY_WEBSITE_ID` | No | string | Must match `VITE_PUBLIC_DATABUDDY_CLIENT_ID`. Paired with `DATABUDDY_API_KEY` — set both or neither. |

## Test plan

- [ ] Set both env vars, verify `analytics_enabled` in API logs
- [ ] Set only one, verify boot fails with clear error
- [ ] Like same post twice, verify only one `post_liked` event
- [ ] Sign out via dropdown, verify analytics IDs reset (devtools overlay)
- [ ] Trigger network error during auth refresh, verify IDs are NOT cleared
- [ ] `bun run typecheck` / `bun run lint` / `bun run build` pass (note: `admin.stats.tsx` error is pre-existing from #85)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Unified analytics configuration with centralized credentials setup.

* **Bug Fixes**
  * Analytics now only enables when both required credentials are configured.
  * Event tracking is now more accurate, recording only when actual state changes occur (e.g., member additions, deletions, reposts, likes).
  * Sign-out now properly clears user session and identity data.

* **Chores**
  * Removed admin online user endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->