### PR TITLE
fix: handle @ prefix in search and add avatar load fallback

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -221,9 +221,14 @@ app.get('/api/m/*', async (c) => {
     key,
     expiresInSeconds: ctx.env.MEDIA_SIGNED_URL_TTL_SEC,
   })
-  // Signing is microseconds; keep the redirect cache short so a bad deploy doesn't poison
-  // browser caches for ages, but long enough to skip re-signing during a single page paint.
-  c.header('Cache-Control', 'public, max-age=30')
+  // Cache the redirect for nearly the full signed-URL lifetime. Each redirect points to a
+  // freshly-signed URL valid for MEDIA_SIGNED_URL_TTL_SEC. Without a matching cache, the
+  // browser re-asks the proxy on every page paint, gets a different signature, and treats
+  // the result as a new resource — re-downloading the same image bytes. Caching for the
+  // URL's validity (minus a buffer to avoid mid-fetch expiry) lets the browser reuse one
+  // signed URL until it's genuinely close to expiring.
+  const cacheSeconds = Math.max(60, ctx.env.MEDIA_SIGNED_URL_TTL_SEC - 60)
+  c.header('Cache-Control', `public, max-age=${cacheSeconds}`)
   return c.redirect(signed, 302)
 })
 app.route('/api/articles', articlesRoute)

--- a/apps/api/src/routes/search.ts
+++ b/apps/api/src/routes/search.ts
@@ -3,6 +3,7 @@ import { z } from 'zod'
 import { and, asc, desc, eq, exists, gte, ilike, inArray, isNull, lte, or, sql } from '@workspace/db'
 import { schema } from '@workspace/db'
 import { assetUrl } from '@workspace/media/s3'
+import { handleSchema } from '@workspace/validators'
 import { requireHandle, type HonoEnv } from '../middleware/session.ts'
 import { toPostDto } from '../lib/post-dto.ts'
 import { loadViewerFlags } from '../lib/viewer-flags.ts'
@@ -37,7 +38,6 @@ interface ParsedQuery {
   minReplies?: number
 }
 
-const handleWord = /^[a-z0-9_]{1,30}$/i
 const langWord = /^[a-z]{2,3}(?:-[A-Za-z]{2,4})?$/
 const isoDate = /^\d{4}-\d{2}-\d{2}$/
 
@@ -61,7 +61,8 @@ function parseQuery(raw: string): ParsedQuery {
     switch (key) {
       case 'from': {
         const v = val.replace(/^@/, '')
-        if (handleWord.test(v)) out.fromHandle = v.toLowerCase()
+        const r = handleSchema.safeParse(v)
+        if (r.success) out.fromHandle = r.data.toLowerCase()
         else free.push(w)
         break
       }
@@ -69,7 +70,8 @@ function parseQuery(raw: string): ParsedQuery {
       case 'mention':
       case 'mentions': {
         const v = val.replace(/^@/, '')
-        if (handleWord.test(v)) out.toHandle = v.toLowerCase()
+        const r = handleSchema.safeParse(v)
+        if (r.success) out.toHandle = r.data.toLowerCase()
         else free.push(w)
         break
       }

--- a/apps/api/src/routes/search.ts
+++ b/apps/api/src/routes/search.ts
@@ -49,22 +49,30 @@ function parseQuery(raw: string): ParsedQuery {
     if (!w) continue
     const m = /^([a-z_]+):(.+)$/i.exec(w)
     if (!m) {
-      free.push(w)
+      // Strip leading @ from bare words: handles are stored without @, so
+      // "@alice" must search as "alice". Mirrors the @-strip already done
+      // for from:/to: handle operators below.
+      const stripped = w.startsWith('@') ? w.slice(1) : w
+      if (stripped) free.push(stripped)
       continue
     }
     const key = m[1]!.toLowerCase()
     const val = m[2]!
     switch (key) {
-      case 'from':
-        if (handleWord.test(val)) out.fromHandle = val.replace(/^@/, '').toLowerCase()
+      case 'from': {
+        const v = val.replace(/^@/, '')
+        if (handleWord.test(v)) out.fromHandle = v.toLowerCase()
         else free.push(w)
         break
+      }
       case 'to':
       case 'mention':
-      case 'mentions':
-        if (handleWord.test(val)) out.toHandle = val.replace(/^@/, '').toLowerCase()
+      case 'mentions': {
+        const v = val.replace(/^@/, '')
+        if (handleWord.test(v)) out.toHandle = v.toLowerCase()
         else free.push(w)
         break
+      }
       case 'has':
         if (val === 'media' || val === 'image' || val === 'images') out.hasMedia = true
         else if (val === 'link' || val === 'links') out.hasLink = true

--- a/packages/ui/src/components/avatar.tsx
+++ b/packages/ui/src/components/avatar.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react"
 import { cn } from "@workspace/ui/lib/utils"
 
 const sizeStyles = {
@@ -21,7 +22,9 @@ export interface AvatarProps {
 }
 
 export function Avatar({ initial, src, size = "md", className }: AvatarProps) {
-  if (src) {
+  const [errored, setErrored] = useState(false)
+
+  if (src && !errored) {
     return (
       <img
         src={src}
@@ -31,6 +34,7 @@ export function Avatar({ initial, src, size = "md", className }: AvatarProps) {
           sizeStyles[size],
           className
         )}
+        onError={() => setErrored(true)}
       />
     )
   }

--- a/packages/ui/src/components/avatar.tsx
+++ b/packages/ui/src/components/avatar.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react"
+import { useRef, useState } from "react"
 import { cn } from "@workspace/ui/lib/utils"
 
 const sizeStyles = {
@@ -23,6 +23,12 @@ export interface AvatarProps {
 
 export function Avatar({ initial, src, size = "md", className }: AvatarProps) {
   const [errored, setErrored] = useState(false)
+  const prevSrcRef = useRef(src)
+
+  if (prevSrcRef.current !== src) {
+    prevSrcRef.current = src
+    setErrored(false)
+  }
 
   if (src && !errored) {
     return (


### PR DESCRIPTION
## Summary

  This PR addresses three sub-items of #107.

  ---

  ### 1. Avatar fallback on image load failure

  **File:** `packages/ui/src/components/avatar.tsx`

  **Problem:** When an avatar image fails to load (404, expired S3 URL,
  network error), the browser shows its broken-image placeholder.

  **Fix:** Added an `onError` handler on the `<img>`. When the image fails,
  the component renders the existing initial-letter circle that's already
  used for users without avatars set.

  ---

  ### 2. Media proxy browser caching

  **File:** `apps/api/src/index.ts`

  **Problem:** The `/api/m/*` proxy mints fresh signed S3 URLs (valid for
  `MEDIA_SIGNED_URL_TTL_SEC`, default 900s) but caches the 302 redirect for
  only 30 seconds. Each cache miss returns a different signature, which the
  browser treats as a new resource and re-downloads the same image bytes.

  **Fix:** Cache the redirect for `MEDIA_SIGNED_URL_TTL_SEC - 60` seconds
  (with a 60-second floor). The browser now reuses one signed URL for nearly
   its full lifetime.

  **Impact:** Roughly 28x reduction in repeated downloads at default
  settings.

  ---

  ### 3. `@` prefix in search queries

  **File:** `apps/api/src/routes/search.ts`

  **Problem:** Handles are stored without `@`, so `?q=@alice` was building
  `ILIKE '%@alice%'` which never matches. The same issue affected the
  `from:`, `to:`, `mention:`, and `mentions:` operators.

  **Fix:** `parseQuery` now strips a leading `@` in two places:

  1. **Bare free-text words.** `@alice` becomes `alice` before being added
  to the SQL pattern.
  2. **Operator values.** `from:@bob` now resolves the same as `from:bob`.

  **Note on the operator path:** The existing `.replace(/^@/, '')` was on
  the assignment side and never executed because the regex test rejected
  `@`-prefixed values first. This PR moves the strip to before the regex
  test.

  ---

  ## Files changed

  - `apps/api/src/routes/search.ts`: `@` stripping in `parseQuery`
  - `apps/api/src/index.ts`: media proxy redirect cache TTL
  - `packages/ui/src/components/avatar.tsx`: `onError` fallback to
  initial-letter circle

  ---

  ## Test plan

  ### CI gates

  - [x] `bun run typecheck` passes (15 of 15 packages)
  - [x] `bun run lint` clean (one pre-existing warning in an unrelated file)
  - [x] `bun run format:check` passes
  - [x] `bun run build` passes

  ### Search behavior

  - [x] `@alice` finds alice
  - [x] `@m` finds Dave Kim and Eve Martinez (display names contain `m`)
  - [x] Plain `alice` still works
  - [x] `from:@bob` finds bob's posts
  - [x] `from:bob` still works
  - [x] `to:@alice` and `mention:@carol` work

  ### Cache behavior

  - [x] `curl -I http://localhost:3001/api/m/anything.jpg` returns
  `Cache-Control: public, max-age=840` (with default
  `MEDIA_SIGNED_URL_TTL_SEC=900`)

  ### Avatar fallback

  - [x] Setting `users.avatar_url` to a broken URL renders the
  initial-letter fallback in the feed instead of a broken-image icon

  ---

  ## Notes

  ### Out of scope

  The remaining sub-items of #107 are not addressed in this PR. They are
  intentionally left for follow-up PRs to keep the review surface small.

  ### Behavior changes

  - Bare `@text` queries now run FTS for `text` instead of literal `@text`.
  Posts containing `text` (with or without `@`) will match. The `mention:`
  and `to:` operators remain the canonical way to find posts mentioning a
  specific user.
  - The cache change does not affect invalidation when an avatar is
  replaced. New uploads get new S3 keys, so the URL itself changes and the
  browser cache misses naturally.

  ---

  Refs #107

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Avatar now falls back to displaying user initials when image loading fails for consistent appearance.
  * Search query parsing improved for more reliable handling of handles and operator tokens.
  * API signed-url redirects now use a dynamic Cache-Control max-age based on configured TTL, allowing browsers to reuse redirects longer.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->