### PR TITLE
Add runtime maintenance mode kill switch

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -83,6 +83,18 @@ VITE_PUBLIC_WEB_URL=http://localhost:3000
 TURNSTILE_SITE_KEY=
 TURNSTILE_SECRET_KEY=
 
+# ---------- Maintenance / kill switch ----------
+# Server: when true, every request (except /healthz and /readyz) gets a 503 with
+# `{ error: "maintenance" }`. Toggle + restart to lock down the app at runtime when
+# abuse is in progress — no redeploy needed.
+# MAINTENANCE_MODE=false
+# Optional human-readable message rendered on the client maintenance screen.
+# MAINTENANCE_MESSAGE=We're temporarily down for maintenance. Check back shortly.
+# Client (build-time): when true, the bundled web app refuses to even hit the network
+# and renders the maintenance screen on load. Belt-and-suspenders to keep cached
+# clients from hammering the API during incidents — requires a redeploy to flip.
+# VITE_PUBLIC_MAINTENANCE_MODE=false
+
 # ---------- Observability ----------
 LOG_LEVEL=info
 SENTRY_DSN=

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -77,6 +77,19 @@ app.use(
     maxAge: 86400,
   }),
 )
+// Hard kill switch. Runs after CORS so the 503 response carries the right CORS headers and
+// the browser can read the body. Health probes bypass so orchestrators don't route the
+// instance out while we're locking the app down.
+app.use('*', async (c, next) => {
+  if (!ctx.env.MAINTENANCE_MODE) return next()
+  const path = c.req.path
+  if (path === '/healthz' || path === '/readyz') return next()
+  c.header('Retry-After', '300')
+  return c.json(
+    { error: 'maintenance', message: ctx.env.MAINTENANCE_MESSAGE },
+    503,
+  )
+})
 app.use('*', sessionMiddleware(ctx))
 app.use('*', requireSameOrigin(ctx.env.AUTH_TRUSTED_ORIGINS))
 

--- a/apps/api/src/lib/env.ts
+++ b/apps/api/src/lib/env.ts
@@ -108,6 +108,20 @@ const envSchema = z.object({
     .default("false")
     .transform((v) => v === "true"),
 
+  // Hard kill switch. When true, every request (except /healthz and /readyz) is short-circuited
+  // with a 503 + `{ error: "maintenance" }` so the app can be locked down at runtime without a
+  // redeploy when abuse is in progress. The client detects the 503 and renders a maintenance
+  // screen over the whole UI.
+  MAINTENANCE_MODE: z
+    .enum(["true", "false"])
+    .default("false")
+    .transform((v) => v === "true"),
+  // Human-readable banner shown on the maintenance screen. Kept on the server so it can be
+  // updated without a client redeploy.
+  MAINTENANCE_MESSAGE: z
+    .string()
+    .default("We're temporarily down for maintenance. Check back shortly."),
+
   // Databuddy server-side analytics API key (format: dbdy_xxx). Optional — if unset,
   // server-side event tracking is silently disabled.
   DATABUDDY_API_KEY: z.string().optional(),

--- a/apps/web/src/components/maintenance-screen.tsx
+++ b/apps/web/src/components/maintenance-screen.tsx
@@ -1,0 +1,22 @@
+import { APP_NAME } from "../lib/env"
+
+const DEFAULT_MESSAGE =
+  "We're temporarily down for maintenance. Check back shortly."
+
+export function MaintenanceScreen({ message }: { message?: string | null }) {
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center gap-6 bg-background px-6 text-center">
+      <div className="flex size-14 items-center justify-center rounded-xl bg-primary text-2xl font-bold text-primary-foreground">
+        {APP_NAME.slice(0, 1).toLowerCase()}
+      </div>
+      <div className="max-w-md space-y-2">
+        <h1 className="text-2xl font-semibold tracking-tight">
+          Be right back
+        </h1>
+        <p className="text-sm text-muted-foreground">
+          {message ?? DEFAULT_MESSAGE}
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -36,15 +36,18 @@ async function request<T>(path: string, init?: RequestInit): Promise<T> {
     ...init,
   })
   if (!res.ok) {
-    const body = await res.json().catch(() => ({ error: "unknown" }))
-    if (res.status === 503 && body.error === "maintenance") {
-      setRuntimeMaintenance(true, typeof body.message === "string" ? body.message : null)
+    const raw: unknown = await res.json().catch(() => null)
+    const body =
+      raw && typeof raw === "object" && !Array.isArray(raw)
+        ? (raw as Record<string, unknown>)
+        : null
+    const code = typeof body?.error === "string" ? body.error : "unknown"
+    const messageStr =
+      typeof body?.message === "string" ? body.message : null
+    if (res.status === 503 && code === "maintenance") {
+      setRuntimeMaintenance(true, messageStr)
     }
-    throw new ApiError(
-      res.status,
-      body.error ?? "unknown",
-      body.message ?? res.statusText
-    )
+    throw new ApiError(res.status, code, messageStr ?? res.statusText)
   }
   return (await res.json()) as T
 }

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1,5 +1,6 @@
 import { getTrackingIds } from "@databuddy/sdk"
-import { API_URL } from "./env"
+import { API_URL, MAINTENANCE_MODE } from "./env"
+import { setRuntimeMaintenance } from "./maintenance"
 import type { GithubCard } from "@workspace/github-unfurl/card"
 
 export type { GithubCard } from "@workspace/github-unfurl/card"
@@ -15,6 +16,11 @@ export class ApiError extends Error {
 }
 
 async function request<T>(path: string, init?: RequestInit): Promise<T> {
+  // Build-time kill switch: refuse to even hit the network so a cached client
+  // can't keep abusing the API while we're locked down.
+  if (MAINTENANCE_MODE) {
+    throw new ApiError(503, "maintenance", "maintenance")
+  }
   const trackingHeaders: Record<string, string> = {}
   const { anonId, sessionId } = getTrackingIds()
   if (anonId) trackingHeaders["X-Db-Anon-Id"] = anonId
@@ -31,6 +37,9 @@ async function request<T>(path: string, init?: RequestInit): Promise<T> {
   })
   if (!res.ok) {
     const body = await res.json().catch(() => ({ error: "unknown" }))
+    if (res.status === 503 && body.error === "maintenance") {
+      setRuntimeMaintenance(true, typeof body.message === "string" ? body.message : null)
+    }
     throw new ApiError(
       res.status,
       body.error ?? "unknown",

--- a/apps/web/src/lib/auth.ts
+++ b/apps/web/src/lib/auth.ts
@@ -1,6 +1,29 @@
 import { createClient } from "@workspace/auth/client"
 import { API_URL } from "./env"
+import { setRuntimeMaintenance } from "./maintenance"
 
-export const authClient = createClient(API_URL)
+export const authClient = createClient(API_URL, {
+  // better-auth uses its own fetch, so it bypasses our api.ts request wrapper. Mirror the
+  // 503 maintenance detection here so locking down the server also flips the client gate
+  // when the auth session probe (which fires before any other call on cold load) is the
+  // first request to hit the wall.
+  onResponse: async (res) => {
+    if (res.status !== 503) return
+    let body: unknown = null
+    try {
+      body = await res.clone().json()
+    } catch {
+      return
+    }
+    if (
+      body &&
+      typeof body === "object" &&
+      (body as { error?: unknown }).error === "maintenance"
+    ) {
+      const message = (body as { message?: unknown }).message
+      setRuntimeMaintenance(true, typeof message === "string" ? message : null)
+    }
+  },
+})
 
 export const { signIn, signUp, signOut, useSession, getSession } = authClient

--- a/apps/web/src/lib/env.ts
+++ b/apps/web/src/lib/env.ts
@@ -5,3 +5,9 @@ export const WEB_URL =
 export const APP_NAME = import.meta.env.VITE_PUBLIC_APP_NAME ?? "twotter"
 export const DATABUDDY_CLIENT_ID = import.meta.env
   .VITE_PUBLIC_DATABUDDY_CLIENT_ID as string | undefined
+
+// Build-time hard block. When true the app refuses to render anything beyond the
+// maintenance screen — used as a belt-and-suspenders companion to the server-side
+// MAINTENANCE_MODE so cached clients don't even attempt API calls during incidents.
+export const MAINTENANCE_MODE =
+  import.meta.env.VITE_PUBLIC_MAINTENANCE_MODE === "true"

--- a/apps/web/src/lib/maintenance.ts
+++ b/apps/web/src/lib/maintenance.ts
@@ -1,31 +1,39 @@
 import { useSyncExternalStore } from "react"
 import { MAINTENANCE_MODE as BUILD_MAINTENANCE } from "./env"
 
+type RuntimeMaintenanceState = {
+  active: boolean
+  message: string | null
+}
+
 // Subscribable runtime maintenance state. Flipped to true by the api wrapper when any
 // request returns 503 with `{ error: "maintenance" }`. The root layout subscribes and
 // renders a full-screen lockout — every page in the app sits behind that gate.
 const listeners = new Set<() => void>()
-let runtimeActive = false
-let runtimeMessage: string | null = null
+let runtimeState: RuntimeMaintenanceState = { active: false, message: null }
+const serverSnapshot: RuntimeMaintenanceState = { active: false, message: null }
+const buildSnapshot: RuntimeMaintenanceState = { active: true, message: null }
 
 function notify() {
   for (const fn of listeners) fn()
 }
 
 export function setRuntimeMaintenance(active: boolean, message?: string | null) {
-  const nextMessage = active ? (message ?? runtimeMessage) : null
-  if (active === runtimeActive && nextMessage === runtimeMessage) return
-  runtimeActive = active
-  runtimeMessage = nextMessage
+  const nextMessage = active ? (message ?? runtimeState.message) : null
+  if (active === runtimeState.active && nextMessage === runtimeState.message) return
+  runtimeState = { active, message: nextMessage }
   notify()
 }
 
+// useSyncExternalStore compares snapshots with Object.is — return the cached object
+// reference (mutated only on real state changes) so React doesn't loop, but message-only
+// updates still trigger a re-render.
 function getSnapshot() {
-  return runtimeActive
+  return runtimeState
 }
 
 function getServerSnapshot() {
-  return false
+  return serverSnapshot
 }
 
 function subscribe(fn: () => void) {
@@ -35,8 +43,8 @@ function subscribe(fn: () => void) {
   }
 }
 
-export function useMaintenance(): { active: boolean; message: string | null } {
+export function useMaintenance(): RuntimeMaintenanceState {
   const runtime = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot)
-  if (BUILD_MAINTENANCE) return { active: true, message: null }
-  return { active: runtime, message: runtime ? runtimeMessage : null }
+  if (BUILD_MAINTENANCE) return buildSnapshot
+  return runtime
 }

--- a/apps/web/src/lib/maintenance.ts
+++ b/apps/web/src/lib/maintenance.ts
@@ -1,0 +1,42 @@
+import { useSyncExternalStore } from "react"
+import { MAINTENANCE_MODE as BUILD_MAINTENANCE } from "./env"
+
+// Subscribable runtime maintenance state. Flipped to true by the api wrapper when any
+// request returns 503 with `{ error: "maintenance" }`. The root layout subscribes and
+// renders a full-screen lockout — every page in the app sits behind that gate.
+const listeners = new Set<() => void>()
+let runtimeActive = false
+let runtimeMessage: string | null = null
+
+function notify() {
+  for (const fn of listeners) fn()
+}
+
+export function setRuntimeMaintenance(active: boolean, message?: string | null) {
+  const nextMessage = active ? (message ?? runtimeMessage) : null
+  if (active === runtimeActive && nextMessage === runtimeMessage) return
+  runtimeActive = active
+  runtimeMessage = nextMessage
+  notify()
+}
+
+function getSnapshot() {
+  return runtimeActive
+}
+
+function getServerSnapshot() {
+  return false
+}
+
+function subscribe(fn: () => void) {
+  listeners.add(fn)
+  return () => {
+    listeners.delete(fn)
+  }
+}
+
+export function useMaintenance(): { active: boolean; message: string | null } {
+  const runtime = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot)
+  if (BUILD_MAINTENANCE) return { active: true, message: null }
+  return { active: runtime, message: runtime ? runtimeMessage : null }
+}

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -12,10 +12,12 @@ import { DatabuddyDevtools } from "@databuddy/devtools/react"
 import appCss from "@workspace/ui/globals.css?url"
 import { Button } from "@workspace/ui/components/button"
 import { AppShell } from "../components/app-shell"
+import { MaintenanceScreen } from "../components/maintenance-screen"
 import { NotFoundPanel } from "../components/page-surface"
 import { PageFrame } from "../components/page-frame"
 import { ThemeProvider, themeBootstrapScript } from "../lib/theme"
 import { APP_NAME, DATABUDDY_CLIENT_ID } from "../lib/env"
+import { useMaintenance } from "../lib/maintenance"
 import { MeProvider } from "../lib/me"
 import { QueryProvider } from "../lib/query"
 import { buildSeoMeta } from "../lib/seo"
@@ -76,34 +78,50 @@ export const Route = createRootRoute({
     </AppShell>
   ),
   shellComponent: RootDocument,
-  component: () => (
-    <IconContext.Provider value={{ weight: "duotone" }}>
-      <QueryProvider>
-        <ThemeProvider>
-          <MeProvider>
-            <AppShell>
-              <Outlet />
-            </AppShell>
-            {DATABUDDY_CLIENT_ID ? (
-              <Databuddy
-                clientId={DATABUDDY_CLIENT_ID}
-                trackWebVitals
-                trackErrors
-                trackPerformance
-                trackOutgoingLinks
-                trackInteractions
-                enableBatching
-                batchSize={20}
-                maskPatterns={["/inbox/*", "/admin/*"]}
-              />
-            ) : null}
-            <DatabuddyDevtools enabled={import.meta.env.DEV} />
-          </MeProvider>
-        </ThemeProvider>
-      </QueryProvider>
-    </IconContext.Provider>
-  ),
+  component: RootComponent,
 })
+
+function RootComponent() {
+  return (
+    <IconContext.Provider value={{ weight: "duotone" }}>
+      <ThemeProvider>
+        <MaintenanceGate>
+          <QueryProvider>
+            <MeProvider>
+              <AppShell>
+                <Outlet />
+              </AppShell>
+              {DATABUDDY_CLIENT_ID ? (
+                <Databuddy
+                  clientId={DATABUDDY_CLIENT_ID}
+                  trackWebVitals
+                  trackErrors
+                  trackPerformance
+                  trackOutgoingLinks
+                  trackInteractions
+                  enableBatching
+                  batchSize={20}
+                  maskPatterns={["/inbox/*", "/admin/*"]}
+                />
+              ) : null}
+              <DatabuddyDevtools enabled={import.meta.env.DEV} />
+            </MeProvider>
+          </QueryProvider>
+        </MaintenanceGate>
+      </ThemeProvider>
+    </IconContext.Provider>
+  )
+}
+
+// Whole-app lockout. When build-time VITE_PUBLIC_MAINTENANCE_MODE is set, or the api wrapper
+// has seen a 503 maintenance response, swap the entire app for the maintenance screen. Sits
+// inside ThemeProvider so the screen still respects the user's theme but outside the query
+// + me providers so we don't keep retrying API calls behind the lockout.
+function MaintenanceGate({ children }: { children: React.ReactNode }) {
+  const { active, message } = useMaintenance()
+  if (active) return <MaintenanceScreen message={message} />
+  return <>{children}</>
+}
 
 function RootDocument({ children }: { children: React.ReactNode }) {
   return (

--- a/packages/auth/src/client.ts
+++ b/packages/auth/src/client.ts
@@ -1,12 +1,24 @@
 import { createAuthClient } from 'better-auth/react'
 import { magicLinkClient } from 'better-auth/client/plugins'
 
-export function createClient(baseURL: string) {
+export interface CreateClientOptions {
+  /** Forwarded to better-fetch as a response observer. Lets the consumer hook into every
+   *  auth response (e.g. to detect a server-side maintenance 503). */
+  onResponse?: (res: Response) => void | Promise<void>
+}
+
+export function createClient(baseURL: string, options: CreateClientOptions = {}) {
+  const onResponse = options.onResponse
   return createAuthClient({
     baseURL,
     plugins: [magicLinkClient()],
     fetchOptions: {
       credentials: 'include',
+      onResponse: onResponse
+        ? async (ctx) => {
+            await onResponse(ctx.response)
+          }
+        : undefined,
     },
   })
 }


### PR DESCRIPTION
## Summary

- Implement a runtime maintenance mode that allows locking down the app without redeployment when abuse is in progress
- Add server-side `MAINTENANCE_MODE` env var that returns 503 responses (except for health checks) with a configurable message
- Add client-side detection of 503 maintenance responses in both the API wrapper and auth client, triggering a full-screen maintenance gate
- Add build-time `VITE_PUBLIC_MAINTENANCE_MODE` as a belt-and-suspenders measure to prevent cached clients from hitting the API during incidents

## Test plan

- [x] `bun run typecheck` passes
- [x] Manually verified maintenance screen renders when `MAINTENANCE_MODE=true` on server
- [x] Verified health check endpoints (`/healthz`, `/readyz`) bypass the maintenance gate
- [x] Verified client detects 503 maintenance response and renders lockout screen
- [x] Verified build-time flag prevents any API calls when set

## Notes

**Environment variables added:**
- `MAINTENANCE_MODE` (server): Toggle to lock down the app at runtime without redeploy
- `MAINTENANCE_MESSAGE` (server): Optional custom message shown on maintenance screen
- `VITE_PUBLIC_MAINTENANCE_MODE` (client, build-time): Hard block for cached clients, requires redeploy to toggle

**Architecture:**
- Maintenance gate sits inside `ThemeProvider` but outside `QueryProvider` and `MeProvider` to prevent unnecessary API retries behind the lockout
- Uses `useSyncExternalStore` for reactive runtime maintenance state that can be updated by API responses
- Auth client mirrors the 503 detection since it uses its own fetch and bypasses the main API wrapper

https://claude.ai/code/session_01MkjeeB8sdaGMk17oiRNKYz

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Global maintenance mode with both server-side and client-side toggles to display a full-screen maintenance UI.
  * Optional custom maintenance message shown to users.
  * Health endpoints continue to respond during maintenance; other requests return appropriate maintenance status with retry guidance.
  * Client runtime sync so apps detect and honor maintenance state without mounting normal app UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->