### PR TITLE
bug: mobile nav fix

### DIFF
--- a/apps/web/src/components/app-shell.tsx
+++ b/apps/web/src/components/app-shell.tsx
@@ -15,7 +15,7 @@ import {
   DialogTitle,
 } from "@workspace/ui/components/dialog"
 import { Button } from "@workspace/ui/components/button"
-import { useEffect } from "react"
+import { useEffect, useRef } from "react"
 import { authClient } from "../lib/auth"
 import { api } from "../lib/api"
 import { AppPageHeaderProvider } from "./app-page-header"
@@ -56,9 +56,13 @@ export function AppShell({ children }: { children: ReactNode }) {
 function SidebarCloseOnNavigate() {
   const router = useRouter()
   const { setOpenMobile } = useSidebar()
+  const lastPath = useRef(router.state.location.pathname)
 
   useEffect(() => {
     return router.subscribe("onResolved", () => {
+      const next = router.state.location.pathname
+      if (next === lastPath.current) return
+      lastPath.current = next
       setOpenMobile(false)
     })
   }, [router, setOpenMobile])


### PR DESCRIPTION
## Summary
On mobile, tapping the hamburger on any non-home route (profile, post detail, etc.) did nothing — the drawer either flashed open and snapped shut or never opened at all. Home worked fine.

## Cause
`SidebarCloseOnNavigate` subscribed to TanStack Router's `onResolved` and called `setOpenMobile(false)` on every fire. `onResolved` doesn't only fire for "user navigated to a new URL" — it also fires whenever the current route re-resolves (loader re-runs, query invalidations, focus refetches, etc.). Subroutes have heavier loader/data dependencies than home, so on those pages the drawer's `open` state was being slammed back to `false` while the user was trying to open it.

Desktop was unaffected because it uses a separate `open` state, not `openMobile`.

## Fix
Track the previous pathname in a ref and only close the drawer when the pathname actually changes — same-route resolutions are ignored.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed mobile sidebar behavior to prevent unnecessary closure when navigating to routes with the same pathname, ensuring a more stable experience during app navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->