### PR TITLE
[Algo] Part 2: Feed ranker service skeleton

### DIFF
--- a/apps/feed-ranker/package.json
+++ b/apps/feed-ranker/package.json
@@ -18,6 +18,7 @@
     "zod": "^3.25.76"
   },
   "devDependencies": {
+    "@types/bun": "^1.3.13",
     "@types/node": "^25.1.0",
     "@workspace/config-tsconfig": "workspace:*",
     "pino-pretty": "^13.1.3",

--- a/apps/feed-ranker/package.json
+++ b/apps/feed-ranker/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "feed-ranker",
+  "version": "0.0.1",
+  "type": "module",
+  "private": true,
+  "scripts": {
+    "dev": "bun run --env-file=../../.env --watch src/index.ts",
+    "start": "bun run --env-file=../../.env src/index.ts",
+    "build": "bun build src/index.ts --outdir=dist --target=bun",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@workspace/db": "workspace:*",
+    "@workspace/types": "workspace:*",
+    "hono": "^4.7.11",
+    "ioredis": "^5.8.0",
+    "pino": "^9.6.0",
+    "zod": "^3.25.76"
+  },
+  "devDependencies": {
+    "@types/node": "^25.1.0",
+    "@workspace/config-tsconfig": "workspace:*",
+    "pino-pretty": "^13.1.3",
+    "typescript": "^5.9.3"
+  }
+}

--- a/apps/feed-ranker/src/env.ts
+++ b/apps/feed-ranker/src/env.ts
@@ -4,7 +4,7 @@ const envSchema = z.object({
   DATABASE_URL: z.string().url(),
   REDIS_URL: z.string().default("redis://localhost:6379"),
   INTERNAL_SERVICE_TOKEN: z.string().min(16),
-  PORT: z.coerce.number().default(3002),
+  PORT: z.coerce.number().int().min(1).max(65535).default(3002),
   NODE_ENV: z.enum(["development", "test", "production"]).default("development"),
   LOG_LEVEL: z.string().default("info"),
   DB_POOL_MAX: z.coerce.number().int().positive().default(5),

--- a/apps/feed-ranker/src/env.ts
+++ b/apps/feed-ranker/src/env.ts
@@ -1,0 +1,22 @@
+import { z } from "zod"
+
+const envSchema = z.object({
+  DATABASE_URL: z.string().url(),
+  REDIS_URL: z.string().default("redis://localhost:6379"),
+  INTERNAL_SERVICE_TOKEN: z.string().min(16),
+  PORT: z.coerce.number().default(3002),
+  NODE_ENV: z.enum(["development", "test", "production"]).default("development"),
+  LOG_LEVEL: z.string().default("info"),
+  DB_POOL_MAX: z.coerce.number().int().positive().default(5),
+})
+
+export type Env = z.infer<typeof envSchema>
+
+export function loadEnv(): Env {
+  const parsed = envSchema.safeParse(process.env)
+  if (!parsed.success) {
+    console.error("Invalid environment:", parsed.error.flatten().fieldErrors)
+    process.exit(1)
+  }
+  return parsed.data
+}

--- a/apps/feed-ranker/src/index.ts
+++ b/apps/feed-ranker/src/index.ts
@@ -9,7 +9,8 @@ import {
 } from "@workspace/types"
 import { loadEnv } from "./env.ts"
 import { createLogger } from "./lib/logger.ts"
-import { runForYouPipeline, type RankerRuntime } from "./lib/pipeline.ts"
+import { runForYouPipeline } from "./lib/pipeline.ts"
+import type { RankerRuntime } from "./lib/runtime.ts"
 
 const rankRequestSchema = z.object({
   userId: z.string().uuid(),
@@ -73,7 +74,7 @@ app.post("/internal/for-you", async (c) => {
     return c.json({ error: "invalid_request", details: parsed.error.flatten().fieldErrors }, 400)
   }
 
-  const response = await runForYouPipeline(runtime, parsed.data satisfies ForYouRankRequest)
+  const response = await runForYouPipeline(parsed.data satisfies ForYouRankRequest, runtime)
   return c.json(response)
 })
 
@@ -87,14 +88,36 @@ function errMsg(err: unknown): string {
   return err instanceof Error ? err.message : String(err)
 }
 
-const shutdown = () => {
-  log.info("feed_ranker_shutdown")
-  redis.disconnect()
-  process.exit(0)
+const SHUTDOWN_TIMEOUT_MS = 5_000
+let shuttingDown = false
+
+const server = Bun.serve({ port: env.PORT, fetch: app.fetch })
+
+const shutdown = async (signal: NodeJS.Signals) => {
+  if (shuttingDown) return
+  shuttingDown = true
+
+  log.info({ signal }, "feed_ranker_shutdown_start")
+
+  const timeout = setTimeout(() => {
+    log.error({ timeoutMs: SHUTDOWN_TIMEOUT_MS }, "feed_ranker_shutdown_timeout")
+    process.exit(1)
+  }, SHUTDOWN_TIMEOUT_MS)
+
+  try {
+    await server.stop(false)
+    redis.disconnect()
+    clearTimeout(timeout)
+    log.info("feed_ranker_shutdown_complete")
+    process.exit(0)
+  } catch (err) {
+    clearTimeout(timeout)
+    log.error({ err: errMsg(err) }, "feed_ranker_shutdown_failed")
+    process.exit(1)
+  }
 }
 
 process.on("SIGINT", shutdown)
 process.on("SIGTERM", shutdown)
 
-log.info({ port: env.PORT }, "feed_ranker_listening")
-export default { port: env.PORT, fetch: app.fetch }
+log.info({ port: server.port }, "feed_ranker_listening")

--- a/apps/feed-ranker/src/index.ts
+++ b/apps/feed-ranker/src/index.ts
@@ -1,0 +1,100 @@
+import { Hono } from "hono"
+import Redis from "ioredis"
+import { z } from "zod"
+import { createDb, sql } from "@workspace/db"
+import {
+  FOR_YOU_ALGO_VERSION,
+  FOR_YOU_VARIANTS,
+  type ForYouRankRequest,
+} from "@workspace/types"
+import { loadEnv } from "./env.ts"
+import { createLogger } from "./lib/logger.ts"
+import { runForYouPipeline, type RankerRuntime } from "./lib/pipeline.ts"
+
+const rankRequestSchema = z.object({
+  userId: z.string().uuid(),
+  limit: z.coerce.number().int().min(1).max(200),
+  cursor: z.string().min(1).nullable().optional(),
+  algoVersion: z.literal(FOR_YOU_ALGO_VERSION),
+  variant: z.enum(FOR_YOU_VARIANTS),
+})
+
+const env = loadEnv()
+const log = createLogger(env)
+const db = createDb(env.DATABASE_URL, { max: env.DB_POOL_MAX })
+const redis = new Redis(env.REDIS_URL, {
+  lazyConnect: true,
+  maxRetriesPerRequest: 1,
+})
+
+redis.on("error", (err) => {
+  log.warn({ err: err.message }, "redis_error")
+})
+
+const runtime: RankerRuntime = { env, db, redis, log }
+const app = new Hono()
+
+app.use("*", async (c, next) => {
+  const start = Date.now()
+  await next()
+  const path = c.req.path
+  if (path === "/healthz" || path === "/readyz") return
+  log.info(
+    { method: c.req.method, path, status: c.res.status, ms: Date.now() - start },
+    "req"
+  )
+})
+
+app.get("/healthz", (c) => c.json({ ok: true }))
+
+app.get("/readyz", async (c) => {
+  try {
+    await db.execute(sql`SELECT 1`)
+    await redis.ping()
+    return c.json({ ok: true })
+  } catch (err) {
+    log.error({ err: errMsg(err) }, "readyz_failed")
+    return c.json({ ok: false, error: "dependency_unreachable" }, 503)
+  }
+})
+
+app.use("/internal/*", async (c, next) => {
+  const authorization = c.req.header("authorization") ?? ""
+  if (authorization !== `Bearer ${env.INTERNAL_SERVICE_TOKEN}`) {
+    return c.json({ error: "unauthorized" }, 401)
+  }
+  await next()
+})
+
+app.post("/internal/for-you", async (c) => {
+  const body = await c.req.json().catch(() => null)
+  const parsed = rankRequestSchema.safeParse(body)
+  if (!parsed.success) {
+    return c.json({ error: "invalid_request", details: parsed.error.flatten().fieldErrors }, 400)
+  }
+
+  const response = await runForYouPipeline(runtime, parsed.data satisfies ForYouRankRequest)
+  return c.json(response)
+})
+
+app.notFound((c) => c.json({ error: "not_found" }, 404))
+app.onError((err, c) => {
+  log.error({ err: err.stack ?? err.message, path: c.req.path }, "unhandled_error")
+  return c.json({ error: "internal_error" }, 500)
+})
+
+function errMsg(err: unknown): string {
+  return err instanceof Error ? err.message : String(err)
+}
+
+const shutdown = () => {
+  log.info("feed_ranker_shutdown")
+  redis.disconnect()
+  process.exit(0)
+}
+
+process.on("SIGINT", shutdown)
+process.on("SIGTERM", shutdown)
+
+log.info({ port: env.PORT }, "feed_ranker_listening")
+export default { port: env.PORT, fetch: app.fetch }

--- a/apps/feed-ranker/src/lib/anonymize.ts
+++ b/apps/feed-ranker/src/lib/anonymize.ts
@@ -1,0 +1,5 @@
+import { createHash } from "node:crypto"
+
+export function hashUserId(userId: string): string {
+  return createHash("sha256").update(userId).digest("hex").slice(0, 16)
+}

--- a/apps/feed-ranker/src/lib/candidates.ts
+++ b/apps/feed-ranker/src/lib/candidates.ts
@@ -1,5 +1,6 @@
 import type { ForYouNetworkClass, ForYouSourceBucket } from "@workspace/types"
 import type { QueryContext } from "./query-context.ts"
+import type { RankerRuntime } from "./runtime.ts"
 
 export interface ForYouCandidate {
   postId: string
@@ -10,6 +11,9 @@ export interface ForYouCandidate {
   createdAt: Date | null
 }
 
-export async function loadCandidates(_context: QueryContext): Promise<ForYouCandidate[]> {
+export async function loadCandidates(
+  _context: QueryContext,
+  _runtime: RankerRuntime
+): Promise<ForYouCandidate[]> {
   return []
 }

--- a/apps/feed-ranker/src/lib/candidates.ts
+++ b/apps/feed-ranker/src/lib/candidates.ts
@@ -1,0 +1,15 @@
+import type { ForYouNetworkClass, ForYouSourceBucket } from "@workspace/types"
+import type { QueryContext } from "./query-context.ts"
+
+export interface ForYouCandidate {
+  postId: string
+  authorId: string | null
+  originalPostId: string | null
+  sourceBucket: ForYouSourceBucket
+  networkClass: ForYouNetworkClass
+  createdAt: Date | null
+}
+
+export async function loadCandidates(_context: QueryContext): Promise<ForYouCandidate[]> {
+  return []
+}

--- a/apps/feed-ranker/src/lib/cursor.ts
+++ b/apps/feed-ranker/src/lib/cursor.ts
@@ -1,0 +1,18 @@
+import type { ForYouSessionCursorPayload } from "@workspace/types"
+
+export function encodeSessionCursor(payload: ForYouSessionCursorPayload): string {
+  return Buffer.from(JSON.stringify(payload), "utf8").toString("base64url")
+}
+
+export function decodeSessionCursor(cursor: string): ForYouSessionCursorPayload | null {
+  try {
+    const raw = Buffer.from(cursor, "base64url").toString("utf8")
+    const parsed = JSON.parse(raw) as Partial<ForYouSessionCursorPayload>
+    if (typeof parsed.sessionId !== "string") return null
+    if (typeof parsed.offset !== "number" || !Number.isInteger(parsed.offset)) return null
+    if (parsed.offset < 0) return null
+    return { sessionId: parsed.sessionId, offset: parsed.offset }
+  } catch {
+    return null
+  }
+}

--- a/apps/feed-ranker/src/lib/filters.ts
+++ b/apps/feed-ranker/src/lib/filters.ts
@@ -1,0 +1,9 @@
+import type { ForYouCandidate } from "./candidates.ts"
+import type { QueryContext } from "./query-context.ts"
+
+export function applyPreScoringFilters(
+  _context: QueryContext,
+  candidates: ForYouCandidate[]
+): ForYouCandidate[] {
+  return candidates
+}

--- a/apps/feed-ranker/src/lib/logger.ts
+++ b/apps/feed-ranker/src/lib/logger.ts
@@ -1,0 +1,18 @@
+import pino from "pino"
+import type { Env } from "../env.ts"
+
+export function createLogger(env: Env) {
+  return pino({
+    level: env.LOG_LEVEL,
+    ...(env.NODE_ENV === "production"
+      ? {}
+      : {
+          transport: {
+            target: "pino-pretty",
+            options: { colorize: true, translateTime: "HH:MM:ss", ignore: "pid,hostname" },
+          },
+        }),
+  })
+}
+
+export type Logger = ReturnType<typeof createLogger>

--- a/apps/feed-ranker/src/lib/logger.ts
+++ b/apps/feed-ranker/src/lib/logger.ts
@@ -4,14 +4,14 @@ import type { Env } from "../env.ts"
 export function createLogger(env: Env) {
   return pino({
     level: env.LOG_LEVEL,
-    ...(env.NODE_ENV === "production"
-      ? {}
-      : {
+    ...(env.NODE_ENV === "development"
+      ? {
           transport: {
             target: "pino-pretty",
             options: { colorize: true, translateTime: "HH:MM:ss", ignore: "pid,hostname" },
           },
-        }),
+        }
+      : {}),
   })
 }
 

--- a/apps/feed-ranker/src/lib/pipeline.ts
+++ b/apps/feed-ranker/src/lib/pipeline.ts
@@ -1,37 +1,28 @@
-import type { Database } from "@workspace/db"
 import type { ForYouRankRequest, ForYouRankResponse } from "@workspace/types"
-import type Redis from "ioredis"
-import type { Env } from "../env.ts"
-import type { Logger } from "./logger.ts"
+import { hashUserId } from "./anonymize.ts"
 import { loadCandidates } from "./candidates.ts"
 import { applyPreScoringFilters } from "./filters.ts"
 import { hydrateQueryContext } from "./query-context.ts"
 import { selectRankedCandidates } from "./rerank.ts"
+import type { RankerRuntime } from "./runtime.ts"
 import { scoreCandidates } from "./scorers.ts"
 import { persistRankedSession, recordRankerSideEffects } from "./side-effects.ts"
 
-export interface RankerRuntime {
-  env: Env
-  db: Database
-  redis: Redis
-  log: Logger
-}
-
 export async function runForYouPipeline(
-  runtime: RankerRuntime,
-  request: ForYouRankRequest
+  request: ForYouRankRequest,
+  runtime: RankerRuntime
 ): Promise<ForYouRankResponse> {
   const context = await hydrateQueryContext(request)
-  const candidates = await loadCandidates(context)
+  const candidates = await loadCandidates(context, runtime)
   const filtered = applyPreScoringFilters(context, candidates)
   const scored = scoreCandidates(context, filtered)
   const selected = selectRankedCandidates(context, scored)
-  const session = await persistRankedSession(context, selected)
-  await recordRankerSideEffects(context, selected)
+  const session = await persistRankedSession(context, selected, runtime)
+  await recordRankerSideEffects(context, selected, runtime)
 
   runtime.log.info(
     {
-      userId: request.userId,
+      anonymizedUserId: hashUserId(request.userId),
       algoVersion: request.algoVersion,
       variant: request.variant,
       candidates: candidates.length,

--- a/apps/feed-ranker/src/lib/pipeline.ts
+++ b/apps/feed-ranker/src/lib/pipeline.ts
@@ -1,0 +1,49 @@
+import type { Database } from "@workspace/db"
+import type { ForYouRankRequest, ForYouRankResponse } from "@workspace/types"
+import type Redis from "ioredis"
+import type { Env } from "../env.ts"
+import type { Logger } from "./logger.ts"
+import { loadCandidates } from "./candidates.ts"
+import { applyPreScoringFilters } from "./filters.ts"
+import { hydrateQueryContext } from "./query-context.ts"
+import { selectRankedCandidates } from "./rerank.ts"
+import { scoreCandidates } from "./scorers.ts"
+import { persistRankedSession, recordRankerSideEffects } from "./side-effects.ts"
+
+export interface RankerRuntime {
+  env: Env
+  db: Database
+  redis: Redis
+  log: Logger
+}
+
+export async function runForYouPipeline(
+  runtime: RankerRuntime,
+  request: ForYouRankRequest
+): Promise<ForYouRankResponse> {
+  const context = await hydrateQueryContext(request)
+  const candidates = await loadCandidates(context)
+  const filtered = applyPreScoringFilters(context, candidates)
+  const scored = scoreCandidates(context, filtered)
+  const selected = selectRankedCandidates(context, scored)
+  const session = await persistRankedSession(context, selected)
+  await recordRankerSideEffects(context, selected)
+
+  runtime.log.info(
+    {
+      userId: request.userId,
+      algoVersion: request.algoVersion,
+      variant: request.variant,
+      candidates: candidates.length,
+      selected: selected.length,
+    },
+    "for_you_ranked"
+  )
+
+  return {
+    postIds: selected.map((candidate) => candidate.postId),
+    nextCursor: session.nextCursor,
+    algoVersion: request.algoVersion,
+    variant: request.variant,
+  }
+}

--- a/apps/feed-ranker/src/lib/query-context.ts
+++ b/apps/feed-ranker/src/lib/query-context.ts
@@ -1,0 +1,21 @@
+import type { ForYouRankRequest } from "@workspace/types"
+
+export interface QueryContext {
+  request: ForYouRankRequest
+  userId: string
+  limit: number
+  cursor: string | null
+  servedPostIds: string[]
+  requestedAt: Date
+}
+
+export async function hydrateQueryContext(request: ForYouRankRequest): Promise<QueryContext> {
+  return {
+    request,
+    userId: request.userId,
+    limit: request.limit,
+    cursor: request.cursor ?? null,
+    servedPostIds: [],
+    requestedAt: new Date(),
+  }
+}

--- a/apps/feed-ranker/src/lib/rerank.ts
+++ b/apps/feed-ranker/src/lib/rerank.ts
@@ -1,0 +1,9 @@
+import type { QueryContext } from "./query-context.ts"
+import type { ScoredForYouCandidate } from "./scorers.ts"
+
+export function selectRankedCandidates(
+  context: QueryContext,
+  candidates: ScoredForYouCandidate[]
+): ScoredForYouCandidate[] {
+  return candidates.slice(0, context.limit)
+}

--- a/apps/feed-ranker/src/lib/rerank.ts
+++ b/apps/feed-ranker/src/lib/rerank.ts
@@ -5,5 +5,9 @@ export function selectRankedCandidates(
   context: QueryContext,
   candidates: ScoredForYouCandidate[]
 ): ScoredForYouCandidate[] {
-  return candidates.slice(0, context.limit)
+  const normalizedLimit = Math.min(
+    Math.max(Number.isFinite(context.limit) ? Math.floor(context.limit) : 0, 0),
+    candidates.length
+  )
+  return candidates.slice(0, normalizedLimit)
 }

--- a/apps/feed-ranker/src/lib/runtime.ts
+++ b/apps/feed-ranker/src/lib/runtime.ts
@@ -1,0 +1,11 @@
+import type { Database } from "@workspace/db"
+import type Redis from "ioredis"
+import type { Env } from "../env.ts"
+import type { Logger } from "./logger.ts"
+
+export interface RankerRuntime {
+  env: Env
+  db: Database
+  redis: Redis
+  log: Logger
+}

--- a/apps/feed-ranker/src/lib/scorers.ts
+++ b/apps/feed-ranker/src/lib/scorers.ts
@@ -1,0 +1,18 @@
+import type { ForYouCandidate } from "./candidates.ts"
+import type { QueryContext } from "./query-context.ts"
+
+export interface ScoredForYouCandidate extends ForYouCandidate {
+  score: number
+  scoreBreakdown: Record<string, number>
+}
+
+export function scoreCandidates(
+  _context: QueryContext,
+  candidates: ForYouCandidate[]
+): ScoredForYouCandidate[] {
+  return candidates.map((candidate) => ({
+    ...candidate,
+    score: 0,
+    scoreBreakdown: {},
+  }))
+}

--- a/apps/feed-ranker/src/lib/side-effects.ts
+++ b/apps/feed-ranker/src/lib/side-effects.ts
@@ -1,4 +1,5 @@
 import type { QueryContext } from "./query-context.ts"
+import type { RankerRuntime } from "./runtime.ts"
 import type { ScoredForYouCandidate } from "./scorers.ts"
 
 export interface RankedSessionResult {
@@ -7,14 +8,16 @@ export interface RankedSessionResult {
 
 export async function persistRankedSession(
   _context: QueryContext,
-  _selected: ScoredForYouCandidate[]
+  _selected: ScoredForYouCandidate[],
+  _runtime: RankerRuntime
 ): Promise<RankedSessionResult> {
   return { nextCursor: null }
 }
 
 export async function recordRankerSideEffects(
   _context: QueryContext,
-  _selected: ScoredForYouCandidate[]
+  _selected: ScoredForYouCandidate[],
+  _runtime: RankerRuntime
 ): Promise<void> {
   // Request logging/cache hooks will live here once the ranker performs real work.
 }

--- a/apps/feed-ranker/src/lib/side-effects.ts
+++ b/apps/feed-ranker/src/lib/side-effects.ts
@@ -1,0 +1,20 @@
+import type { QueryContext } from "./query-context.ts"
+import type { ScoredForYouCandidate } from "./scorers.ts"
+
+export interface RankedSessionResult {
+  nextCursor: string | null
+}
+
+export async function persistRankedSession(
+  _context: QueryContext,
+  _selected: ScoredForYouCandidate[]
+): Promise<RankedSessionResult> {
+  return { nextCursor: null }
+}
+
+export async function recordRankerSideEffects(
+  _context: QueryContext,
+  _selected: ScoredForYouCandidate[]
+): Promise<void> {
+  // Request logging/cache hooks will live here once the ranker performs real work.
+}

--- a/apps/feed-ranker/tsconfig.json
+++ b/apps/feed-ranker/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "@workspace/config-tsconfig/node.json",
+  "include": ["src/**/*"],
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "jsx": "react-jsx"
+  }
+}

--- a/apps/feed-ranker/tsconfig.json
+++ b/apps/feed-ranker/tsconfig.json
@@ -4,6 +4,7 @@
   "compilerOptions": {
     "outDir": "./dist",
     "rootDir": "./src",
-    "jsx": "react-jsx"
+    "jsx": "react-jsx",
+    "types": ["node", "bun"]
   }
 }

--- a/apps/web/src/lib/env.ts
+++ b/apps/web/src/lib/env.ts
@@ -4,7 +4,7 @@ export const WEB_URL =
   import.meta.env.VITE_PUBLIC_WEB_URL ?? "http://localhost:3000"
 export const APP_NAME = import.meta.env.VITE_PUBLIC_APP_NAME ?? "twotter"
 export const DATABUDDY_CLIENT_ID = import.meta.env
-  .VITE_PUBLIC_DATABUDDY_CLIENT_ID as string | undefined
+  .VITE_PUBLIC_DATABUDDY_CLIENT_ID
 
 // Build-time hard block. When true the app refuses to render anything beyond the
 // maintenance screen — used as a belt-and-suspenders companion to the server-side

--- a/bun.lock
+++ b/bun.lock
@@ -54,6 +54,7 @@
         "zod": "^3.25.76",
       },
       "devDependencies": {
+        "@types/bun": "^1.3.13",
         "@types/node": "^25.1.0",
         "@workspace/config-tsconfig": "workspace:*",
         "pino-pretty": "^13.1.3",
@@ -1162,6 +1163,8 @@
 
     "@types/babel__traverse": ["@types/babel__traverse@7.28.0", "", { "dependencies": { "@babel/types": "^7.28.2" } }, "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q=="],
 
+    "@types/bun": ["@types/bun@1.3.13", "", { "dependencies": { "bun-types": "1.3.13" } }, "sha512-9fqXWk5YIHGGnUau9TEi+qdlTYDAnOj+xLCmSTwXfAIqXr2x4tytJb43E9uCvt09zJURKXwAtkoH4nLQfzeTXw=="],
+
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 
     "@types/json-schema": ["@types/json-schema@7.0.15", "", {}, "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="],
@@ -1321,6 +1324,8 @@
     "browserslist": ["browserslist@4.28.2", "", { "dependencies": { "baseline-browser-mapping": "^2.10.12", "caniuse-lite": "^1.0.30001782", "electron-to-chromium": "^1.5.328", "node-releases": "^2.0.36", "update-browserslist-db": "^1.2.3" }, "bin": { "browserslist": "cli.js" } }, "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg=="],
 
     "buffer-from": ["buffer-from@1.1.2", "", {}, "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="],
+
+    "bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
 
     "bundle-name": ["bundle-name@4.1.0", "", { "dependencies": { "run-applescript": "^7.0.0" } }, "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -42,6 +42,24 @@
         "typescript": "^5.9.3",
       },
     },
+    "apps/feed-ranker": {
+      "name": "feed-ranker",
+      "version": "0.0.1",
+      "dependencies": {
+        "@workspace/db": "workspace:*",
+        "@workspace/types": "workspace:*",
+        "hono": "^4.7.11",
+        "ioredis": "^5.8.0",
+        "pino": "^9.6.0",
+        "zod": "^3.25.76",
+      },
+      "devDependencies": {
+        "@types/node": "^25.1.0",
+        "@workspace/config-tsconfig": "workspace:*",
+        "pino-pretty": "^13.1.3",
+        "typescript": "^5.9.3",
+      },
+    },
     "apps/web": {
       "name": "web",
       "version": "0.0.1",
@@ -1563,6 +1581,8 @@
     "fastq": ["fastq@1.20.1", "", { "dependencies": { "reusify": "^1.0.4" } }, "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw=="],
 
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
+
+    "feed-ranker": ["feed-ranker@workspace:apps/feed-ranker"],
 
     "fetch-blob": ["fetch-blob@3.2.0", "", { "dependencies": { "node-domexception": "^1.0.0", "web-streams-polyfill": "^3.0.3" } }, "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ=="],
 


### PR DESCRIPTION
Adds the internal `feed-ranker` app so we have a real place to run the For You pipeline: env + logging, health/readiness, bearer auth on `/internal/*`, and `POST /internal/for-you` wired through the planned stages (query context → candidates → filters → scorers → rerank → side effects). Responses match the shared contracts from Part 1; ranking is still a no-op until Part 3 fills in sourcing, scoring, and Redis sessions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new feed-ranking service that powers personalized "for you" feed recommendations.
  * Included health check and readiness probe endpoints for service monitoring and dependency verification.
  * Implemented cursor-based pagination for seamless browsing through ranked feed results.
  * Support for multiple algorithm versions and ranking variants to enable experimentation and optimization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->