### PR TITLE
Dedupe post-like notifications when someone re-likes

### DIFF
--- a/apps/api/src/routes/posts.ts
+++ b/apps/api/src/routes/posts.ts
@@ -423,6 +423,17 @@ postsRoute.post('/:id/like', requireHandle(), async (c) => {
       .where(eq(schema.posts.id, id))
       .limit(1)
     if (!target) return new Set<string>()
+    await tx
+      .delete(schema.notifications)
+      .where(
+        and(
+          eq(schema.notifications.userId, target.authorId),
+          eq(schema.notifications.actorId, session.user.id),
+          eq(schema.notifications.kind, 'like'),
+          eq(schema.notifications.entityType, 'post'),
+          eq(schema.notifications.entityId, id),
+        ),
+      )
     return notify(tx, [
       {
         userId: target.authorId,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- When a user likes a post after unliking, the API used to insert a new notification row every time, so the notifications list could show many identical "X liked your post" lines for the same post.
- Before inserting a like notification, we now delete any existing like notification for the same recipient (post author), actor, post entity (`kind` `like`, `entityType` `post`, `entityId` post id), then insert one fresh row. That collapses historical duplicates on the next like and keeps a single row with an updated timestamp.

## Test plan

- [x] `bun install` (Bun 1.3.13)
- [x] `bun run lint:fix` and `bun run format`
- [x] `bunx turbo run typecheck --filter=api --only` (full monorepo `bun run typecheck` still fails on `@workspace/auth` until the separate tsconfig PR lands: `Response`/`URL`/`process`/`Buffer` globals)
- [ ] Manually exercised the affected flow in the browser
- [ ] No new console errors / network errors

## Notes

- Repost notifications are unchanged; only post likes use this replace-before-insert pattern.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a39ede07-59fb-48d7-847f-b87d0de60e4d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a39ede07-59fb-48d7-847f-b87d0de60e4d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved notification handling when liking posts to prevent duplicate or stale notification entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->