### PR TITLE
fix: auth session drop

### DIFF
--- a/packages/auth/src/server.ts
+++ b/packages/auth/src/server.ts
@@ -51,12 +51,10 @@ export function createAuth(config: AuthConfig) {
     session: {
       expiresIn: 60 * 60 * 24 * 30, // 30 days
       updateAge: 60 * 60 * 24, // 1 day
-      // Short TTL so admin actions that revoke a session (ban, delete, etc. — all of which
-      // wipe the row from `sessions`) take effect within ~30s instead of waiting up to the
-      // cache window. Better-auth caches the session in a signed cookie alongside the
-      // session token, and the cache cookie remains valid until it expires regardless of
-      // DB state, so this window is the worst-case lag for forced logout.
-      cookieCache: { enabled: true, maxAge: 30 },
+      // Cookie cache TTL (seconds). Too short forces constant DB revalidation and made
+      // sessions feel broken (~30s). Better-auth defaults to 5 minutes; that still bounds
+      // worst-case lag for forced logout (revoke/ban) vs trusting stale session_data.
+      cookieCache: { enabled: true, maxAge: 5 * 60 },
     },
     advanced: {
       // Our auth tables use uuid PKs with defaultRandom() in Postgres.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Raised Better Auth `session.cookieCache.maxAge` from 30 seconds to **5 minutes** (`5 * 60`), matching the library default and stopping the aggressive cache expiry that aligned with `/api/me` polling and produced apparent session drops.

## Test plan

- [ ] `bun run typecheck` passes
- [ ] Manually exercised the affected flow in the browser
- [ ] No new console errors / network errors

**Note:** CI gates were not run in this agent environment (`bun` / `prettier` CLI unavailable). Please run `bun run format` (or `bun x prettier --write packages/auth/src/server.ts`) locally if you want the formatter to touch the file; the change matches `.prettierrc` conventions as committed.

## Notes

- Forced logout / ban visibility worst-case lag from stale `session_data` is now up to ~5 minutes instead of ~30 seconds. If you need tighter revocation, consider `disableCookieCache: true` on sensitive routes per Better Auth docs instead of a 30s global cache.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-707ca8e8-bd90-4a10-9d4e-e78c72ec05af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-707ca8e8-bd90-4a10-9d4e-e78c72ec05af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

