### PR TITLE
fix(web): constrain main layout width on mobile

### DIFF
--- a/apps/web/src/components/app-shell.tsx
+++ b/apps/web/src/components/app-shell.tsx
@@ -47,7 +47,7 @@ export function AppShell({ children }: { children: ReactNode }) {
               <SidebarWithCompose compact={isAdminShell} />
             </div>
 
-            <div className="mx-auto flex min-h-svh w-full min-w-0 max-w-[1080px]">
+            <div className="mx-auto flex min-h-svh w-full max-w-[1080px] min-w-0">
               <div
                 className={
                   isAdminShell

--- a/apps/web/src/components/app-shell.tsx
+++ b/apps/web/src/components/app-shell.tsx
@@ -47,7 +47,7 @@ export function AppShell({ children }: { children: ReactNode }) {
               <SidebarWithCompose compact={isAdminShell} />
             </div>
 
-            <div className="mx-auto flex min-h-svh max-w-[1080px]">
+            <div className="mx-auto flex min-h-svh w-full min-w-0 max-w-[1080px]">
               <div
                 className={
                   isAdminShell
@@ -55,7 +55,9 @@ export function AppShell({ children }: { children: ReactNode }) {
                     : "w-[68px] shrink-0 xl:w-[240px]"
                 }
               />
-              <main className="flex min-h-svh flex-1 flex-col">{children}</main>
+              <main className="flex min-h-svh min-w-0 flex-1 flex-col overflow-x-hidden">
+                {children}
+              </main>
               <div
                 className={
                   isAdminShell

--- a/apps/web/src/components/page-frame.tsx
+++ b/apps/web/src/components/page-frame.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from "react"
 
-const base = "mx-auto w-full min-w-0"
+const base = "mx-auto w-full min-w-0 max-w-full"
 
 const widthClass = {
   narrow: "md:max-w-md",

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -21,6 +21,7 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true,
     "allowJs": true,
+    "ignoreDeprecations": "6.0",
     "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"],

--- a/packages/auth/tsconfig.json
+++ b/packages/auth/tsconfig.json
@@ -1,8 +1,9 @@
 {
-  "extends": "@workspace/config-tsconfig/base.json",
+  "extends": "@workspace/config-tsconfig/node.json",
   "include": ["src/**/*"],
   "compilerOptions": {
     "outDir": "./dist",
-    "rootDir": "./src"
+    "rootDir": "./src",
+    "lib": ["ES2023", "DOM"]
   }
 }

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "@workspace/config-tsconfig/react.json",
   "compilerOptions": {
     "jsx": "react-jsx",
+    "ignoreDeprecations": "6.0",
     "baseUrl": ".",
     "paths": {
       "@workspace/ui/*": ["./src/*"]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Constrain the authenticated shell flex row with `w-full min-w-0` so the content column cannot grow past the viewport when children have intrinsic min-widths.
- Add `min-w-0` and `overflow-x-hidden` on `<main>` so the feed and other routes clip horizontal overflow instead of forcing the page to zoom out on narrow viewports.
- Cap `PageFrame` with `max-w-full` so nested max-width tokens cannot exceed the parent width.


- **TypeScript:** `@workspace/auth` now extends the node tsconfig and includes the DOM lib so `Response` / `URL` and pulled-in `@workspace/db` types typecheck. `apps/web` and `packages/ui` set `ignoreDeprecations: "6.0"` for the TS 6 `baseUrl` deprecation until paths are migrated for TS 7.

## Test plan

- [x] `bun run format`
- [x] `bun run typecheck`
- [ ] Manually exercised the affected flow in the browser
- [ ] No new console errors / network errors

## Notes

Wide content (e.g. long unbroken strings) may now be clipped at the main column edge until a follow-up adds per-component wrapping. If any intentional horizontal scroll is lost, scope `overflow-x-hidden` to a breakpoint or replace with targeted `min-w-0` on offenders.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-33ac6384-a924-49f8-94c1-dc52dbb07933"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-33ac6384-a924-49f8-94c1-dc52dbb07933"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved layout structure for better content display and overflow handling.

* **Chores**
  * Updated TypeScript configuration settings for enhanced compatibility and deprecation management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->