### PR TITLE
feat(feed): chain previews for deep replies on Following and All

### DIFF
--- a/apps/api/src/lib/feed-chain-preview.ts
+++ b/apps/api/src/lib/feed-chain-preview.ts
@@ -1,0 +1,149 @@
+import { and, eq, inArray, isNull } from "@workspace/db"
+import type { Database } from "@workspace/db"
+import { schema } from "@workspace/db"
+import type { MediaEnv } from "@workspace/media/env"
+import { toPostDto, type PostDto } from "./post-dto.ts"
+import { loadViewerFlags } from "./viewer-flags.ts"
+import { loadPostMedia } from "./post-media.ts"
+import { loadArticleCards } from "./article-cards.ts"
+import { loadRepostTargets } from "./repost-targets.ts"
+import { loadQuoteTargets } from "./quote-targets.ts"
+import { loadPolls } from "./polls.ts"
+import { loadUnfurlCards } from "./unfurl-cards.ts"
+
+/**
+ * For reply rows in home/public feeds, attach chainPreview (conversation root + omitted count)
+ * when depth >= 2 so the client can render root → "N more replies" → leaf with thread lines.
+ * Root is omitted when it would not be visible to the viewer (followers-only without follow).
+ */
+export async function attachFeedChainPreviews(args: {
+  db: Database
+  viewerId: string | undefined
+  env: MediaEnv
+  posts: Array<PostDto>
+}): Promise<void> {
+  const { db, viewerId, env, posts } = args
+
+  const targets: Array<{
+    outer: PostDto
+    displayed: PostDto
+    rootId: string
+    depth: number
+  }> = []
+
+  for (const p of posts) {
+    const displayed = p.repostOf ?? p
+    if (!displayed.replyToId || !displayed.rootId) continue
+    if (displayed.conversationDepth < 2) continue
+    targets.push({
+      outer: p,
+      displayed,
+      rootId: displayed.rootId,
+      depth: displayed.conversationDepth,
+    })
+  }
+
+  if (targets.length === 0) return
+
+  const rootIds = Array.from(new Set(targets.map((t) => t.rootId)))
+
+  const rootRows = await db
+    .select({ post: schema.posts, author: schema.users })
+    .from(schema.posts)
+    .innerJoin(schema.users, eq(schema.users.id, schema.posts.authorId))
+    .where(and(inArray(schema.posts.id, rootIds), isNull(schema.posts.deletedAt)))
+
+  const rootById = new Map(rootRows.map((r) => [r.post.id, r]))
+
+  const visibleRootAuthorIds = new Set<string>()
+  const followersOnlyAuthorIds = Array.from(
+    new Set(
+      rootIds
+        .map((id) => rootById.get(id))
+        .filter((r) => r?.post.visibility === "followers")
+        .map((r) => r!.post.authorId),
+    ),
+  )
+
+  if (followersOnlyAuthorIds.length > 0 && viewerId) {
+    const followRows = await db
+      .select({ followeeId: schema.follows.followeeId })
+      .from(schema.follows)
+      .where(
+        and(
+          eq(schema.follows.followerId, viewerId),
+          inArray(schema.follows.followeeId, followersOnlyAuthorIds),
+        ),
+      )
+    for (const fr of followRows) visibleRootAuthorIds.add(fr.followeeId)
+  }
+
+  const rootsToLoad: typeof rootRows = []
+  for (const id of rootIds) {
+    const row = rootById.get(id)
+    if (!row) continue
+    if (row.post.visibility === "followers") {
+      const authorId = row.post.authorId
+      if (viewerId === authorId || visibleRootAuthorIds.has(authorId)) {
+        rootsToLoad.push(row)
+      }
+    } else {
+      rootsToLoad.push(row)
+    }
+  }
+
+  if (rootsToLoad.length === 0) return
+
+  const loadIds = rootsToLoad.map((r) => r.post.id)
+  const [flags, mediaMap, articleMap, repostMap, quoteMap, pollMap] = await Promise.all([
+    loadViewerFlags(db, viewerId, loadIds),
+    loadPostMedia(db, loadIds),
+    loadArticleCards(db, loadIds),
+    loadRepostTargets({
+      db,
+      viewerId,
+      env,
+      repostRows: rootsToLoad.map((r) => ({
+        id: r.post.id,
+        repostOfId: r.post.repostOfId,
+      })),
+    }),
+    loadQuoteTargets({
+      db,
+      viewerId,
+      env,
+      quoteRows: rootsToLoad.map((r) => ({
+        id: r.post.id,
+        quoteOfId: r.post.quoteOfId,
+      })),
+    }),
+    loadPolls(db, viewerId, loadIds),
+  ])
+  const unfurlCardsMap = await loadUnfurlCards(db, loadIds, articleMap)
+
+  const rootDtoById = new Map<string, PostDto>()
+  for (const r of rootsToLoad) {
+    rootDtoById.set(
+      r.post.id,
+      toPostDto(
+        r.post,
+        r.author,
+        flags.get(r.post.id),
+        mediaMap.get(r.post.id),
+        env,
+        unfurlCardsMap.get(r.post.id),
+        repostMap.get(r.post.id),
+        quoteMap.get(r.post.id),
+        pollMap.get(r.post.id),
+      ),
+    )
+  }
+
+  for (const t of targets) {
+    const rootDto = rootDtoById.get(t.rootId)
+    if (!rootDto) continue
+    const omitted = Math.max(0, t.depth - 1)
+    ;(t.outer as PostDto).chainPreview = { root: rootDto, omittedCount: omitted }
+    delete t.displayed.replyParent
+  }
+}

--- a/apps/api/src/lib/post-dto.ts
+++ b/apps/api/src/lib/post-dto.ts
@@ -39,6 +39,10 @@ export interface PostDto {
   createdAt: string
   editedAt: string | null
   visibility: "public" | "followers" | "unlisted"
+  /** Conversation root post id; null for top-level posts. */
+  rootId: string | null
+  /** Depth from the conversation root (root = 0, immediate reply = 1). */
+  conversationDepth: number
   replyToId: string | null
   quoteOfId: string | null
   repostOfId: string | null
@@ -81,6 +85,8 @@ export interface PostDto {
   pinned?: boolean
   /** Attached poll, if any. Renders below the post text. */
   poll?: PollDto
+  /** Home/public feed only: when set, render root + leaf with a collapsed gap label. */
+  chainPreview?: { root: PostDto; omittedCount: number }
 }
 
 export function toMediaDto(m: MediaRow, env: MediaEnv): MediaDto {
@@ -129,6 +135,8 @@ export function toPostDto(
     createdAt: post.createdAt.toISOString(),
     editedAt: post.editedAt?.toISOString() ?? null,
     visibility: post.visibility,
+    rootId: post.rootId,
+    conversationDepth: post.conversationDepth,
     replyToId: post.replyToId,
     quoteOfId: post.quoteOfId,
     repostOfId: post.repostOfId,

--- a/apps/api/src/routes/feed.ts
+++ b/apps/api/src/routes/feed.ts
@@ -8,6 +8,7 @@ import { loadPostMedia } from '../lib/post-media.ts'
 import { loadArticleCards } from '../lib/article-cards.ts'
 import { loadRepostTargets } from '../lib/repost-targets.ts'
 import { loadQuoteTargets } from '../lib/quote-targets.ts'
+import { attachFeedChainPreviews } from '../lib/feed-chain-preview.ts'
 import { attachReplyParents } from '../lib/reply-parents.ts'
 import { loadPolls } from '../lib/polls.ts'
 import { loadUnfurlCards } from '../lib/unfurl-cards.ts'
@@ -18,7 +19,7 @@ export const feedRoute = new Hono<HonoEnv>()
 const HOME_FEED_TTL_SEC = 30
 
 export function homeFeedCacheKey(userId: string) {
-  return `feed:home:${userId}:v2`
+  return `feed:home:${userId}:v3`
 }
 
 /**
@@ -102,6 +103,7 @@ feedRoute.get('/', requireHandle(), async (c) => {
     ),
   )
   await attachReplyParents({ db, viewerId: me, env: mediaEnv, posts })
+  await attachFeedChainPreviews({ db, viewerId: me, env: mediaEnv, posts })
   const nextCursor = posts.length === limit ? posts[posts.length - 1]!.createdAt : null
   const response = { posts, nextCursor }
 

--- a/apps/api/src/routes/posts.ts
+++ b/apps/api/src/routes/posts.ts
@@ -11,6 +11,7 @@ import { loadPostMedia } from '../lib/post-media.ts'
 import { loadArticleCards } from '../lib/article-cards.ts'
 import { loadRepostTargets } from '../lib/repost-targets.ts'
 import { loadQuoteTargets } from '../lib/quote-targets.ts'
+import { attachFeedChainPreviews } from '../lib/feed-chain-preview.ts'
 import { attachReplyParents } from '../lib/reply-parents.ts'
 import { loadPolls } from '../lib/polls.ts'
 import { linkHashtags } from '../lib/hashtags.ts'
@@ -968,6 +969,7 @@ postsRoute.get('/', async (c) => {
     ),
   )
   await attachReplyParents({ db, viewerId, env: mediaEnv, posts })
+  await attachFeedChainPreviews({ db, viewerId, env: mediaEnv, posts })
   const nextCursor = posts.length === limit ? posts[posts.length - 1]!.createdAt : null
   return c.json({ posts, nextCursor })
 })

--- a/apps/web/src/components/feed-chain-preview.tsx
+++ b/apps/web/src/components/feed-chain-preview.tsx
@@ -31,10 +31,10 @@ export function FeedChainPreview({ post }: { post: Post }) {
           e.stopPropagation()
           openLeaf()
         }}
-        className="text-muted-foreground hover:text-primary flex items-center gap-3 py-1.5 pr-4 pl-[68px] text-left text-xs"
+        className="text-muted-foreground flex items-center gap-3 py-1.5 pr-4 pl-[68px] text-left text-xs hover:text-primary"
       >
         <span
-          className="bg-[var(--border-color-neutral)] h-8 w-px shrink-0"
+          className="h-8 w-px shrink-0 bg-[var(--border-color-neutral)]"
           aria-hidden
         />
         <span className="underline-offset-2 hover:underline">

--- a/apps/web/src/components/feed-chain-preview.tsx
+++ b/apps/web/src/components/feed-chain-preview.tsx
@@ -1,0 +1,47 @@
+import { useNavigate } from "@tanstack/react-router"
+import { FeedPostCard } from "./feed-post-card"
+import type { Post } from "../lib/api"
+
+function leafPostId(post: Post): string {
+  const inner = post.repostOf ?? post
+  return inner.id
+}
+
+export function FeedChainPreview({ post }: { post: Post }) {
+  const navigate = useNavigate()
+  const preview = post.chainPreview
+  if (!preview) return <FeedPostCard post={post} />
+
+  const { root, omittedCount } = preview
+  const leafId = leafPostId(post)
+  const openLeaf = () => {
+    const inner = post.repostOf ?? post
+    const handle = inner.author.handle ?? "unknown"
+    navigate({ to: "/$handle/p/$id", params: { handle, id: leafId } })
+  }
+
+  const replyWord = omittedCount === 1 ? "reply" : "replies"
+
+  return (
+    <div className="flex flex-col">
+      <FeedPostCard post={root} threadLine="bottom" />
+      <button
+        type="button"
+        onClick={(e) => {
+          e.stopPropagation()
+          openLeaf()
+        }}
+        className="text-muted-foreground hover:text-primary flex items-center gap-3 py-1.5 pr-4 pl-[68px] text-left text-xs"
+      >
+        <span
+          className="bg-[var(--border-color-neutral)] h-8 w-px shrink-0"
+          aria-hidden
+        />
+        <span className="underline-offset-2 hover:underline">
+          {omittedCount} more {replyWord}
+        </span>
+      </button>
+      <FeedPostCard post={post} threadLine="top" />
+    </div>
+  )
+}

--- a/apps/web/src/components/feed.tsx
+++ b/apps/web/src/components/feed.tsx
@@ -3,6 +3,7 @@ import { useInfiniteQuery, useQueryClient } from "@tanstack/react-query"
 import { useVirtualizer, useWindowVirtualizer } from "@tanstack/react-virtual"
 import { Skeleton } from "@workspace/ui/components/skeleton"
 import { PageEmpty, PageError } from "./page-surface"
+import { FeedChainPreview } from "./feed-chain-preview"
 import { FeedPostCard } from "./feed-post-card"
 import type { InfiniteData } from "@tanstack/react-query"
 import type { FeedPage, Post } from "../lib/api"
@@ -45,9 +46,9 @@ const ESTIMATED_LINK_CARD_BUMP = 260
 const ESTIMATED_QUOTE_BUMP = 110
 const ESTIMATED_ARTICLE_BUMP = 90
 const ESTIMATED_POLL_BUMP = 140
+const ESTIMATED_CHAIN_GAP = 36
 
-function estimatePostHeight(post: Post | undefined): number {
-  if (!post) return ESTIMATED_POST_HEIGHT
+function estimateInnerCardHeight(post: Post): number {
   const target = post.repostOf ?? post
   let height = ESTIMATED_POST_HEIGHT
   if (target.media && target.media.length > 0) height += ESTIMATED_MEDIA_BUMP
@@ -63,6 +64,18 @@ function estimatePostHeight(post: Post | undefined): number {
   return height
 }
 
+function estimatePostHeight(post: Post | undefined): number {
+  if (!post) return ESTIMATED_POST_HEIGHT
+  if (post.chainPreview) {
+    return (
+      estimateInnerCardHeight(post.chainPreview.root) +
+      ESTIMATED_CHAIN_GAP +
+      estimateInnerCardHeight(post)
+    )
+  }
+  return estimateInnerCardHeight(post)
+}
+
 export function Feed({
   queryKey,
   load,
@@ -72,6 +85,7 @@ export function Feed({
   hideReplies = false,
   onlyReplies = false,
   renderActivityBanner,
+  chainPreview = false,
   quietPending = false,
   onReady,
 }: {
@@ -87,6 +101,8 @@ export function Feed({
   /** Optional banner rendered above each post card (e.g. "Lucas liked this"
    *  on the network feed). Returning null skips the banner for that row. */
   renderActivityBanner?: (post: Post) => React.ReactNode
+  /** When true, render root → gap → leaf for posts with `chainPreview` (home-style feeds). */
+  chainPreview?: boolean
   /** When true, render `null` instead of the skeleton placeholders during the
    *  initial pending state. Lets a parent show its own loading affordance. */
   quietPending?: boolean
@@ -178,7 +194,11 @@ export function Feed({
     return (
       <>
         {banner && <div className="pt-2 pr-4 pl-[68px]">{banner}</div>}
-        <FeedPostCard post={post} />
+        {chainPreview && post.chainPreview ? (
+          <FeedChainPreview post={post} />
+        ) : (
+          <FeedPostCard post={post} />
+        )}
       </>
     )
   }

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -672,6 +672,8 @@ export interface Post {
   createdAt: string
   editedAt: string | null
   visibility: "public" | "followers" | "unlisted"
+  rootId: string | null
+  conversationDepth: number
   replyToId: string | null
   quoteOfId: string | null
   repostOfId: string | null
@@ -714,6 +716,8 @@ export interface Post {
   pinned?: boolean
   /** Optional poll attached to this post. */
   poll?: PollDto
+  /** Home/public feed: root + collapsed gap + leaf for deep reply threads. */
+  chainPreview?: { root: Post; omittedCount: number }
 }
 
 export interface PollOption {

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -290,6 +290,7 @@ function Home() {
             prependItem={newPost}
             quietPending={!feedReady}
             onReady={() => setFeedReady(true)}
+            chainPreview={tab === "following" || tab === "all"}
             renderActivityBanner={
               tab === "network"
                 ? (p) => {

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -21,6 +21,7 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true,
     "allowJs": true,
+    "ignoreDeprecations": "6.0",
     "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"],

--- a/packages/auth/tsconfig.json
+++ b/packages/auth/tsconfig.json
@@ -1,8 +1,9 @@
 {
-  "extends": "@workspace/config-tsconfig/base.json",
+  "extends": "@workspace/config-tsconfig/node.json",
   "include": ["src/**/*"],
   "compilerOptions": {
     "outDir": "./dist",
-    "rootDir": "./src"
+    "rootDir": "./src",
+    "lib": ["ES2023", "DOM"]
   }
 }

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "@workspace/config-tsconfig/react.json",
   "compilerOptions": {
     "jsx": "react-jsx",
+    "ignoreDeprecations": "6.0",
     "baseUrl": ".",
     "paths": {
       "@workspace/ui/*": ["./src/*"]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What this does

Reply threads in **Following** and **All** used to show only the latest reply, which felt disconnected from the conversation. Now when a feed row is a deeper reply (not just one hop under the root), we show **the conversation root**, a **“N more replies”** line in the middle, and **the post that surfaced**—with the same vertical thread lines you already see on the single-post page.

**Network** is untouched for now.

## Details worth knowing

- **Short threads:** If you’re only one reply below the root, nothing changes—you still get the small parent embed above the reply.
- **Long threads:** “N more replies” counts posts **between** root and leaf. Tap that label or the bottom card and you land on the leaf in the normal thread view.
- **Private roots:** If the root is followers-only, we only attach the chain when you’re allowed to see that root (you follow them or it’s your post). Otherwise you just see the reply row like before.
- **API:** Posts now include `rootId` / `conversationDepth`, and reply-heavy feed responses may include `chainPreview`. Home feed cache key bumped so cached pages don’t miss the new shape.

## TS / tooling

Small tsconfig updates so **typecheck passes on TS 6** (`ignoreDeprecations` where we still use `baseUrl`, auth package uses the node preset + DOM lib for fetch types).

## How we checked it

`bun install`, `bun run format`, `bun run lint:fix`, `bun run typecheck`, `bun run format:check`, `bun run lint` (one existing web warning in the GitHub heatmap file).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f0d7a514-3931-497d-b756-9a677859ff5c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f0d7a514-3931-497d-b756-9a677859ff5c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Conversation thread previews in feeds: shows the root post, a collapsed "X more reply(s)" indicator, and the current reply in context.
  * Previews enabled on Home feed (Following and All tabs) and the global public timeline.
  * Clicking the preview navigates to the full conversation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->