### PR TITLE
[Algo] Part 1: Shared feed policy and ranking contracts

### DIFF
--- a/docs/algo/ALGO_DESIGN.md
+++ b/docs/algo/ALGO_DESIGN.md
@@ -1,0 +1,599 @@
+# Recommendation Algorithm Design
+
+This document is intentionally **repo-agnostic**.
+
+It describes the product/system design for a first-generation `For You` feed:
+
+- what components should exist
+- what responsibilities they should own
+- what ranking mechanisms are worth adopting
+- what should explicitly wait until later
+
+It is **not** the codebase integration doc.
+
+For repository structure, file paths, ownership inside the current monorepo, and concrete implementation sequencing, see:
+
+- `ALGO_PLAN.md`
+
+## Final call
+
+For the first version of the `For You` feed:
+
+- **Do not build the ranking system in Go.**
+- **Build a separate internal ranking service in TypeScript.**
+- **Keep post hydration and final response shaping in the existing client-facing API layer.**
+- **Use Postgres as the primary online feature source; add aggregate tables only where they clearly improve quality or latency.**
+- **If aggregate tables are not ready at launch, compute a small recent-window freshness signal on demand for the final candidate set.**
+- **Use deterministic experiment bucketing and shared `algoVersion` / variant logic between the request layer and the ranking service.**
+- **Structure the ranker internally as a composable pipeline: query context hydration, sources, pre-filters, scorers/rerankers, post-selection checks, and side effects.**
+- **Add short-TTL caching for ranked first-page results.**
+- **Use Redis-backed ranked sessions for stable pagination.**
+- **Enforce strict timeout + fallback so ranking problems never hurt core post/create/read endpoints.**
+- **Use shared feed eligibility/filter rules so ranking and response layers do not drift on visibility, block, mute, and deletion behavior.**
+
+---
+
+## Why this is the right tradeoff
+
+This decision is based on the current product and traffic assumptions:
+
+- target latency: **p95 under 300ms**
+- freshness requirement: **30–60 seconds stale is acceptable**
+- expected scale: about **5k DAU** and **up to 10k posts/day**
+- ranking complexity: **heuristic now, ML later**
+- candidate count: about **100–500 posts per request**
+- team: **same full-stack/backend team owns it**
+- ops appetite: **one extra service is acceptable**
+
+At this stage, the main bottlenecks are much more likely to be:
+
+- candidate fetches
+- feature lookups
+- joins / aggregation
+- cache misses
+- hydration / serialization
+
+—not raw scoring CPU.
+
+Because of that, a rewrite in Go would add complexity without likely producing meaningful product wins yet.
+
+---
+
+## Architecture decision
+
+### 1. Separate ranking service
+
+Create a dedicated internal ranking service.
+
+Responsibilities:
+
+- hydrate compact request context
+  - viewer graph, recent interaction context, experiment/version info
+- generate `For You` candidates from multiple sources
+- assign candidate metadata such as `sourceBucket` and `networkClass`
+- run pre-scoring filters
+  - duplicate removal, repost/original dedup, self-post suppression, age cutoffs, social-graph filters
+- score candidates
+- apply reranking / diversity constraints
+  - especially author diversity, reply control, and bucket saturation limits
+- run post-selection checks before returning IDs
+- manage ranked pagination sessions
+- run non-critical side effects such as caching/request logging
+- return ranked post IDs, cursor, algorithm version, and experiment variant
+
+This service should be isolated from the main API so that slow ranking work cannot degrade:
+
+- post creation
+- post reads
+- notifications
+- profile routes
+- other core app traffic
+
+### 2. Client-facing API remains the hydration layer
+
+The client-facing API layer should continue to own:
+
+- auth / session handling
+- client-facing endpoint contracts
+- post DTO generation
+- media loading
+- repost / quote / reply-parent hydration
+- viewer flags
+- final response shaping
+- final safety filtering before response
+
+Recommended request flow:
+
+1. Client requests the `For You` feed
+2. Client-facing API authenticates the user
+3. Client-facing API computes `variant` and `algoVersion` using shared logic
+4. Client-facing API checks first-page cache when eligible
+5. Client-facing API calls the internal ranking service
+6. Ranker returns ordered post IDs plus cursor and algorithm metadata
+7. Client-facing API hydrates those posts using the normal post rendering pipeline
+8. Client-facing API re-checks visibility / mute / block / deletion constraints
+9. Client-facing API returns the final feed response
+
+This keeps ranking isolated while avoiding duplication of all post rendering logic.
+
+### 3. Shared feed eligibility / filter helpers
+
+Do not duplicate feed safety logic by hand across services.
+
+Extract shared helpers for rules such as:
+
+- `deletedAt is null`
+- public visibility requirements
+- block relationships
+- feed mutes
+- viewer-specific exclusions
+
+The ranker should use these helpers during candidate generation, and the API should still perform a final safety check before returning hydrated results.
+
+Without this, the ranker and API will drift and create:
+
+- short pages
+- hard-to-debug dropped IDs
+- inconsistent visibility behavior across feeds
+
+### 4. Internal pipeline pattern
+
+One idea worth borrowing from larger feed systems is the **serving architecture shape**, not the full ML stack.
+
+The ranker should be organized internally as a pipeline with stages such as:
+
+1. query context hydration
+2. candidate sources
+3. candidate hydrators
+4. pre-scoring filters
+5. scorers / rerankers
+6. selector
+7. post-selection checks
+8. side effects
+
+This is useful because it:
+
+- keeps business logic composable
+- lets independent sources/hydrators run in parallel where useful
+- makes it easier to reason about failures per stage
+- gives a clean place to add or remove heuristics later
+
+We should borrow that structure, but **not** copy the heavy ML/retrieval stack 1:1.
+
+---
+
+## Language choice
+
+### Use TypeScript for v1
+
+Use the existing stack for the ranker service.
+
+Reasons:
+
+- fastest implementation speed
+- easiest sharing of contracts/helpers with the current API
+- easiest experimentation with multiple formulas
+- lowest organizational overhead for the current team
+- candidate counts are small enough that TypeScript performance should be fine
+
+### Do not use Go yet
+
+Go may become useful later if the ranker becomes:
+
+- significantly CPU-bound
+- much higher QPS
+- much larger candidate sets
+- embedding / ANN / retrieval heavy
+- a specialized infrastructure service with tighter p95/p99 goals
+
+But for v1, Go is premature.
+
+---
+
+## Feature storage strategy
+
+Do **not** introduce a full feature store, vector DB, or warehouse-backed online ranking path yet.
+
+### Primary source of truth: Postgres
+
+Use Postgres tables and joins for core data such as:
+
+- follows
+- likes
+- reposts
+- replies
+- blocks / mutes
+- post metadata
+- post age
+- author relationships
+
+### Prefer a small number of precomputed aggregates when they pay for themselves
+
+Useful examples, once justified:
+
+#### `user_author_affinity`
+Tracks how much a user tends to engage with an author.
+
+Possible fields:
+
+- `user_id`
+- `author_id`
+- `affinity_score`
+- `last_interaction_at`
+- optional counters for likes/replies/reposts/clicks
+
+#### `post_engagement_velocity`
+Tracks recent normalized engagement on a post.
+
+Possible fields:
+
+- `post_id`
+- `like_count_30m`
+- `reply_count_30m`
+- `repost_count_30m`
+- `engagement_score_1h`
+- `engagement_score_6h`
+- `updated_at`
+
+#### Later, if needed: `user_topic_affinity`
+Tracks affinity to hashtags, keywords, or topic clusters.
+
+Possible fields:
+
+- `user_id`
+- `topic_key`
+- `score`
+- `updated_at`
+
+### Launch shortcut if aggregates are not ready yet
+
+If aggregate tables are not ready for launch, that should **not** block v1.
+
+A good interim approach is:
+
+- fetch the candidate pool from existing tables
+- for the final candidate set only, compute small recent-window counts on demand
+- e.g. likes/reposts/replies in the last `30m` / `6h`
+
+This gives the ranker a basic freshness / velocity signal without committing to a full feature pipeline on day one.
+
+### Redis usage
+
+Redis should be optional and narrow.
+
+Recommended use:
+
+- cache first-page ranked results
+- store short-lived ranked pagination sessions
+- cache short-lived candidate buckets if needed
+- avoid turning Redis into the primary feature source unless proven necessary
+
+This keeps RAM usage and operational complexity lower.
+
+---
+
+## Initial ranking approach
+
+Start with a **heuristic ranker**.
+
+### Query context hydration
+
+Before sourcing candidates, hydrate a compact request context with things like:
+
+- viewer follow/block/mute state
+- recent interaction history
+- top affinity authors or recent action aggregates
+- experiment `variant` and `algoVersion`
+- ranked-session state when paginating
+
+This keeps sources, filters, and scorers from each reloading the same viewer information independently.
+
+### Candidate sources
+
+Initial `For You` candidates can come from a blend of:
+
+- posts liked by people the user follows
+- posts reposted by people the user follows
+- fresh public original posts and quote posts
+- posts from authors the user historically engages with
+- optional trending posts later
+
+Each candidate should carry both:
+
+- a `sourceBucket` for debugging / analysis
+- a `networkClass` such as `following`, `adjacent`, or `discovery`
+
+The exact label set can stay small in v1, but keeping this distinction explicit is useful for scoring, policy, and analytics.
+
+### Candidate eligibility rules
+
+Be explicit about what is and is not a direct candidate:
+
+- filter blocked/muted content
+- exclude deleted content
+- require public visibility for discovery buckets
+- treat repost rows primarily as **signals**, not as direct candidates
+- exclude or heavily penalize low-signal replies
+- if affinity buckets include followed authors, cap their share so `For You` does not collapse into a shuffled `Following` feed
+
+### Pre-scoring filters
+
+Before scoring, apply cheap/high-value filters such as:
+
+- exact duplicate removal
+- repost/original deduplication
+- self-post filtering when appropriate
+- age limits
+- block/mute filtering
+- optional muted-keyword filtering later
+- optional seen/served suppression
+
+A key distinction worth keeping is:
+
+- **served** = we already placed this content into the current ranked session / pagination flow
+- **seen** = the user likely already encountered the content recently
+
+These are related but not identical, and should not be collapsed into one concept.
+
+### Features for scoring
+
+Use lightweight features such as:
+
+- recency
+- network proof
+  - how many follows liked/reposted the post
+- author affinity
+  - how much the viewer historically engages with the author
+- recent engagement / freshness signal
+  - preferably recent-window counts or a light velocity score
+- network class / source bucket
+- optional light topic match later
+
+### Scoring and reranking
+
+The scoring system should remain heuristic for v1, but it should still be **multi-objective** rather than pretending there is one magical relevance number.
+
+In practice, combine signals for things like:
+
+- engagement likelihood
+- network validation
+- freshness
+- discovery value
+- low-quality reply penalty
+- later, negative-feedback risk if we capture it cleanly
+
+Apply reranking rules such as:
+
+- reduce repeated authors
+- avoid stale posts dominating
+- cap oversaturation from one source/bucket
+- preserve some freshness in the first screen
+- preserve some discovery if followed authors are allowed in the pool
+
+One especially useful mechanism is **author diversity attenuation**:
+
+- do not only hard-cap repeated authors
+- also progressively decay the score of later posts from the same author within the same ranked set
+
+That usually gives a better result than binary allow/disallow rules alone.
+
+### Post-selection checks
+
+After selection, run one more lightweight pass for:
+
+- final visibility/safety checks
+- conversation/thread dedup where needed
+- any route-level exclusions that are cheaper to enforce late
+
+This gives us two helpful layers:
+
+- pre-scoring filters to avoid wasting work
+- post-selection checks to protect final response quality
+
+---
+
+## Failure isolation and fallbacks
+
+This is a hard requirement.
+
+### Rules
+
+- the main API must use a **strict timeout** when calling the ranker
+- if the ranker is slow or unavailable on **page 1**, the user should still get a feed
+- ranking failures must not consume enough resources to degrade core endpoints
+- if a ranked pagination session is missing/expired on **page 2+**, do **not** silently switch to another feed family mid-scroll
+
+### Recommended behavior
+
+- ranker timeout budget: roughly **100–150ms**
+- if page-1 timeout/failure happens:
+  - fall back to a simpler feed strategy
+  - e.g. a network-based blend
+  - or public chronological feed as last resort
+- if a cursor references a missing/expired ranked session:
+  - return a restart-required signal
+  - let the client refresh from page 1 rather than mixing ranking modes
+
+### Infra isolation
+
+Use:
+
+- separate deployment/container for ranker
+- separate resource limits
+- separate DB pool limits from the main API
+
+That ensures ranking load cannot starve the core app.
+
+---
+
+## Experimentation strategy
+
+We want multiple formulas and fast debugging when users report that the algorithm feels great or bad.
+
+### Deterministic bucketing must be shared
+
+Assign users to variants deterministically using something like:
+
+- `hash(userId + experimentName)`
+
+Example variants:
+
+- `for_you_v1_a`
+- `for_you_v1_b`
+
+Important detail:
+
+- the bucketing helper and the `algoVersion` constant should live in shared code imported by **both** API and ranker
+- this lets the API know the variant **before** cache lookup
+- this keeps cache keys, logging, and ranker behavior aligned
+
+### Include markers everywhere
+
+Each ranked response should include:
+
+- `algoVersion`
+- `variant`
+
+These markers should also be logged on:
+
+- impressions
+- likes
+- reposts
+- replies
+- hides
+- reports
+
+That lets us quickly tie user sentiment and observed metrics to a specific ranking formula.
+
+---
+
+## Analytics attribution
+
+If we want to evaluate ranking quality, impression markers alone are not enough.
+
+For `For You`, analytics should carry feed context on both:
+
+- impressions
+- downstream engagement events
+
+Recommended metadata:
+
+- `surface: "for_you"`
+- `algoVersion`
+- `variant`
+- `position`
+- optional `sourceBucket` only if the response actually exposes per-item bucket context
+
+Existing product analytics calls can continue, but ranking evaluation should rely on feed-context-aware events stored with durable metadata.
+
+---
+
+## Caching and pagination
+
+Cache conservatively.
+
+### First page cache
+
+Cache only the first page of `For You`.
+
+Suggested TTL:
+
+- **30–60 seconds**
+
+Cache key should include:
+
+- `userId`
+- `variant`
+- `algoVersion`
+
+### Ranked session cache
+
+For ranked pagination, use Redis-backed sessions.
+
+Store at least:
+
+- `userId`
+- `postIds`
+- `algoVersion`
+- `variant`
+- `snapshotAt`
+
+TTL:
+
+- roughly **5–10 minutes**
+
+Cursor payload should remain opaque, but logically encode:
+
+- `sessionId`
+- `offset`
+
+This stabilizes pagination and prevents score drift across pages.
+
+---
+
+## What not to build yet
+
+Avoid overbuilding v1.
+
+Do not introduce yet:
+
+- Go-based ranking service
+- full ML ranking pipeline
+- feature store
+- vector DB
+- ANN retrieval service
+- Thunder-like realtime ingestion / in-memory candidate service
+- large explainability system
+- per-user/per-post online feature tables unless profiling clearly justifies them
+
+These can come later if usage and ranking complexity justify them.
+
+---
+
+## Upgrade path
+
+### Phase 1
+- ship heuristic ranking in the dedicated ranking service
+- structure it as a pipeline with query hydration, sources, filters, scorers/rerankers, post-selection checks, and side effects
+- extract shared eligibility/filter helpers
+- add semantic dedup, author diversity attenuation, and explicit network-class labeling
+- use existing Postgres tables plus light recent-window freshness signals
+- add caching, timeout, fallback, and variant markers
+
+### Phase 2
+- add targeted aggregate tables where they clearly improve quality/latency
+- improve author/topic affinity
+- add better seen-content suppression if it proves valuable
+- compare multiple formulas via experiments
+
+### Phase 3
+- add ML ranking if data quality and scale justify it
+- possibly add embeddings / retrieval if recall becomes the bottleneck
+- consider a faster dedicated in-network retrieval layer only if feed reads actually demand it
+
+### Phase 4
+- revisit runtime choice only if profiling shows the ranker is truly constrained by CPU/runtime behavior
+
+---
+
+## Bottom line
+
+The first `For You` system should be:
+
+- **TypeScript**
+- **a separate internal ranking service**
+- **structured internally as a composable pipeline**
+- **backed primarily by Postgres, with small aggregate tables added only as needed**
+- **supported by short-lived page-0 cache plus Redis ranking sessions**
+- **using semantic dedup, explicit network-class labels, and author-diversity attenuation**
+- **protected by strict timeouts, graceful page-1 fallback, and restart-required semantics for expired ranked cursors**
+- **kept consistent through shared bucketing/version helpers and shared feed safety filters**
+- **ready for experimentation through deterministic traffic splitting and feed-context-aware analytics markers**
+
+This gives us the right balance of:
+
+- speed of shipping
+- safety for core endpoints
+- low-to-moderate ops complexity
+- cheap iteration on ranking logic
+- a clean path to evolve later if scale demands it

--- a/docs/algo/ALGO_PLAN.md
+++ b/docs/algo/ALGO_PLAN.md
@@ -1,0 +1,1323 @@
+# Twitbruv `For You` Feed: Implementation Plan
+
+This document is intentionally **repository-specific**.
+
+It explains how the generalized decisions in `ALGO_DESIGN.md` map onto the current monorepo:
+
+- where the new ranker service lives
+- what stays in `apps/api`
+- what becomes shared code in `packages/*`
+- what needs to change in `apps/web`
+- how request flow, caching, analytics, and pagination integrate with the code that already exists
+
+For generalized rationale and system design, see:
+
+- `ALGO_DESIGN.md`
+
+## Goal
+
+Ship a real `For You` feed that is:
+
+- better than reverse-chronological follow-only ranking
+- small enough to actually implement in this repo soon
+- isolated from core API traffic
+- measurable
+- easy to iterate on
+
+In this codebase, the main idea is:
+
+- add **one new internal service**: `apps/feed-ranker`
+- add **one small shared helper layer** for feed policy + experiment/version logic
+- keep **post hydration and response shaping** in `apps/api`
+- use the **existing schema first**
+- use **Redis-backed ranking sessions** for stable pagination
+- add **timeouts, caching, fallback, and analytics markers** from day one
+
+---
+
+## Concrete v1 shape in this repo
+
+In this repo, v1 means wiring the design into these concrete pieces:
+
+- **TypeScript**, not Go
+- **a separate internal ranker service** at `apps/feed-ranker`
+- **a composable internal pipeline** inside the ranker
+  - query context hydration → sources → pre-filters → scorers/rerankers → post-selection checks → side effects
+- **shared feed policy helpers** so API and ranker use the same visibility/block/mute rules
+- **shared bucketing + `algoVersion` helpers** so API knows the variant before cache lookup
+- **explicit candidate metadata** such as `sourceBucket` and `networkClass`
+- **semantic dedup**, not just exact post-ID dedup
+- **author-diversity attenuation** as part of ranking, not only hard caps
+- **an API route** at `GET /api/feed/for-you`
+- **first-page caching** in `apps/api`
+- **stable ranked pagination** using Redis session cursors
+- **a clear distinction between `served` and `seen` content state**
+- **deterministic experiment bucketing**
+- **feed-context-aware analytics** for impressions and engagements
+- **fallback behavior** if ranking is slow or unavailable on page 1
+- **restart-required behavior** for expired ranked cursors on page 2+
+
+And in this repo, v1 should **not** expand into:
+
+- a Go service
+- a feature store
+- a vector DB
+- ANN retrieval
+- ML ranking
+- a Thunder-like realtime candidate service
+- a big precomputed feature pipeline
+- a per-user/per-post `network_post_signals (user_id, post_id)` table
+
+---
+
+## Why this shape fits the current repo
+
+This section is specifically about the **current code structure**, not the generalized design rationale.
+
+The repo already has the right split points:
+
+- `apps/api` for user-facing HTTP routes and hydration
+- `apps/worker` for async jobs
+- `packages/db` for schema/shared DB access
+- `packages/types` for shared TS contracts/helpers
+- Redis already exists and is used for caching
+
+The existing feed code already gives us:
+
+- reverse-chrono following feed in `apps/api/src/routes/feed.ts`
+- network-adjacent feed logic in `apps/api/src/routes/feed.ts`
+- public feed logic in `apps/api/src/routes/posts.ts`
+- impression ingestion in `apps/api/src/routes/analytics.ts`
+- client-side impression tracking in `apps/web/src/lib/analytics.ts`
+- DTO hydration pipeline in `apps/api/src/lib/post-dto.ts` and related loaders
+
+That means the cheapest implementation path is:
+
+1. rank IDs in a new service
+2. send ordered post IDs back to the API
+3. let the API hydrate them with the existing pipeline
+
+---
+
+## Scope of v1
+
+### In scope
+
+- `For You` tab/feed for signed-in users
+- one new service: `feed-ranker`
+- one small shared helper layer for experiments/contracts/feed policy
+- candidate generation from existing data
+- heuristic scoring
+- diversity/reranking pass
+- opaque cursoring via Redis ranking sessions
+- page-0 cache in API
+- deterministic user bucketing
+- feed analytics metadata (`surface`, `algoVersion`, `variant`, `position`)
+- strict timeout and fallback on page 1
+- explicit restart behavior for expired ranked sessions on page 2+
+
+### Out of scope
+
+- model training
+- online feature store
+- embeddings
+- topic clustering
+- large-scale offline backfills
+- full explainability UI
+- replacing existing Following / Network / All feeds
+
+---
+
+## Product behavior
+
+### Initial rollout behavior
+
+On the home page, we should add a new tab:
+
+- `For You`
+- `Following`
+- `Network`
+- `All`
+
+For rollout, the default tab should stay:
+
+- **`Following`**, not `For You`
+
+That gives us room to test without making the algo the default immediately.
+
+### Messaging note
+
+The landing page currently says things like:
+
+- “No black-box feeds”
+- “without model-driven ranking”
+
+So `For You` should be framed as:
+
+- optional
+- heuristic first
+- non-ML
+- measurable and iterated deliberately
+
+---
+
+## High-level architecture in this repo
+
+The purpose of this section is to show **how the new pieces fit into the existing codebase**.
+
+We do not restate the generalized recommendation-system rationale here; `ALGO_DESIGN.md` covers that.
+
+### Shared modules
+
+Before we add the ranker, we should extract two tiny shared layers.
+
+#### `packages/db`: feed policy helpers
+
+Shared predicates/helpers for:
+
+- `deletedAt is null`
+- public visibility requirements
+- block relationships
+- feed mutes
+- common viewer-specific exclusions
+
+Both `apps/api` and `apps/feed-ranker` should import these.
+
+#### `packages/types`: feed-ranking contracts/helpers
+
+Shared pure code for:
+
+- `algoVersion`
+- deterministic `variant` bucketing
+- API <-> ranker request/response types
+- ranked-session cursor payload types if useful
+- small shared enums/types like `networkClass`
+
+The API must know the variant **before** page-0 cache lookup, so this cannot live only inside the ranker.
+
+### Internal ranker pipeline
+
+Inside `apps/feed-ranker`, organize the work as stages.
+
+This is not just an abstract pattern; it is the shape we want the new service code to take in this repo:
+
+1. **Query context hydration**
+   - follow/block/mute state
+   - recent interaction context
+   - pagination/session context
+2. **Candidate sources**
+   - network-adjacent
+   - affinity-author
+   - fresh public discovery
+3. **Candidate hydrators / feature loaders**
+   - lightweight derived features
+   - `sourceBucket`
+   - `networkClass`
+4. **Pre-scoring filters**
+   - exact duplicate removal
+   - repost/original dedup
+   - self-post suppression
+   - age limits
+   - block/mute filtering
+   - low-signal reply suppression
+   - served/seen suppression where applicable
+5. **Scorers**
+   - heuristic feature blend
+   - optional network-class adjustments
+6. **Selector / rerankers**
+   - top-K selection
+   - author-diversity attenuation
+   - source-bucket caps
+   - freshness balance
+7. **Post-selection checks**
+   - final safety checks
+   - conversation/thread dedup
+8. **Side effects**
+   - ranked-session persistence
+   - cache/logging hooks
+
+This gives us a clean place to evolve the ranking logic without overcommitting to heavyweight infra.
+
+### Request flow in the current app
+
+1. Client requests `GET /api/feed/for-you`
+2. `apps/api` authenticates the user
+3. `apps/api` computes `variant` + `algoVersion` from shared code
+4. `apps/api` checks first-page cache when eligible
+5. `apps/api` calls `apps/feed-ranker` with strict timeout
+6. `feed-ranker` hydrates query context, generates candidates, filters, scores, reranks, stores/reads ranked session state, and returns ordered post IDs
+7. `apps/api` loads posts by ID and hydrates with the existing DTO pipeline
+8. `apps/api` applies final safety filtering before responding
+9. `apps/api` returns:
+   - `posts`
+   - `nextCursor`
+   - `algoVersion`
+   - `variant`
+   - optional `fallback: true` marker if we want debugging visibility
+
+### What moves where
+
+To keep responsibilities clear in the current codebase:
+
+- **stays in `apps/api`**
+  - auth/session handling
+  - client route contract
+  - post hydration / DTO shaping
+  - final response safety filtering
+  - page-0 cache lookup and fallback policy
+- **moves into `apps/feed-ranker`**
+  - query context hydration for ranking
+  - candidate sourcing
+  - pre-scoring filters
+  - scoring / reranking
+  - ranked-session cursor storage and lookup
+- **becomes shared in `packages/*`**
+  - feed-policy helpers
+  - bucketing/version helpers
+  - ranker contracts and tiny ranking enums/types
+- **gets threaded into `apps/web`**
+  - new tab
+  - feed-context-aware analytics metadata
+  - restart-required handling for expired ranked sessions
+
+### Service boundaries
+
+#### `apps/feed-ranker`
+Owns:
+
+- query context hydration
+- candidate generation
+- lightweight feature extraction
+- pre-scoring filters
+- heuristic scoring
+- reranking/diversity
+- post-selection checks on ranked IDs
+- ranked session storage + cursor validation
+- ranker-side side effects
+
+Returns:
+
+- ordered `postIds`
+- `nextCursor`
+- `algoVersion`
+- `variant`
+
+#### `apps/api`
+Owns:
+
+- auth/session handling
+- client-facing route contract
+- experiment assignment before cache lookup
+- hydration/DTO shaping
+- media/article/repost/quote/reply-parent/poll loading
+- viewer flags
+- final safety filtering
+- caching first page
+- timeout/fallback policy
+- handling expired session responses from the ranker
+
+#### Shared helpers
+Own:
+
+- `algoVersion`
+- deterministic bucketing
+- common feed eligibility rules
+- internal request/response contracts
+- tiny shared ranking enums/types
+
+---
+
+## Concrete implementation plan
+
+# Phase 0: extract shared helpers first
+
+This is a prerequisite, not a nice-to-have.
+
+## New shared files
+
+Create:
+
+- `packages/db/src/feed-policy.ts`
+- `packages/types/src/feed-ranking.ts`
+
+## `packages/db/src/feed-policy.ts`
+
+Export shared helpers for ranker/API reuse, for example:
+
+- `isVisibleFeedPost()`
+- `excludeViewerBlocks(viewerId, authorId)`
+- `excludeViewerFeedMutes(viewerId, authorId)`
+- `excludeViewerOwnPosts(viewerId, authorId)` where useful
+
+The exact helper shape can be `sql` fragments or small query-builder helpers, but the key point is:
+
+- the ranker and API must not hand-roll slightly different copies of block/mute/visibility logic
+
+## `packages/types/src/feed-ranking.ts`
+
+Export shared pure values/helpers such as:
+
+- `FOR_YOU_ALGO_VERSION = "for_you_v1"`
+- `bucketForYouVariant(userId)`
+- `ForYouRankRequest`
+- `ForYouRankResponse`
+- `ForYouSessionCursorPayload`
+- `ForYouNetworkClass = "following" | "adjacent" | "discovery"`
+- `ForYouSourceBucket = "network" | "affinity" | "public"`
+
+This lets the API:
+
+- compute `variant` before cache lookup
+- use the same constants as the ranker
+- share small contract types with the ranker without pushing ranker internals into the client API layer
+
+---
+
+# Phase 1: add the new ranker app
+
+## New app
+
+Create:
+
+- `apps/feed-ranker/package.json`
+- `apps/feed-ranker/tsconfig.json`
+- `apps/feed-ranker/src/index.ts`
+- `apps/feed-ranker/src/env.ts`
+- `apps/feed-ranker/src/lib/query-context.ts`
+- `apps/feed-ranker/src/lib/pipeline.ts`
+- `apps/feed-ranker/src/lib/candidates.ts`
+- `apps/feed-ranker/src/lib/filters.ts`
+- `apps/feed-ranker/src/lib/scorers.ts`
+- `apps/feed-ranker/src/lib/rerank.ts`
+- `apps/feed-ranker/src/lib/cursor.ts`
+- `apps/feed-ranker/src/lib/side-effects.ts`
+- `apps/feed-ranker/src/lib/logger.ts` (optional)
+
+The exact split can vary, but the internals should map cleanly to the pipeline stages described above.
+
+Use the same stack as the API where practical:
+
+- Bun
+- Hono
+- `@workspace/db`
+- `@workspace/types`
+- `ioredis`
+- `zod`
+- `pino`
+
+## Internal route
+
+Expose a single internal route for v1, for example:
+
+- `POST /internal/for-you`
+
+Request body:
+
+```json
+{
+  "userId": "uuid",
+  "limit": 60,
+  "cursor": null,
+  "algoVersion": "for_you_v1",
+  "variant": "for_you_v1_a"
+}
+```
+
+Response body:
+
+```json
+{
+  "postIds": ["uuid", "uuid"],
+  "nextCursor": "opaque-cursor-or-null",
+  "algoVersion": "for_you_v1",
+  "variant": "for_you_v1_a"
+}
+```
+
+The ranker should return **IDs only**, not hydrated posts.
+
+## Expired-session response
+
+When a cursor references a missing or expired ranked session, the ranker should **not** silently rerank from scratch and it should **not** switch to fallback behavior.
+
+Recommended response:
+
+- HTTP `410`
+- body like:
+
+```json
+{
+  "error": "session_expired",
+  "restartRequired": true
+}
+```
+
+The API can translate that into a client-visible restart signal.
+
+## Environment variables
+
+### Add to `apps/api`
+
+- `FEED_RANKER_URL`
+- `FEED_RANKER_TOKEN`
+- `FEED_RANKER_TIMEOUT_MS=120`
+
+### Add to `apps/feed-ranker`
+
+- `INTERNAL_SERVICE_TOKEN`
+- `DATABASE_URL`
+- `REDIS_URL`
+- `DB_POOL_MAX=5` or `10`
+- normal logging envs
+
+The API should authenticate to the ranker using a shared bearer token or equivalent internal header.
+
+The ranker should have a smaller DB pool than the main API by default.
+
+---
+
+# Phase 2: candidate generation using existing schema first
+
+## Principle
+
+Do **not** start by adding new ranking tables.
+
+Use the schema we already have:
+
+- `posts`
+- `likes`
+- `follows`
+- `blocks`
+- `mutes`
+- repost rows via `posts.repostOfId`
+- post counters already on `posts`
+
+This is enough for a good v1.
+
+## Query context hydration
+
+Before candidate sourcing, build a compact `QueryContext` with things like:
+
+- viewer follow/block/mute state
+- recent interaction summary for affinity seeding
+- `variant` + `algoVersion`
+- ranked-session cursor state
+- any request-local `served` state derived from the ranked session
+
+Important distinction:
+
+- **served** = content already issued by this ranked session / page flow
+- **seen** = content the user likely encountered recently via impressions or other recent feed state
+
+For v1, `served` handling is required and `seen` suppression can stay lightweight or optional.
+
+## Candidate metadata
+
+Each candidate should carry:
+
+- `sourceBucket`
+  - `network` | `affinity` | `public`
+- `networkClass`
+  - `following` | `adjacent` | `discovery`
+
+This is useful for:
+
+- scoring
+- diversity/reranking policy
+- experiment analysis
+- future surface-specific safety rules
+
+## Candidate buckets
+
+Generate candidates from three buckets.
+
+### Bucket A: network-adjacent posts
+
+Use the same core idea as the existing `GET /api/feed/network` route.
+
+Source candidates from:
+
+- posts liked by people the viewer follows
+- posts reposted by people the viewer follows
+
+Constraints:
+
+- exclude deleted posts
+- exclude non-public posts
+- exclude blocked/muted authors
+- exclude the viewer’s own posts
+- exclude posts from authors the viewer already follows
+- surface the **original post**, not the repost row itself
+- label these candidates as `sourceBucket=network`, `networkClass=adjacent`
+
+This gives us “people you may care about because your network engaged with it.”
+
+### Bucket B: affinity-author posts, computed on demand
+
+Do not add a `user_author_affinity` table yet.
+
+Instead, compute a lightweight affinity score on demand from recent interaction history, for example over the last 30 days:
+
+- likes by viewer on author’s posts
+- replies by viewer to author
+- reposts by viewer of author
+- bookmarks if we want one more light signal
+
+From that, derive a small set of top authors and fetch recent public posts from them.
+
+Important explicit choice for v1:
+
+- this bucket **may include followed authors**, but cap their presence in the top results so `For You` stays discovery-oriented
+- e.g. no more than roughly **25% of the first 20 results** from followed authors unless later tuning says otherwise
+- if the author is followed, mark `networkClass=following`
+- if not followed, mark `networkClass=adjacent`
+
+This gives us a useful “you often engage with this author” signal without a new feature pipeline.
+
+### Bucket C: fresh public posts
+
+Use the same general idea as the current public feed in `apps/api/src/routes/posts.ts`, but be stricter than the raw public timeline.
+
+Source candidates from:
+
+- recent public original posts
+- recent public quote posts
+- likely within the last 24–48 hours
+- filtered for deletion, visibility, blocks, and mutes
+
+For v1, Bucket C should **not** directly include:
+
+- repost rows as standalone candidates
+- low-signal replies unless they already have strong network/engagement proof
+
+Label these candidates as:
+
+- `sourceBucket=public`
+- `networkClass=discovery`
+
+This keeps the discovery pool higher-signal than the plain public timeline.
+
+## Candidate count
+
+After:
+
+- exact post-ID dedup
+- repost/original semantic dedup
+- basic eligibility filtering
+
+cap the total candidate pool to roughly:
+
+- **150–250 posts** per request
+
+That is plenty for v1 and should be easy to score in TypeScript.
+
+---
+
+# Phase 3: features and heuristic scoring
+
+## Pre-scoring filters
+
+Before scoring, run a cheap/high-value filter pass over the candidate pool.
+
+Required v1 filters:
+
+- exact post-ID dedup
+- repost/original dedup
+- self-post filtering where appropriate
+- age cutoffs
+- blocks / mutes
+- low-signal reply suppression
+- `served` suppression for ranked pagination
+
+Nice-to-have if cheap:
+
+- lightweight `seen` suppression from recent `For You` impression state
+- muted-keyword filtering if we can source it cleanly
+
+## Features to compute per candidate
+
+Use lightweight features only:
+
+- `ageHours`
+- `networkLikeCount`
+- `networkRepostCount`
+- `authorAffinityScore`
+- `likeCount`
+- `repostCount`
+- `replyCount`
+- `quoteCount`
+- `recentEngagement30m`
+- `recentEngagement6h`
+- `isReply`
+- `isFollowedAuthor`
+- `sourceBucket`
+- `networkClass`
+
+Important nuance:
+
+- `recentEngagement30m` / `6h` should be computed on demand for the final candidate set if we have not yet built aggregate tables
+- `sourceBucket` is useful for ranker-side debugging, but should stay server-side unless we explicitly choose to expose per-item feed context to the client
+- `networkClass` is worth carrying explicitly because it can affect scoring and policy even when the source bucket is the same
+
+## Initial heuristic formula
+
+Start with a simple base score like:
+
+```txt
+baseScore =
+  + 2.0 * networkRepostCount
+  + 1.5 * networkLikeCount
+  + 1.2 * authorAffinityScore
+  + 1.0 * recentEngagement30m
+  + 0.6 * recentEngagement6h
+  + 0.6 * log1p(likeCount + repostCount * 2 + replyCount * 1.5 + quoteCount * 1.5)
+  - 0.35 * ageHours
+  - 1.5 if reply with weak signals
+```
+
+Then allow a small adjustment layer for:
+
+- `networkClass`
+- discovery caps / attenuation
+- later, negative-feedback risk if we instrument it cleanly
+
+The exact numbers are tunable.
+
+The important behavior is:
+
+- network proof matters
+- authors the user tends to care about matter
+- recent engagement matters, not just lifetime counts
+- stale posts decay
+- low-signal replies are penalized
+- pure discovery does not overwhelm the top of feed
+
+## Diversity / reranking pass
+
+After base scoring, apply a reranking pass.
+
+### Author diversity attenuation
+
+Do not rely only on hard caps.
+
+Also apply a score decay for repeated authors within the ranked set, e.g.:
+
+- first post from author: full score
+- second post: attenuated score
+- third+ post: further attenuated, plus possible hard cap in top windows
+
+This usually gives a better result than binary allow/disallow rules alone.
+
+### Additional reranking rules
+
+For v1:
+
+- max 2 posts per author in the first 20 results
+- prevent replies from dominating the top of feed
+- keep some freshness in the first screen
+- avoid one source bucket taking over the first 20
+- cap followed-author presence in the first 20
+
+## Post-selection checks
+
+After selecting the top-ranked IDs, run one more pass for:
+
+- final safety / visibility checks
+- conversation/thread dedup where needed
+- any late route-level exclusions that are cheaper to enforce after ranking
+
+This keeps the system aligned with the general pattern:
+
+- pre-scoring filters to avoid wasted work
+- scoring / reranking for relevance and diversity
+- post-selection checks to protect final response quality
+
+---
+
+# Phase 4: cursor strategy for ranked feeds
+
+## Problem
+
+The current repo paginates feeds with timestamp cursors via `apps/api/src/lib/cursor.ts`.
+
+That works for reverse-chrono feeds, but ranked feeds are different:
+
+- scores can change while the user is scrolling
+- candidates can change between page loads
+- naive timestamp cursors create duplicates, missing results, and unstable ordering
+
+## Solution: Redis-backed ranking sessions
+
+For `For You`, page 1 should create a short-lived ranked session.
+
+### Page 1 behavior
+
+1. rank the top ~200 post IDs
+2. store them in Redis under a session key
+3. return the first page of IDs plus an opaque cursor
+
+### Seen vs served semantics
+
+Within ranked pagination:
+
+- `served` means IDs already handed out from this ranked session
+- `seen` means broader recent exposure state outside the current session
+
+The ranked session should be the source of truth for `served` behavior. We should not collapse `served` and `seen` into one concept.
+
+### Redis session key
+
+Example:
+
+- `feed:foryou:session:${sessionId}:v1`
+
+Stored value:
+
+```json
+{
+  "userId": "viewer-uuid",
+  "postIds": ["..."],
+  "algoVersion": "for_you_v1",
+  "variant": "for_you_v1_a",
+  "snapshotAt": "2026-04-27T00:00:00.000Z"
+}
+```
+
+TTL:
+
+- **10 minutes**
+
+### Cursor payload
+
+Cursor should be opaque and encode:
+
+- `sessionId`
+- `offset`
+
+Example logical payload:
+
+```json
+{
+  "s": "abc123",
+  "o": 40
+}
+```
+
+Then base64url-encode it.
+
+### Why this is the right v1 solution
+
+This avoids:
+
+- score drift across pages
+- duplicate rows
+- missing rows
+- complex score+timestamp cursors
+
+It also fits well with our existing Redis setup.
+
+### Expired-session semantics
+
+If the client asks for page 2+ and the session is gone:
+
+- do **not** silently drop to fallback feed logic
+- do **not** regenerate a new ranking session under the same cursor
+- return `restartRequired`
+
+That keeps scrolling behavior deterministic.
+
+---
+
+# Phase 5: API route and hydration integration
+
+## Add API route
+
+In `apps/api/src/routes/feed.ts`, add:
+
+- `GET /api/feed/for-you`
+
+## Add ranker client
+
+Create:
+
+- `apps/api/src/lib/feed-ranker.ts`
+
+Responsibilities:
+
+- call the internal ranker
+- attach auth token header
+- enforce timeout via abort signal
+- parse response
+- surface `session_expired` distinctly from generic ranker failure
+
+## Request flow in API
+
+For `GET /api/feed/for-you`:
+
+1. require signed-in user with handle
+2. parse `limit` and `cursor`
+3. compute `variant` and `algoVersion` from shared helper code
+4. if first page with default limit, check cache using `userId + variant + algoVersion`
+5. call ranker with a strict timeout
+6. ask ranker for a little more than the client page size
+7. fetch and hydrate posts in API
+8. apply final safety filtering in API
+9. return hydrated posts + cursor + algo metadata
+
+## Overfetching
+
+The API should ask for more IDs than it needs.
+
+Example:
+
+- client asks for 40
+- API asks ranker for 60
+
+That helps when the API’s final safety filter removes some ranked IDs.
+
+## Final safety filter in API
+
+Even if the ranker already filtered candidates, the API should re-check before returning the response.
+
+Re-check:
+
+- `deletedAt is null`
+- visibility constraints
+- blocks
+- mutes
+- any other route-level safety constraints
+
+These checks should use the same shared helpers introduced in Phase 0.
+
+---
+
+# Phase 6: fallback behavior
+
+## Timeout budget
+
+The ranker call should have a hard timeout around:
+
+- **120ms**
+
+## Fallback feed strategy
+
+Fallback is allowed only when there is **no ranked cursor yet**.
+
+### No cursor / page 1
+
+If the ranker is slow or errors on page 1, the API should build a blended fallback from existing routes/queries:
+
+1. network-adjacent items
+2. then following-feed items
+3. then public-feed top-up
+
+Dedup by post ID and return the first page.
+
+This is better than dropping directly to public chronological feed.
+
+### Cursor present / page 2+
+
+If the request already has a ranked cursor and the ranker returns `session_expired`:
+
+- return a restart-required response to the client
+- let the client refresh from page 1
+- do **not** swap to a different feed family mid-scroll
+
+## Principle
+
+Ranking failure must never hurt:
+
+- post creation
+- post reads
+- notifications
+- session/auth flows
+- other core app traffic
+
+To support that, `feed-ranker` should run separately with:
+
+- its own process/deployment
+- its own DB pool cap
+- its own resource limits
+
+---
+
+# Phase 7: caching
+
+## Page-0 API cache
+
+Cache only the first page of `For You` in the API.
+
+Eligibility:
+
+- no cursor
+- default limit only
+
+Example key:
+
+- `feed:foryou:${userId}:${variant}:${algoVersion}:v1`
+
+TTL:
+
+- **30 seconds**
+
+This is now safe because the API computes `variant` and `algoVersion` before cache lookup.
+
+## Ranking-session cache
+
+Separate from page-0 cache, the ranker stores ranked sessions in Redis.
+
+Example key:
+
+- `feed:foryou:session:${sessionId}:v1`
+
+TTL:
+
+- **10 minutes**
+
+The two caches solve different problems:
+
+- page-0 cache reduces repeated recomputation
+- session cache stabilizes pagination
+
+## Invalidation policy
+
+Do **not** try to invalidate every `For You` cache on every like/repost/new post.
+
+Use TTL-based freshness for most updates.
+
+Only consider viewer-specific invalidation when the viewer’s graph changes materially:
+
+- follow/unfollow
+- block/unblock
+- mute/unmute
+
+If needed, use a prefix scheme like:
+
+- `feed:foryou:${userId}:...`
+
+and invalidate by prefix from existing API mutation routes.
+
+---
+
+# Phase 8: deterministic experiments
+
+## Variant bucketing
+
+Bucket users deterministically using something like:
+
+- `hash(userId + experimentName)`
+
+Initial variants:
+
+- `for_you_v1_a`
+- `for_you_v1_b`
+
+This helper should live in shared code so:
+
+- the API can cache by variant before calling the ranker
+- the ranker and API cannot disagree about the user’s bucket
+
+## Required response markers
+
+Every ranked response should include:
+
+- `algoVersion`
+- `variant`
+
+These markers should flow through to analytics events so we can tie outcomes back to a ranking formula.
+
+---
+
+# Phase 9: analytics changes
+
+## Current state
+
+The repo already has:
+
+- client-side impression batching in `apps/web/src/lib/analytics.ts`
+- post-card impression detection in `apps/web/src/components/post-card.tsx`
+- ingest endpoint in `apps/api/src/routes/analytics.ts`
+- `metadata` JSON field in `analytics_events`
+- `event_kind` already includes both `impression` and `engagement`
+
+That is enough to extend without a new table.
+
+## What to add
+
+For `For You`, store feed context on analytics events.
+
+### Required impression metadata
+
+- `surface: "for_you"`
+- `algoVersion`
+- `variant`
+- `position`
+
+### Required engagement metadata
+
+When a user likes/reposts/replies/bookmarks from `For You`, record an `engagement` event with metadata such as:
+
+- `surface: "for_you"`
+- `algoVersion`
+- `variant`
+- `position`
+- `action: "like" | "repost" | "reply" | "bookmark"`
+- `subjectType`
+- `subjectId`
+
+This is important because impression markers alone are **not** enough to answer “likes/reposts/replies by variant”.
+
+## API ingest changes
+
+Update `/api/analytics/ingest` to accept:
+
+- `kind: "impression" | "engagement"`
+- optional `metadata`
+
+and persist that metadata to `analytics_events.metadata`.
+
+## Web analytics changes
+
+Update the web client so analytics recording supports feed-specific context.
+
+### Impression dedupe fix
+
+Right now client dedupe is effectively by:
+
+- `subjectType + subjectId`
+
+For ranked feed analysis, that is too coarse.
+
+If a user sees the same post in `Following` and then later in `For You`, we should still be able to count a `For You` impression.
+
+So impression dedupe should include at least:
+
+- `surface`
+- `subjectType`
+- `subjectId`
+
+### Engagement tracking note
+
+Do **not** rely only on existing server-side product analytics calls like `track('post_liked', ...)` for ranking evaluation.
+
+Keep those if they are useful for general product telemetry, but the feed experiment analysis should come from `analytics_events` with explicit feed context.
+
+### `sourceBucket` note
+
+Do not make `sourceBucket` a required client analytics field in v1.
+
+The client cannot infer it from feed order alone. If we later want per-bucket client analytics, we can expose per-item feed context in the API response. For now, keep `sourceBucket` ranker-side/server-side only.
+
+---
+
+# Phase 10: web integration
+
+## API client
+
+In `apps/web/src/lib/api.ts`, add:
+
+- `forYouFeed(cursor?: string)`
+
+And define a response type like:
+
+```ts
+export interface ForYouFeedPage extends FeedPage {
+  algoVersion: string
+  variant: string
+}
+```
+
+## Home route
+
+In `apps/web/src/routes/index.tsx`:
+
+- add a `for-you` tab
+- wire it to `api.forYouFeed`
+- keep `Following` as the default tab during rollout
+
+## Feed rendering
+
+The existing `Feed` component can likely stay mostly unchanged if the response shape remains compatible with `FeedPage` plus top-level metadata.
+
+However, we will likely need to thread feed context down to row rendering so `PostCard` can record:
+
+- impression `surface`
+- `algoVersion`
+- `variant`
+- `position`
+
+and emit engagement analytics with the same context after successful actions.
+
+---
+
+## Exact files to add
+
+### New files
+
+- `apps/feed-ranker/package.json`
+- `apps/feed-ranker/tsconfig.json`
+- `apps/feed-ranker/src/index.ts`
+- `apps/feed-ranker/src/env.ts`
+- `apps/feed-ranker/src/lib/query-context.ts`
+- `apps/feed-ranker/src/lib/pipeline.ts`
+- `apps/feed-ranker/src/lib/candidates.ts`
+- `apps/feed-ranker/src/lib/filters.ts`
+- `apps/feed-ranker/src/lib/scorers.ts`
+- `apps/feed-ranker/src/lib/rerank.ts`
+- `apps/feed-ranker/src/lib/cursor.ts`
+- `apps/feed-ranker/src/lib/side-effects.ts`
+- `packages/db/src/feed-policy.ts`
+- `packages/types/src/feed-ranking.ts`
+- `apps/api/src/lib/feed-ranker.ts`
+
+---
+
+## Exact files likely to change
+
+### API
+
+- `apps/api/src/lib/env.ts`
+  - add ranker env vars
+- `apps/api/src/routes/feed.ts`
+  - add `/for-you`
+  - add cache key helpers
+  - add fallback behavior
+  - handle `session_expired`
+- `apps/api/src/routes/analytics.ts`
+  - accept/store feed-context metadata
+- `apps/api/src/index.ts`
+  - mount path likely unchanged if `feedRoute` already mounted
+
+### Shared packages
+
+- `packages/db/src/index.ts`
+  - export `feed-policy.ts`
+- `packages/types/src/index.ts`
+  - export `feed-ranking.ts`
+
+### Web
+
+- `apps/web/src/lib/api.ts`
+  - add `forYouFeed()` and types
+- `apps/web/src/routes/index.tsx`
+  - add new tab
+- `apps/web/src/lib/analytics.ts`
+  - support metadata, impressions + engagements, and better dedupe key
+- `apps/web/src/components/post-card.tsx`
+  - pass feed context into impression/engagement recording
+- `apps/web/src/components/feed.tsx`
+  - likely thread surface/algo metadata + position to row rendering
+
+### Infra/config
+
+- root `package.json`
+  - workspace already covers `apps/*`; package export changes may be enough
+
+---
+
+## Suggested internal contracts
+
+## API -> ranker request
+
+```json
+{
+  "userId": "uuid",
+  "limit": 60,
+  "cursor": null,
+  "algoVersion": "for_you_v1",
+  "variant": "for_you_v1_a"
+}
+```
+
+Notes:
+
+- `limit` is the ranker fetch size, not necessarily the client page size
+- page 1 can use `60` while API returns `40`
+- `variant` and `algoVersion` come from shared helper code, not ranker-only logic
+
+## ranker -> API response
+
+```json
+{
+  "postIds": ["uuid1", "uuid2", "uuid3"],
+  "nextCursor": "opaque-cursor",
+  "algoVersion": "for_you_v1",
+  "variant": "for_you_v1_a"
+}
+```
+
+## ranker expired-session response
+
+```json
+{
+  "error": "session_expired",
+  "restartRequired": true
+}
+```
+
+## API -> client response
+
+```json
+{
+  "posts": [/* hydrated Post DTOs */],
+  "nextCursor": "opaque-cursor",
+  "algoVersion": "for_you_v1",
+  "variant": "for_you_v1_a"
+}
+```
+
+---
+
+## What we explicitly defer
+
+These are reasonable future upgrades, but they are not part of v1:
+
+- worker-maintained per-user candidate sets
+- topic affinity tables
+- embeddings
+- ML ranker
+- a Thunder-like realtime in-network candidate service
+- runtime rewrite to Go
+- exposing per-item `sourceBucket` to clients
+
+We should only add these once profiling or product feedback proves the current system is insufficient.
+
+---
+
+## Success criteria for v1
+
+We can call v1 successful if:
+
+- `GET /api/feed/for-you` works reliably for signed-in users
+- p95 stays within acceptable latency for the product stage
+- ranker failures cleanly fall back on page 1 without harming core API traffic
+- ranked pagination is stable across multiple pages
+- expired ranked sessions return a clean restart-required signal instead of silently changing feed mode
+- the top of feed shows healthy diversity rather than repeating the same author/thread too often
+- analytics can answer basic questions such as:
+  - which variant a user saw
+  - which posts were shown in `For You`
+  - impression counts by position and variant
+  - downstream likes/reposts/replies/bookmarks by variant
+- the team can tune ranking weights without major schema or infra work
+
+---
+
+## Bottom line
+
+The implementation we should actually build next is:
+
+- **`apps/feed-ranker` in TypeScript**
+- **shared feed-policy helpers and shared bucketing/version helpers**
+- **an internal pipeline with query hydration, sources, pre-filters, scorers/rerankers, post-selection checks, and side effects**
+- **candidate generation from existing tables**
+- **heuristic ranking, not ML**
+- **a small recent-window freshness signal, even before aggregate tables exist**
+- **semantic dedup + author-diversity attenuation + explicit network-class labeling**
+- **Redis session cursors for stable pagination**
+- **`/api/feed/for-you` in the existing API**
+- **page-0 cache with short TTL**
+- **strict timeout, graceful page-1 fallback, and restart-required semantics for expired ranked cursors**
+- **feed-context-aware analytics from day one**
+
+This is small enough to ship, fits the current codebase, and leaves a clean path to add smarter features later if Twitbruv actually needs them.

--- a/docs/algo/ALGO_PRS.md
+++ b/docs/algo/ALGO_PRS.md
@@ -1,0 +1,134 @@
+# Twitbruv `For You` Feed: Scoped Work Outline
+
+This file is intentionally brief.
+
+It exists only to show **how we scoped the work into implementation chunks**.
+For full architecture, behavior, and file-level detail, see:
+
+- `ALGO_PLAN.md`
+
+---
+
+## Why this doc exists
+
+We do **not strictly need** a PR breakdown doc, but it helps keep the work:
+
+- reviewable
+- low-risk
+- easy to stage
+- easy to roll back
+
+---
+
+## Scope split
+
+### 1. Shared ranking primitives
+
+Create the shared pieces both API and ranker depend on:
+
+- feed-policy helpers
+- `algoVersion` / bucketing helpers
+- ranker request/response contracts
+- small shared ranking enums/types
+
+Goal:
+- prevent API/ranker drift from day one
+
+### 2. Ranker service skeleton
+
+Add `apps/feed-ranker` with the intended internal shape:
+
+- query context hydration
+- sources
+- pre-filters
+- scorers/rerankers
+- post-selection checks
+- side effects
+
+Goal:
+- land the service shape before filling in all ranking logic
+
+### 3. Ranker logic
+
+Implement the actual v1 ranker behavior:
+
+- candidate sourcing
+- semantic dedup
+- served/seen handling
+- heuristic scoring
+- author diversity attenuation
+- network-class-aware behavior
+- Redis ranked-session cursors
+
+Goal:
+- make the internal ranker actually useful and stable
+
+### 4. API integration
+
+Add `GET /api/feed/for-you` in `apps/api` with:
+
+- timeout to ranker
+- page-0 cache
+- hydration via existing DTO pipeline
+- final safety filtering
+- page-1 fallback
+- page-2+ restart-required handling
+
+Goal:
+- expose the ranker safely without affecting core feeds
+
+### 5. Web integration
+
+Add the `For You` tab and wire it to the new API route.
+
+Goal:
+- ship the surface conservatively
+- keep `Following` as the default tab initially
+
+### 6. Analytics context
+
+Add feed-context-aware analytics for:
+
+- impressions
+- engagements
+
+Goal:
+- make experiment results measurable by surface / variant / position
+
+### 7. Post-launch tuning only if needed
+
+After shipping, tune or extend only if data justifies it, e.g.:
+
+- heuristic weights
+- reply suppression
+- affinity improvements
+- small aggregate tables
+
+Goal:
+- avoid overbuilding before real usage proves the need
+
+---
+
+## Things explicitly out of scope for v1
+
+- ML ranking
+- vector retrieval
+- feature store
+- Go rewrite
+- Thunder-like realtime candidate service
+
+---
+
+## Bottom line
+
+The work is scoped into:
+
+1. shared primitives
+2. ranker skeleton
+3. ranker logic
+4. API route
+5. web tab
+6. analytics
+7. tuning if needed
+
+For the full rationale and implementation detail, use `ALGO_PLAN.md`.

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -6,7 +6,8 @@
   "exports": {
     ".": "./src/index.ts",
     "./schema": "./src/schema/index.ts",
-    "./client": "./src/client.ts"
+    "./client": "./src/client.ts",
+    "./feed-policy": "./src/feed-policy.ts"
   },
   "scripts": {
     "push": "drizzle-kit push",

--- a/packages/db/src/feed-policy.ts
+++ b/packages/db/src/feed-policy.ts
@@ -1,0 +1,67 @@
+import { and, eq, isNull, sql, type SQL } from "drizzle-orm"
+import { blocks, mutes, posts } from "./schema/index.ts"
+
+type FeedPolicyColumn = SQL | typeof posts.authorId
+
+export function isVisibleFeedPost(): SQL {
+  return isNull(posts.deletedAt)
+}
+
+export function isPublicFeedPost(): SQL {
+  return and(isVisibleFeedPost(), eq(posts.visibility, "public"))!
+}
+
+export function excludeViewerBlocks(
+  viewerId: string,
+  authorId: FeedPolicyColumn = posts.authorId
+): SQL {
+  return sql`NOT EXISTS (
+    SELECT 1
+    FROM ${blocks} b
+    WHERE
+      (b.blocker_id = ${viewerId} AND b.blocked_id = ${authorId})
+      OR (b.blocker_id = ${authorId} AND b.blocked_id = ${viewerId})
+  )`
+}
+
+export function excludeViewerFeedMutes(
+  viewerId: string,
+  authorId: FeedPolicyColumn = posts.authorId
+): SQL {
+  return sql`NOT EXISTS (
+    SELECT 1
+    FROM ${mutes} m
+    WHERE
+      m.muter_id = ${viewerId}
+      AND m.muted_id = ${authorId}
+      AND (m.scope = 'feed' OR m.scope = 'both')
+  )`
+}
+
+export function excludeViewerOwnPosts(
+  viewerId: string,
+  authorId: FeedPolicyColumn = posts.authorId
+): SQL {
+  return sql`${authorId} <> ${viewerId}`
+}
+
+export function excludeViewerSocialFilters(
+  viewerId: string,
+  authorId: FeedPolicyColumn = posts.authorId
+): SQL {
+  return and(
+    excludeViewerBlocks(viewerId, authorId),
+    excludeViewerFeedMutes(viewerId, authorId)
+  )!
+}
+
+export function eligiblePublicFeedPost(
+  viewerId: string,
+  authorId: FeedPolicyColumn = posts.authorId
+): SQL {
+  return and(
+    isPublicFeedPost(),
+    excludeViewerSocialFilters(viewerId, authorId),
+    excludeViewerOwnPosts(viewerId, authorId)
+  )!
+}

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -1,4 +1,24 @@
-export * as schema from './schema/index.ts'
-export { createDb, createDbFromEnv } from './client.ts'
-export type { Database } from './client.ts'
-export { sql, eq, ne, and, or, not, desc, asc, gt, gte, lt, lte, inArray, isNull, isNotNull, like, ilike, exists } from 'drizzle-orm'
+export * as schema from "./schema/index.ts"
+export { createDb, createDbFromEnv } from "./client.ts"
+export type { Database } from "./client.ts"
+export * from "./feed-policy.ts"
+export {
+  sql,
+  eq,
+  ne,
+  and,
+  or,
+  not,
+  desc,
+  asc,
+  gt,
+  gte,
+  lt,
+  lte,
+  inArray,
+  isNull,
+  isNotNull,
+  like,
+  ilike,
+  exists,
+} from "drizzle-orm"

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -4,7 +4,8 @@
   "type": "module",
   "private": true,
   "exports": {
-    ".": "./src/index.ts"
+    ".": "./src/index.ts",
+    "./feed-ranking": "./src/feed-ranking.ts"
   },
   "scripts": {
     "typecheck": "tsc --noEmit"

--- a/packages/types/src/feed-ranking.ts
+++ b/packages/types/src/feed-ranking.ts
@@ -1,0 +1,83 @@
+export const FOR_YOU_ALGO_VERSION = "for_you_v1" as const
+export type ForYouAlgoVersion = typeof FOR_YOU_ALGO_VERSION
+
+export const FOR_YOU_EXPERIMENT_NAME = "for_you_v1" as const
+
+export const FOR_YOU_VARIANTS = ["for_you_v1_a", "for_you_v1_b"] as const
+export type ForYouVariant = (typeof FOR_YOU_VARIANTS)[number]
+
+export const FOR_YOU_NETWORK_CLASSES = [
+  "following",
+  "adjacent",
+  "discovery",
+] as const
+export type ForYouNetworkClass = (typeof FOR_YOU_NETWORK_CLASSES)[number]
+
+export const FOR_YOU_SOURCE_BUCKETS = ["network", "affinity", "public"] as const
+export type ForYouSourceBucket = (typeof FOR_YOU_SOURCE_BUCKETS)[number]
+
+export const FOR_YOU_SURFACE = "for_you" as const
+export type ForYouSurface = typeof FOR_YOU_SURFACE
+
+export interface ForYouRankRequest {
+  userId: string
+  limit: number
+  cursor?: string | null
+  algoVersion: ForYouAlgoVersion
+  variant: ForYouVariant
+}
+
+export interface ForYouRankResponse {
+  postIds: string[]
+  nextCursor: string | null
+  algoVersion: ForYouAlgoVersion
+  variant: ForYouVariant
+}
+
+export interface ForYouSessionCursorPayload {
+  sessionId: string
+  offset: number
+}
+
+export interface ForYouSessionExpiredResponse {
+  error: "session_expired"
+  restartRequired: true
+}
+
+export type ForYouRankerResponse =
+  | ForYouRankResponse
+  | ForYouSessionExpiredResponse
+
+export interface ForYouFeedContext {
+  surface: ForYouSurface
+  algoVersion: ForYouAlgoVersion
+  variant: ForYouVariant
+  position?: number
+}
+
+export function bucketForYouVariant(userId: string): ForYouVariant {
+  const bucket = hashToBucket(
+    `${FOR_YOU_EXPERIMENT_NAME}:${userId}`,
+    FOR_YOU_VARIANTS.length
+  )
+  return FOR_YOU_VARIANTS[bucket]!
+}
+
+export function hashToBucket(input: string, bucketCount: number): number {
+  if (bucketCount <= 0 || bucketCount % 1 !== 0) {
+    throw new Error("bucketCount must be a positive integer")
+  }
+
+  return fnv1a32(input) % bucketCount
+}
+
+function fnv1a32(input: string): number {
+  let hash = 0x811c9dc5
+
+  for (let i = 0; i < input.length; i += 1) {
+    hash ^= input.charCodeAt(i)
+    hash += (hash << 1) + (hash << 4) + (hash << 7) + (hash << 8) + (hash << 24)
+  }
+
+  return hash >>> 0
+}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,5 +1,7 @@
-import type { InferSelectModel, InferInsertModel } from 'drizzle-orm'
-import { schema } from '@workspace/db'
+import type { InferSelectModel, InferInsertModel } from "drizzle-orm"
+import { schema } from "@workspace/db"
+
+export * from "./feed-ranking.ts"
 
 export type User = InferSelectModel<typeof schema.users>
 export type NewUser = InferInsertModel<typeof schema.users>
@@ -26,17 +28,17 @@ export type ModerationAction = InferSelectModel<typeof schema.moderationActions>
 // Public-facing user DTO: strip sensitive fields.
 export type PublicUser = Pick<
   User,
-  | 'id'
-  | 'handle'
-  | 'displayName'
-  | 'bio'
-  | 'location'
-  | 'websiteUrl'
-  | 'bannerUrl'
-  | 'avatarUrl'
-  | 'isVerified'
-  | 'isBot'
-  | 'createdAt'
+  | "id"
+  | "handle"
+  | "displayName"
+  | "bio"
+  | "location"
+  | "websiteUrl"
+  | "bannerUrl"
+  | "avatarUrl"
+  | "isVerified"
+  | "isBot"
+  | "createdAt"
 >
 
-export type SessionUser = PublicUser & { email: string; role: User['role'] }
+export type SessionUser = PublicUser & { email: string; role: User["role"] }


### PR DESCRIPTION
Adds the shared pieces the API and future ranker will both use: Drizzle helpers for visibility, blocks, and feed mutes, plus For You algo version, variant bucketing, and ranker request/response types. No new services or routes yet—that keeps this PR small and reviewable.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added foundational infrastructure and type definitions to support a new "For You" feed experience
  * Introduced shared feed policy utilities for managing visibility and social filtering
  * Established ranking contracts and bucketing logic for personalized content delivery

* **Documentation**
  * Added comprehensive design specifications, implementation plan, and work scope documents for the "For You" feed system

<!-- end of auto-generated comment: release notes by coderabbit.ai -->