### PR TITLE
redesign notification cards with improved layout and reply chain context

### DIFF
--- a/apps/api/src/lib/post-dto.ts
+++ b/apps/api/src/lib/post-dto.ts
@@ -87,6 +87,9 @@ export interface PostDto {
   poll?: PollDto
   /** Home/public feed only: when set, render root + leaf with a collapsed gap label. */
   chainPreview?: { root: PostDto; omittedCount: number }
+  /** For replies: the handles of users in the reply chain (from root to immediate parent).
+   *  Used to show "Replying to @user1, @user2, ..." in notifications. */
+  replyChainHandles?: string[]
 }
 
 export function toMediaDto(m: MediaRow, env: MediaEnv): MediaDto {

--- a/apps/api/src/lib/reply-parents.ts
+++ b/apps/api/src/lib/reply-parents.ts
@@ -67,3 +67,108 @@ export async function attachReplyParents(args: {
     displayed.replyParent = parent
   }
 }
+
+/**
+ * For reply posts, load the full chain of handles from the conversation root to the
+ * immediate parent. This is used in notifications to show "Replying to @user1, @user2, ...".
+ *
+ * Mutates `posts` in place, setting `replyChainHandles` on each reply.
+ */
+export async function attachReplyChainHandles(args: {
+  db: Database
+  posts: Array<PostDto>
+}): Promise<void> {
+  const { db, posts } = args
+
+  // Collect posts that are replies (have rootId indicating they're in a thread)
+  const repliesWithRoot: Array<{ post: PostDto; rootId: string }> = []
+  for (const p of posts) {
+    const displayed = p.repostOf ?? p
+    if (displayed.rootId && displayed.replyToId) {
+      repliesWithRoot.push({ post: displayed, rootId: displayed.rootId })
+    }
+  }
+  if (repliesWithRoot.length === 0) return
+
+  // Group by rootId to batch load conversation posts
+  const byRoot = new Map<string, PostDto[]>()
+  for (const { post, rootId } of repliesWithRoot) {
+    if (!byRoot.has(rootId)) byRoot.set(rootId, [])
+    byRoot.get(rootId)!.push(post)
+  }
+
+  // For each conversation, load all posts from root to the reply and build chain handles
+  for (const [rootId, postsInConvo] of byRoot) {
+    // Load all posts in this conversation that could be ancestors
+    // (posts with same rootId, or the root itself)
+    const ancestorRows = await db
+      .select({
+        id: schema.posts.id,
+        replyToId: schema.posts.replyToId,
+        authorHandle: schema.users.handle,
+      })
+      .from(schema.posts)
+      .innerJoin(schema.users, eq(schema.users.id, schema.posts.authorId))
+      .where(
+        and(
+          isNull(schema.posts.deletedAt),
+          // Posts that are either the root or have this rootId
+          inArray(
+            schema.posts.id,
+            db
+              .select({ id: schema.posts.id })
+              .from(schema.posts)
+              .where(
+                and(
+                  isNull(schema.posts.deletedAt),
+                  // Either the root post itself or posts in this conversation
+                  eq(schema.posts.rootId, rootId),
+                ),
+              ),
+          ),
+        ),
+      )
+
+    // Also load the root post itself (which has rootId = null)
+    const rootRows = await db
+      .select({
+        id: schema.posts.id,
+        replyToId: schema.posts.replyToId,
+        authorHandle: schema.users.handle,
+      })
+      .from(schema.posts)
+      .innerJoin(schema.users, eq(schema.users.id, schema.posts.authorId))
+      .where(and(eq(schema.posts.id, rootId), isNull(schema.posts.deletedAt)))
+
+    // Build a map of postId -> { replyToId, authorHandle }
+    const postMap = new Map<string, { replyToId: string | null; authorHandle: string | null }>()
+    for (const row of [...ancestorRows, ...rootRows]) {
+      postMap.set(row.id, { replyToId: row.replyToId, authorHandle: row.authorHandle })
+    }
+
+    // For each reply post, walk up the chain and collect handles
+    for (const post of postsInConvo) {
+      const handles: string[] = []
+      const seen = new Set<string>()
+      let currentId: string | null = post.replyToId
+
+      // Walk up to 10 levels to prevent infinite loops
+      let depth = 0
+      while (currentId && depth < 10) {
+        const ancestor = postMap.get(currentId)
+        if (!ancestor) break
+
+        if (ancestor.authorHandle && !seen.has(ancestor.authorHandle)) {
+          seen.add(ancestor.authorHandle)
+          handles.push(ancestor.authorHandle)
+        }
+
+        currentId = ancestor.replyToId
+        depth++
+      }
+
+      // Reverse so handles are in order from root to immediate parent
+      post.replyChainHandles = handles.reverse()
+    }
+  }
+}

--- a/apps/api/src/lib/reply-parents.ts
+++ b/apps/api/src/lib/reply-parents.ts
@@ -1,4 +1,4 @@
-import { and, eq, inArray, isNull } from '@workspace/db'
+import { and, eq, inArray, isNull, or } from '@workspace/db'
 import type { Database } from '@workspace/db'
 import { schema } from '@workspace/db'
 import type { MediaEnv } from '@workspace/media/env'
@@ -90,85 +90,65 @@ export async function attachReplyChainHandles(args: {
   }
   if (repliesWithRoot.length === 0) return
 
-  // Group by rootId to batch load conversation posts
-  const byRoot = new Map<string, PostDto[]>()
-  for (const { post, rootId } of repliesWithRoot) {
-    if (!byRoot.has(rootId)) byRoot.set(rootId, [])
-    byRoot.get(rootId)!.push(post)
+  // Collect all unique rootIds
+  const allRootIds = Array.from(new Set(repliesWithRoot.map((r) => r.rootId)))
+
+  // Single batched query: fetch root posts (id IN rootIds) and conversation posts (rootId IN rootIds)
+  const allRows = await db
+    .select({
+      id: schema.posts.id,
+      replyToId: schema.posts.replyToId,
+      rootId: schema.posts.rootId,
+      authorHandle: schema.users.handle,
+    })
+    .from(schema.posts)
+    .innerJoin(schema.users, eq(schema.users.id, schema.posts.authorId))
+    .where(
+      and(
+        isNull(schema.posts.deletedAt),
+        or(
+          inArray(schema.posts.id, allRootIds),
+          inArray(schema.posts.rootId, allRootIds),
+        ),
+      ),
+    )
+
+  // Build a single map of postId -> { replyToId, authorHandle }
+  const postMap = new Map<string, { replyToId: string | null; authorHandle: string | null }>()
+  for (const row of allRows) {
+    postMap.set(row.id, { replyToId: row.replyToId, authorHandle: row.authorHandle })
   }
 
-  // For each conversation, load all posts from root to the reply and build chain handles
-  for (const [rootId, postsInConvo] of byRoot) {
-    // Load all posts in this conversation that could be ancestors
-    // (posts with same rootId, or the root itself)
-    const ancestorRows = await db
-      .select({
-        id: schema.posts.id,
-        replyToId: schema.posts.replyToId,
-        authorHandle: schema.users.handle,
-      })
-      .from(schema.posts)
-      .innerJoin(schema.users, eq(schema.users.id, schema.posts.authorId))
-      .where(
-        and(
-          isNull(schema.posts.deletedAt),
-          // Posts that are either the root or have this rootId
-          inArray(
-            schema.posts.id,
-            db
-              .select({ id: schema.posts.id })
-              .from(schema.posts)
-              .where(
-                and(
-                  isNull(schema.posts.deletedAt),
-                  // Either the root post itself or posts in this conversation
-                  eq(schema.posts.rootId, rootId),
-                ),
-              ),
-          ),
-        ),
-      )
+  // For each reply post, walk up the chain and collect handles
+  for (const { post } of repliesWithRoot) {
+    const handles: string[] = []
+    let currentId: string | null = post.replyToId
 
-    // Also load the root post itself (which has rootId = null)
-    const rootRows = await db
-      .select({
-        id: schema.posts.id,
-        replyToId: schema.posts.replyToId,
-        authorHandle: schema.users.handle,
-      })
-      .from(schema.posts)
-      .innerJoin(schema.users, eq(schema.users.id, schema.posts.authorId))
-      .where(and(eq(schema.posts.id, rootId), isNull(schema.posts.deletedAt)))
+    // Walk up to 10 levels to prevent infinite loops
+    let depth = 0
+    while (currentId && depth < 10) {
+      const ancestor = postMap.get(currentId)
+      if (!ancestor) break
 
-    // Build a map of postId -> { replyToId, authorHandle }
-    const postMap = new Map<string, { replyToId: string | null; authorHandle: string | null }>()
-    for (const row of [...ancestorRows, ...rootRows]) {
-      postMap.set(row.id, { replyToId: row.replyToId, authorHandle: row.authorHandle })
-    }
-
-    // For each reply post, walk up the chain and collect handles
-    for (const post of postsInConvo) {
-      const handles: string[] = []
-      const seen = new Set<string>()
-      let currentId: string | null = post.replyToId
-
-      // Walk up to 10 levels to prevent infinite loops
-      let depth = 0
-      while (currentId && depth < 10) {
-        const ancestor = postMap.get(currentId)
-        if (!ancestor) break
-
-        if (ancestor.authorHandle && !seen.has(ancestor.authorHandle)) {
-          seen.add(ancestor.authorHandle)
-          handles.push(ancestor.authorHandle)
-        }
-
-        currentId = ancestor.replyToId
-        depth++
+      if (ancestor.authorHandle) {
+        handles.push(ancestor.authorHandle)
       }
 
-      // Reverse so handles are in order from root to immediate parent
-      post.replyChainHandles = handles.reverse()
+      currentId = ancestor.replyToId
+      depth++
     }
+
+    // Reverse so handles are in order from root to immediate parent,
+    // then dedupe keeping the first (root-most) occurrence of each handle
+    const reversed = handles.reverse()
+    const seen = new Set<string>()
+    const deduped: string[] = []
+    for (const h of reversed) {
+      if (!seen.has(h)) {
+        seen.add(h)
+        deduped.push(h)
+      }
+    }
+    post.replyChainHandles = deduped
   }
 }

--- a/apps/api/src/routes/notifications.ts
+++ b/apps/api/src/routes/notifications.ts
@@ -10,6 +10,7 @@ import { loadPostMedia } from '../lib/post-media.ts'
 import { loadArticleCards } from '../lib/article-cards.ts'
 import { loadUnfurlCards } from '../lib/unfurl-cards.ts'
 import { loadViewerFlags } from '../lib/viewer-flags.ts'
+import { attachReplyParents, attachReplyChainHandles } from '../lib/reply-parents.ts'
 
 export const notificationsRoute = new Hono<HonoEnv>()
 
@@ -114,6 +115,12 @@ notificationsRoute.get('/', async (c) => {
       ),
     )
   }
+
+  // Attach reply parents so replies display "Replying to @user"
+  const postList = Array.from(postById.values())
+  await attachReplyParents({ db, viewerId: session.user.id, env: mediaEnv, posts: postList })
+  // Attach full reply chain handles for thread context (e.g., "Replying to @user1, @user2")
+  await attachReplyChainHandles({ db, posts: postList })
 
   const items = rows.map((r) => ({
     id: r.n.id,

--- a/apps/web/src/components/feed-post-card.tsx
+++ b/apps/web/src/components/feed-post-card.tsx
@@ -247,7 +247,7 @@ export function FeedPostCard({
         }
       }}
       resolveBruvLikeBurstSrc={resolveBruvLikeBurstSrc}
-      renderPostText={(t) => <RichText text={t} stopLinkPropagation />}
+      renderPostText={(t) => <RichText text={t} />}
     />
   )
 }

--- a/apps/web/src/components/page-frame.tsx
+++ b/apps/web/src/components/page-frame.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from "react"
 
-const base = "mx-auto w-full min-w-0"
+const base = "mx-auto w-full min-w-0 mt-4"
 
 const widthClass = {
   narrow: "md:max-w-md",

--- a/apps/web/src/components/rich-text.tsx
+++ b/apps/web/src/components/rich-text.tsx
@@ -1,6 +1,6 @@
 import { Link } from "@tanstack/react-router"
 import { LinkPill } from "./link-card"
-import type { MouseEvent, ReactNode } from "react"
+import type { ReactNode } from "react"
 
 type Part =
   | { type: "text"; value: string }
@@ -9,9 +9,6 @@ type Part =
   | { type: "url"; value: string }
 
 const PATTERN = /(#[a-z0-9_]+|@[a-z0-9_]+|https?:\/\/\S+)/gi
-
-const entityLinkClassName =
-  "text-link underline underline-offset-2 decoration-from-font decoration-link/0 transition-[text-decoration-color] duration-200 ease-out hover:decoration-link/55"
 
 export function linkifyText(text: string): Array<Part> {
   const parts: Array<Part> = []
@@ -29,24 +26,8 @@ export function linkifyText(text: string): Array<Part> {
   return parts
 }
 
-function stopCardSurfaceClick(e: MouseEvent) {
-  e.stopPropagation()
-}
-
-export function RichText({
-  text,
-  stopLinkPropagation = false,
-}: {
-  text: string
-  stopLinkPropagation?: boolean
-}): ReactNode {
+export function RichText({ text }: { text: string }): ReactNode {
   const parts = linkifyText(text)
-  const linkSurfaceProps = stopLinkPropagation
-    ? {
-        "data-post-card-ignore-open": true as const,
-        onClick: stopCardSurfaceClick,
-      }
-    : {}
   return (
     <>
       {parts.map((p, i) => {
@@ -57,8 +38,7 @@ export function RichText({
               key={i}
               to="/hashtag/$tag"
               params={{ tag: p.value.slice(1) }}
-              className={entityLinkClassName}
-              {...linkSurfaceProps}
+              className="text-primary hover:underline"
             >
               {p.value}
             </Link>
@@ -70,8 +50,7 @@ export function RichText({
               key={i}
               to="/$handle"
               params={{ handle: p.value.slice(1) }}
-              className={entityLinkClassName}
-              {...linkSurfaceProps}
+              className="text-sky-500 hover:underline"
             >
               {p.value}
             </Link>

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -720,7 +720,7 @@ export interface Post {
   chainPreview?: { root: Post; omittedCount: number }
   /** For replies: the handles of users in the reply chain (from root to immediate parent).
    *  Used to show "Replying to @user1, @user2, ..." in notifications. */
-  replyChainHandles?: string[]
+  replyChainHandles?: Array<string>
 }
 
 export interface PollOption {

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -718,6 +718,9 @@ export interface Post {
   poll?: PollDto
   /** Home/public feed: root + collapsed gap + leaf for deep reply threads. */
   chainPreview?: { root: Post; omittedCount: number }
+  /** For replies: the handles of users in the reply chain (from root to immediate parent).
+   *  Used to show "Replying to @user1, @user2, ..." in notifications. */
+  replyChainHandles?: string[]
 }
 
 export interface PollOption {

--- a/apps/web/src/routes/notifications.tsx
+++ b/apps/web/src/routes/notifications.tsx
@@ -1,4 +1,9 @@
-import { Link, createFileRoute, useRouter } from "@tanstack/react-router"
+import {
+  Link,
+  createFileRoute,
+  useNavigate,
+  useRouter,
+} from "@tanstack/react-router"
 import {
   useCallback,
   useEffect,
@@ -35,6 +40,7 @@ import { useCompose } from "../components/compose-provider"
 import { PageEmpty } from "../components/page-surface"
 import { PageFrame } from "../components/page-frame"
 import { VerifiedBadge } from "../components/verified-badge"
+import { RichText } from "../components/rich-text"
 import { useInfiniteScrollSentinel } from "../lib/use-infinite-scroll-sentinel"
 import type { InfiniteData } from "@tanstack/react-query"
 import type { NotificationItem, Post } from "../lib/api"
@@ -536,9 +542,8 @@ function GroupedLikeRow({
   target: Post
 }) {
   const lead = items[0]
-  const leadName =
-    lead.actor?.displayName ??
-    (lead.actor?.handle ? `@${lead.actor.handle}` : "someone")
+  const leadDisplayName = lead.actor?.displayName ?? null
+  const leadHandle = lead.actor?.handle ?? null
   const isUnread = items.some((n) => !n.readAt)
 
   const postLink =
@@ -559,7 +564,12 @@ function GroupedLikeRow({
       </div>
       <div className="mt-2 pl-[52px]">
         <p className="text-sm">
-          <span className="font-semibold text-primary">{leadName}</span>
+          <span className="font-semibold text-primary">
+            {leadDisplayName || leadHandle || "someone"}
+          </span>
+          {leadHandle && (
+            <span className="text-tertiary"> @{leadHandle}</span>
+          )}
           <span className="text-secondary">
             {" "}and {items.length - 1} other{items.length - 1 !== 1 ? "s" : ""}{" "}
             liked your post
@@ -575,9 +585,7 @@ function GroupedLikeRow({
 
 function GroupedFollowRow({ items }: { items: NotificationItem[] }) {
   const lead = items[0]
-  const leadName =
-    lead.actor?.displayName ??
-    (lead.actor?.handle ? `@${lead.actor.handle}` : "someone")
+  const leadDisplayName = lead.actor?.displayName ?? null
   const leadHandle = lead.actor?.handle ?? null
   const isUnread = items.some((n) => !n.readAt)
 
@@ -599,10 +607,15 @@ function GroupedFollowRow({ items }: { items: NotificationItem[] }) {
               params={{ handle: leadHandle }}
               className="font-semibold text-primary hover:underline"
             >
-              {leadName}
+              {leadDisplayName || leadHandle}
             </Link>
           ) : (
-            <span className="font-semibold text-primary">{leadName}</span>
+            <span className="font-semibold text-primary">
+              {leadDisplayName || "someone"}
+            </span>
+          )}
+          {leadHandle && (
+            <span className="text-tertiary"> @{leadHandle}</span>
           )}
           <span className="text-secondary">
             {" "}and {items.length - 1} other{items.length - 1 !== 1 ? "s" : ""}{" "}
@@ -615,10 +628,9 @@ function GroupedFollowRow({ items }: { items: NotificationItem[] }) {
 }
 
 function ReplyRow({ item }: { item: NotificationItem }) {
+  const navigate = useNavigate()
   const actor = item.actor
-  const actorLabel = actor
-    ? actor.displayName || (actor.handle ? `@${actor.handle}` : "someone")
-    : "someone"
+  const actorDisplayName = actor?.displayName ?? null
   const actorHandle = actor?.handle ?? null
   const actorInitial = (actor?.displayName ?? actorHandle ?? "·")
     .slice(0, 1)
@@ -633,15 +645,18 @@ function ReplyRow({ item }: { item: NotificationItem }) {
   const replyToHandles =
     chainHandles.length > 0 ? chainHandles : fallbackHandle ? [fallbackHandle] : []
 
-  const postLink =
-    replyTarget?.author.handle && replyTarget?.id
-      ? `/${replyTarget.author.handle}/p/${replyTarget.id}`
-      : null
+  function openPost() {
+    if (!replyTarget?.author.handle || !replyTarget?.id) return
+    navigate({
+      to: "/$handle/p/$id",
+      params: { handle: replyTarget.author.handle, id: replyTarget.id },
+    })
+  }
 
   return (
-    <Link
-      to={postLink ?? "#"}
-      className={`block border-b border-neutral px-4 py-3.5 transition-colors hover:bg-base-2/20 ${!item.readAt ? "bg-subtle" : ""}`}
+    <div
+      onClick={openPost}
+      className={`cursor-pointer border-b border-neutral px-4 py-3.5 transition-colors hover:bg-base-2/20 ${!item.readAt ? "bg-subtle" : ""}`}
     >
       <div className="flex items-start gap-3">
         <Avatar
@@ -652,11 +667,14 @@ function ReplyRow({ item }: { item: NotificationItem }) {
         <div className="min-w-0 flex-1 text-sm">
           <div className="flex items-center gap-1.5">
             <span className="inline-flex items-center gap-1 font-semibold text-primary">
-              {actorLabel}
+              {actorDisplayName || actorHandle || "someone"}
               {actor?.isVerified && (
                 <VerifiedBadge size={14} role={actor.role} />
               )}
             </span>
+            {actorHandle && (
+              <span className="text-tertiary">@{actorHandle}</span>
+            )}
             <span className="text-xs text-tertiary">
               · {formatShortTime(item.createdAt)}
             </span>
@@ -680,10 +698,13 @@ function ReplyRow({ item }: { item: NotificationItem }) {
           )}
           {replyTarget?.text && (
             <p className="mt-0.5 text-primary leading-relaxed whitespace-pre-wrap">
-              {replyTarget.text}
+              <RichText text={replyTarget.text} />
             </p>
           )}
-          <div className="mt-2 flex items-center">
+          <div
+            className="mt-2 flex items-center"
+            onClick={(e) => e.stopPropagation()}
+          >
             <div className="flex-1">
               <span className="inline-flex size-7 items-center justify-center rounded-full text-tertiary">
                 <ChatBubbleOutline className="size-4" />
@@ -707,30 +728,32 @@ function ReplyRow({ item }: { item: NotificationItem }) {
           </div>
         </div>
       </div>
-    </Link>
+    </div>
   )
 }
 
 function MentionRow({ item }: { item: NotificationItem }) {
+  const navigate = useNavigate()
   const actor = item.actor
-  const actorLabel = actor
-    ? actor.displayName || (actor.handle ? `@${actor.handle}` : "someone")
-    : "someone"
+  const actorDisplayName = actor?.displayName ?? null
   const actorHandle = actor?.handle ?? null
-  const actorInitial = (actor?.displayName ?? actorHandle ?? "·")
+  const actorInitial = (actorDisplayName ?? actorHandle ?? "·")
     .slice(0, 1)
     .toUpperCase()
   const mentionTarget = item.target
 
-  const postLink =
-    mentionTarget?.author.handle && mentionTarget?.id
-      ? `/${mentionTarget.author.handle}/p/${mentionTarget.id}`
-      : null
+  function openPost() {
+    if (!mentionTarget?.author.handle || !mentionTarget?.id) return
+    navigate({
+      to: "/$handle/p/$id",
+      params: { handle: mentionTarget.author.handle, id: mentionTarget.id },
+    })
+  }
 
   return (
-    <Link
-      to={postLink ?? "#"}
-      className={`block border-b border-neutral px-4 py-3.5 transition-colors hover:bg-base-2/20 ${!item.readAt ? "bg-subtle" : ""}`}
+    <div
+      onClick={openPost}
+      className={`cursor-pointer border-b border-neutral px-4 py-3.5 transition-colors hover:bg-base-2/20 ${!item.readAt ? "bg-subtle" : ""}`}
     >
       <div className="flex items-start gap-3">
         <Avatar
@@ -741,22 +764,27 @@ function MentionRow({ item }: { item: NotificationItem }) {
         <div className="min-w-0 flex-1 text-sm">
           <div className="flex items-center gap-1.5">
             <span className="inline-flex items-center gap-1 font-semibold text-primary">
-              {actorLabel}
+              {actorDisplayName || actorHandle || "someone"}
               {actor?.isVerified && (
                 <VerifiedBadge size={14} role={actor.role} />
               )}
             </span>
+            {actorHandle && (
+              <span className="text-tertiary">@{actorHandle}</span>
+            )}
             <span className="text-xs text-tertiary">
               · {formatShortTime(item.createdAt)}
             </span>
           </div>
-          <p className="mt-0.5 text-secondary">Mentioned you</p>
           {mentionTarget?.text && (
             <p className="mt-0.5 text-primary leading-relaxed whitespace-pre-wrap">
-              {mentionTarget.text}
+              <RichText text={mentionTarget.text} />
             </p>
           )}
-          <div className="mt-2 flex items-center">
+          <div
+            className="mt-2 flex items-center"
+            onClick={(e) => e.stopPropagation()}
+          >
             <div className="flex-1">
               <span className="inline-flex size-7 items-center justify-center rounded-full text-tertiary">
                 <ChatBubbleOutline className="size-4" />
@@ -780,7 +808,7 @@ function MentionRow({ item }: { item: NotificationItem }) {
           </div>
         </div>
       </div>
-    </Link>
+    </div>
   )
 }
 
@@ -802,12 +830,9 @@ function NotificationRow({ item }: { item: NotificationItem }) {
   const Icon = iconForKind(item.kind)
   const iconClass = iconClassForKind(item.kind)
   const verb = verbForKind(item.kind)
-  const actorLabel = item.actor
-    ? item.actor.displayName ||
-      (item.actor.handle ? `@${item.actor.handle}` : "someone")
-    : "someone"
+  const actorDisplayName = item.actor?.displayName ?? null
   const actorHandle = item.actor?.handle ?? null
-  const actorInitial = (item.actor?.displayName ?? actorHandle ?? "·")
+  const actorInitial = (actorDisplayName ?? actorHandle ?? "·")
     .slice(0, 1)
     .toUpperCase()
 
@@ -833,11 +858,14 @@ function NotificationRow({ item }: { item: NotificationItem }) {
         <div className="min-w-0 flex-1 text-sm">
           <p>
             <span className="inline-flex items-center gap-1 align-middle font-semibold text-primary">
-              {actorLabel}
+              {actorDisplayName || actorHandle || "someone"}
               {item.actor?.isVerified && (
                 <VerifiedBadge size={14} role={item.actor.role} />
               )}
             </span>
+            {actorHandle && (
+              <span className="text-tertiary"> @{actorHandle}</span>
+            )}
             <span className="text-secondary"> {verb}</span>
             <span className="ml-1.5 text-xs text-tertiary">
               · {formatShortTime(item.createdAt)}

--- a/apps/web/src/routes/notifications.tsx
+++ b/apps/web/src/routes/notifications.tsx
@@ -711,6 +711,79 @@ function ReplyRow({ item }: { item: NotificationItem }) {
   )
 }
 
+function MentionRow({ item }: { item: NotificationItem }) {
+  const actor = item.actor
+  const actorLabel = actor
+    ? actor.displayName || (actor.handle ? `@${actor.handle}` : "someone")
+    : "someone"
+  const actorHandle = actor?.handle ?? null
+  const actorInitial = (actor?.displayName ?? actorHandle ?? "·")
+    .slice(0, 1)
+    .toUpperCase()
+  const mentionTarget = item.target
+
+  const postLink =
+    mentionTarget?.author.handle && mentionTarget?.id
+      ? `/${mentionTarget.author.handle}/p/${mentionTarget.id}`
+      : null
+
+  return (
+    <Link
+      to={postLink ?? "#"}
+      className={`block border-b border-neutral px-4 py-3.5 transition-colors hover:bg-base-2/20 ${!item.readAt ? "bg-subtle" : ""}`}
+    >
+      <div className="flex items-start gap-3">
+        <Avatar
+          initial={actorInitial}
+          src={actor?.avatarUrl}
+          className="size-10 shrink-0"
+        />
+        <div className="min-w-0 flex-1 text-sm">
+          <div className="flex items-center gap-1.5">
+            <span className="inline-flex items-center gap-1 font-semibold text-primary">
+              {actorLabel}
+              {actor?.isVerified && (
+                <VerifiedBadge size={14} role={actor.role} />
+              )}
+            </span>
+            <span className="text-xs text-tertiary">
+              · {formatShortTime(item.createdAt)}
+            </span>
+          </div>
+          <p className="mt-0.5 text-secondary">Mentioned you</p>
+          {mentionTarget?.text && (
+            <p className="mt-0.5 text-primary leading-relaxed whitespace-pre-wrap">
+              {mentionTarget.text}
+            </p>
+          )}
+          <div className="mt-2 flex items-center">
+            <div className="flex-1">
+              <span className="inline-flex size-7 items-center justify-center rounded-full text-tertiary">
+                <ChatBubbleOutline className="size-4" />
+              </span>
+            </div>
+            <div className="flex-1">
+              <span className="inline-flex size-7 items-center justify-center rounded-full text-tertiary">
+                <ArrowPathOutline className="size-4" />
+              </span>
+            </div>
+            <div className="flex-1">
+              <span className="inline-flex size-7 items-center justify-center rounded-full text-tertiary">
+                <HeartOutline className="size-4" />
+              </span>
+            </div>
+            <div>
+              <span className="inline-flex size-7 items-center justify-center rounded-full text-tertiary">
+                <BookmarkIconOutline className="size-4" />
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </Link>
+  )
+}
+
 function formatShortTime(iso: string): string {
   const d = new Date(iso)
   const now = new Date()

--- a/apps/web/src/routes/notifications.tsx
+++ b/apps/web/src/routes/notifications.tsx
@@ -18,6 +18,12 @@ import {
   HeartIcon,
   UserPlusIcon,
 } from "@heroicons/react/24/solid"
+import {
+  BookmarkIcon as BookmarkIconOutline,
+  ChatBubbleOvalLeftIcon as ChatBubbleOutline,
+  ArrowPathIcon as ArrowPathOutline,
+  HeartIcon as HeartOutline,
+} from "@heroicons/react/24/outline"
 import { Button } from "@workspace/ui/components/button"
 import { Skeleton } from "@workspace/ui/components/skeleton"
 import { Avatar } from "@workspace/ui/components/avatar"
@@ -31,7 +37,7 @@ import { PageFrame } from "../components/page-frame"
 import { VerifiedBadge } from "../components/verified-badge"
 import { useInfiniteScrollSentinel } from "../lib/use-infinite-scroll-sentinel"
 import type { InfiniteData } from "@tanstack/react-query"
-import type { ArticleUnfurlCard, NotificationItem, Post } from "../lib/api"
+import type { NotificationItem, Post } from "../lib/api"
 
 export const Route = createFileRoute("/notifications")({
   component: Notifications,
@@ -46,9 +52,96 @@ type NotificationsQueryKey = ReturnType<typeof qk.notifications.list>
 
 const ESTIMATED_NOTIFICATION_HEIGHT = 140
 
-// Walk up the DOM to find the nearest ancestor that scrolls. Returns null when
-// the page itself scrolls (the common case on mobile and on routes that don't
-// pin the column).
+const GROUPING_THRESHOLD = 3
+
+type GroupedNotification =
+  | { type: "single"; item: NotificationItem }
+  | { type: "grouped-likes"; items: NotificationItem[]; target: Post }
+  | { type: "grouped-follows"; items: NotificationItem[] }
+  | { type: "reply"; item: NotificationItem }
+  | { type: "mention"; item: NotificationItem }
+
+function groupNotifications(
+  items: NotificationItem[]
+): GroupedNotification[] {
+  const likesByEntity = new Map<string, NotificationItem[]>()
+  const follows: NotificationItem[] = []
+  const others: Array<{ index: number; entry: GroupedNotification }> = []
+
+  for (let i = 0; i < items.length; i++) {
+    const item = items[i]
+    if (item.kind === "like" && item.entityId) {
+      const key = item.entityId
+      if (!likesByEntity.has(key)) likesByEntity.set(key, [])
+      likesByEntity.get(key)!.push(item)
+    } else if (item.kind === "follow") {
+      follows.push(item)
+    } else if (item.kind === "reply" || item.kind === "article_reply") {
+      others.push({ index: i, entry: { type: "reply", item } })
+    } else if (item.kind === "mention") {
+      others.push({ index: i, entry: { type: "mention", item } })
+    } else {
+      others.push({ index: i, entry: { type: "single", item } })
+    }
+  }
+
+  const result: Array<{ index: number; entry: GroupedNotification }> = [
+    ...others,
+  ]
+
+  for (const [, likeItems] of likesByEntity) {
+    const firstIndex = items.indexOf(likeItems[0])
+    if (likeItems.length >= GROUPING_THRESHOLD && likeItems[0].target) {
+      result.push({
+        index: firstIndex,
+        entry: {
+          type: "grouped-likes",
+          items: likeItems,
+          target: likeItems[0].target,
+        },
+      })
+    } else {
+      for (const item of likeItems) {
+        result.push({
+          index: items.indexOf(item),
+          entry: { type: "single", item },
+        })
+      }
+    }
+  }
+
+  if (follows.length >= GROUPING_THRESHOLD) {
+    const firstIndex = items.indexOf(follows[0])
+    result.push({
+      index: firstIndex,
+      entry: { type: "grouped-follows", items: follows },
+    })
+  } else {
+    for (const item of follows) {
+      result.push({
+        index: items.indexOf(item),
+        entry: { type: "single", item },
+      })
+    }
+  }
+
+  result.sort((a, b) => a.index - b.index)
+  return result.map((r) => r.entry)
+}
+
+function groupId(group: GroupedNotification): string {
+  switch (group.type) {
+    case "single":
+    case "reply":
+    case "mention":
+      return group.item.id
+    case "grouped-likes":
+      return `likes-${group.items[0].entityId}`
+    case "grouped-follows":
+      return `follows-${group.items[0].id}`
+  }
+}
+
 function findScrollParent(el: HTMLElement | null): HTMLElement | null {
   let node: HTMLElement | null = el?.parentElement ?? null
   while (node) {
@@ -107,7 +200,7 @@ function Notifications() {
         queryClient.setQueryData(qk.notifications.unread(), { count: 0 })
         queryClient.invalidateQueries({ queryKey: qk.notifications.unread() })
       })
-      .catch(() => {})
+      .catch(() => { })
   }, [session, queryClient])
 
   const items = useMemo(
@@ -216,22 +309,24 @@ interface NotificationsListProps {
 
 function NotificationsList(props: NotificationsListProps) {
   const probeRef = useRef<HTMLDivElement>(null)
-  // null = window scroll, HTMLElement = contained scroll, undefined = unresolved
   const [scrollEl, setScrollEl] = useState<HTMLElement | null | undefined>(
     undefined
+  )
+
+  const grouped = useMemo(
+    () => groupNotifications(props.items),
+    [props.items]
   )
 
   useIsoLayoutEffect(() => {
     setScrollEl(findScrollParent(probeRef.current))
   }, [])
 
-  // First paint (and SSR): render non-virtualized so the page isn't blank
-  // while the scroll container is being detected.
   if (scrollEl === undefined) {
     return (
       <div ref={probeRef}>
-        {props.items.map((item) => (
-          <NotificationRow key={item.id} item={item} />
+        {grouped.map((group) => (
+          <GroupedNotificationRow key={groupId(group)} group={group} />
         ))}
         {props.hasNextPage && (
           <div className="flex justify-center py-4 text-xs text-tertiary">
@@ -243,17 +338,23 @@ function NotificationsList(props: NotificationsListProps) {
   }
 
   if (scrollEl === null) {
-    return <WindowNotificationsList {...props} />
+    return <WindowNotificationsList {...props} grouped={grouped} />
   }
-  return <ContainerNotificationsList {...props} scrollEl={scrollEl} />
+  return (
+    <ContainerNotificationsList
+      {...props}
+      grouped={grouped}
+      scrollEl={scrollEl}
+    />
+  )
 }
 
 function WindowNotificationsList({
-  items,
+  grouped,
   hasNextPage,
   isFetchingNextPage,
   fetchNextPage,
-}: NotificationsListProps) {
+}: NotificationsListProps & { grouped: GroupedNotification[] }) {
   const wrapperRef = useRef<HTMLDivElement>(null)
   const sentinelRef = useRef<HTMLDivElement>(null)
   const [scrollMargin, setScrollMargin] = useState(0)
@@ -266,11 +367,11 @@ function WindowNotificationsList({
   }, [])
 
   const virtualizer = useWindowVirtualizer({
-    count: items.length,
+    count: grouped.length,
     estimateSize: () => ESTIMATED_NOTIFICATION_HEIGHT,
     overscan: 6,
     scrollMargin,
-    getItemKey: (i) => items[i].id,
+    getItemKey: (i) => groupId(grouped[i]),
   })
 
   useInfiniteScrollSentinel(
@@ -295,7 +396,7 @@ function WindowNotificationsList({
         }}
       >
         {virtualItems.map((vi) => {
-          const item = items[vi.index]
+          const group = grouped[vi.index]
           return (
             <div
               key={vi.key}
@@ -309,7 +410,7 @@ function WindowNotificationsList({
                 transform: `translateY(${vi.start - scrollMargin}px)`,
               }}
             >
-              <NotificationRow item={item} />
+              <GroupedNotificationRow group={group} />
             </div>
           )
         })}
@@ -325,20 +426,23 @@ function WindowNotificationsList({
 }
 
 function ContainerNotificationsList({
-  items,
+  grouped,
   hasNextPage,
   isFetchingNextPage,
   fetchNextPage,
   scrollEl,
-}: NotificationsListProps & { scrollEl: HTMLElement }) {
+}: NotificationsListProps & {
+  grouped: GroupedNotification[]
+  scrollEl: HTMLElement
+}) {
   const sentinelRef = useRef<HTMLDivElement>(null)
 
   const virtualizer = useVirtualizer({
-    count: items.length,
+    count: grouped.length,
     getScrollElement: () => scrollEl,
     estimateSize: () => ESTIMATED_NOTIFICATION_HEIGHT,
     overscan: 6,
-    getItemKey: (i) => items[i].id,
+    getItemKey: (i) => groupId(grouped[i]),
   })
 
   useInfiniteScrollSentinel(
@@ -356,7 +460,7 @@ function ContainerNotificationsList({
     <div>
       <div style={{ height: totalSize, position: "relative", width: "100%" }}>
         {virtualItems.map((vi) => {
-          const item = items[vi.index]
+          const group = grouped[vi.index]
           return (
             <div
               key={vi.key}
@@ -370,7 +474,7 @@ function ContainerNotificationsList({
                 transform: `translateY(${vi.start}px)`,
               }}
             >
-              <NotificationRow item={item} />
+              <GroupedNotificationRow group={group} />
             </div>
           )
         })}
@@ -383,6 +487,242 @@ function ContainerNotificationsList({
       )}
     </div>
   )
+}
+
+function GroupedNotificationRow({ group }: { group: GroupedNotification }) {
+  switch (group.type) {
+    case "grouped-likes":
+      return <GroupedLikeRow items={group.items} target={group.target} />
+    case "grouped-follows":
+      return <GroupedFollowRow items={group.items} />
+    case "reply":
+      return <ReplyRow item={group.item} />
+    case "mention":
+      return <MentionRow item={group.item} />
+    case "single":
+      return <NotificationRow item={group.item} />
+  }
+}
+
+function AvatarRow({ items }: { items: NotificationItem[] }) {
+  return (
+    <div className="flex items-center gap-1.5">
+      {items.slice(0, 8).map((item) => {
+        const initial = (
+          item.actor?.displayName ??
+          item.actor?.handle ??
+          "·"
+        )
+          .slice(0, 1)
+          .toUpperCase()
+        return (
+          <Avatar
+            key={item.id}
+            initial={initial}
+            src={item.actor?.avatarUrl}
+            size="md"
+          />
+        )
+      })}
+    </div>
+  )
+}
+
+function GroupedLikeRow({
+  items,
+  target,
+}: {
+  items: NotificationItem[]
+  target: Post
+}) {
+  const lead = items[0]
+  const leadName =
+    lead.actor?.displayName ??
+    (lead.actor?.handle ? `@${lead.actor.handle}` : "someone")
+  const isUnread = items.some((n) => !n.readAt)
+
+  const postLink =
+    target.author.handle && target.id
+      ? `/${target.author.handle}/p/${target.id}`
+      : null
+
+  return (
+    <Link
+      to={postLink ?? "#"}
+      className={`block border-b border-neutral px-4 py-3.5 transition-colors hover:bg-base-2/20 ${isUnread ? "bg-subtle" : ""}`}
+    >
+      <div className="flex items-center gap-3">
+        <div className="flex size-10 shrink-0 items-center justify-center">
+          <HeartIcon className="size-5.5 text-like" />
+        </div>
+        <AvatarRow items={items} />
+      </div>
+      <div className="mt-2 pl-[52px]">
+        <p className="text-sm">
+          <span className="font-semibold text-primary">{leadName}</span>
+          <span className="text-secondary">
+            {" "}and {items.length - 1} other{items.length - 1 !== 1 ? "s" : ""}{" "}
+            liked your post
+          </span>
+        </p>
+        {target.text && (
+          <p className="mt-1 text-sm text-tertiary line-clamp-1">{target.text}</p>
+        )}
+      </div>
+    </Link>
+  )
+}
+
+function GroupedFollowRow({ items }: { items: NotificationItem[] }) {
+  const lead = items[0]
+  const leadName =
+    lead.actor?.displayName ??
+    (lead.actor?.handle ? `@${lead.actor.handle}` : "someone")
+  const leadHandle = lead.actor?.handle ?? null
+  const isUnread = items.some((n) => !n.readAt)
+
+  return (
+    <div
+      className={`border-b border-neutral px-4 py-3.5 transition-colors hover:bg-base-2/20 ${isUnread ? "bg-subtle" : ""}`}
+    >
+      <div className="flex items-center gap-3">
+        <div className="flex size-10 shrink-0 items-center justify-center">
+          <UserPlusIcon className="size-5.5 text-sky-500" />
+        </div>
+        <AvatarRow items={items} />
+      </div>
+      <div className="mt-2 pl-[52px]">
+        <p className="text-sm">
+          {leadHandle ? (
+            <Link
+              to="/$handle"
+              params={{ handle: leadHandle }}
+              className="font-semibold text-primary hover:underline"
+            >
+              {leadName}
+            </Link>
+          ) : (
+            <span className="font-semibold text-primary">{leadName}</span>
+          )}
+          <span className="text-secondary">
+            {" "}and {items.length - 1} other{items.length - 1 !== 1 ? "s" : ""}{" "}
+            followed you
+          </span>
+        </p>
+      </div>
+    </div>
+  )
+}
+
+function ReplyRow({ item }: { item: NotificationItem }) {
+  const actor = item.actor
+  const actorLabel = actor
+    ? actor.displayName || (actor.handle ? `@${actor.handle}` : "someone")
+    : "someone"
+  const actorHandle = actor?.handle ?? null
+  const actorInitial = (actor?.displayName ?? actorHandle ?? "·")
+    .slice(0, 1)
+    .toUpperCase()
+  const replyTarget = item.target
+
+  // Use chain handles if available, otherwise fall back to single parent handle
+  const chainHandles = replyTarget?.replyChainHandles ?? []
+  const fallbackHandle = replyTarget?.replyToId
+    ? replyTarget?.replyParent?.author.handle ?? null
+    : null
+  const replyToHandles =
+    chainHandles.length > 0 ? chainHandles : fallbackHandle ? [fallbackHandle] : []
+
+  const postLink =
+    replyTarget?.author.handle && replyTarget?.id
+      ? `/${replyTarget.author.handle}/p/${replyTarget.id}`
+      : null
+
+  return (
+    <Link
+      to={postLink ?? "#"}
+      className={`block border-b border-neutral px-4 py-3.5 transition-colors hover:bg-base-2/20 ${!item.readAt ? "bg-subtle" : ""}`}
+    >
+      <div className="flex items-start gap-3">
+        <Avatar
+          initial={actorInitial}
+          src={actor?.avatarUrl}
+          className="size-10 shrink-0"
+        />
+        <div className="min-w-0 flex-1 text-sm">
+          <div className="flex items-center gap-1.5">
+            <span className="inline-flex items-center gap-1 font-semibold text-primary">
+              {actorLabel}
+              {actor?.isVerified && (
+                <VerifiedBadge size={14} role={actor.role} />
+              )}
+            </span>
+            <span className="text-xs text-tertiary">
+              · {formatShortTime(item.createdAt)}
+            </span>
+          </div>
+          {replyToHandles.length > 0 && (
+            <p className="mt-0.5 text-secondary">
+              Replying to{" "}
+              {replyToHandles.slice(0, 2).map((handle, i) => (
+                <span key={handle}>
+                  {i > 0 && ", "}
+                  <span className="text-sky-500">@{handle}</span>
+                </span>
+              ))}
+              {replyToHandles.length > 2 && (
+                <span className="text-secondary">
+                  {" "}and {replyToHandles.length - 2} other
+                  {replyToHandles.length - 2 !== 1 ? "s" : ""}
+                </span>
+              )}
+            </p>
+          )}
+          {replyTarget?.text && (
+            <p className="mt-0.5 text-primary leading-relaxed whitespace-pre-wrap">
+              {replyTarget.text}
+            </p>
+          )}
+          <div className="mt-2 flex items-center">
+            <div className="flex-1">
+              <span className="inline-flex size-7 items-center justify-center rounded-full text-tertiary">
+                <ChatBubbleOutline className="size-4" />
+              </span>
+            </div>
+            <div className="flex-1">
+              <span className="inline-flex size-7 items-center justify-center rounded-full text-tertiary">
+                <ArrowPathOutline className="size-4" />
+              </span>
+            </div>
+            <div className="flex-1">
+              <span className="inline-flex size-7 items-center justify-center rounded-full text-tertiary">
+                <HeartOutline className="size-4" />
+              </span>
+            </div>
+            <div>
+              <span className="inline-flex size-7 items-center justify-center rounded-full text-tertiary">
+                <BookmarkIconOutline className="size-4" />
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </Link>
+  )
+}
+
+function formatShortTime(iso: string): string {
+  const d = new Date(iso)
+  const now = new Date()
+  const diffMs = now.getTime() - d.getTime()
+  const diffMin = Math.floor(diffMs / 60000)
+  if (diffMin < 1) return "now"
+  if (diffMin < 60) return `${diffMin}m`
+  const diffHr = Math.floor(diffMin / 60)
+  if (diffHr < 24) return `${diffHr}h`
+  const diffDays = Math.floor(diffHr / 24)
+  if (diffDays < 7) return `${diffDays}d`
+  return d.toLocaleDateString(undefined, { month: "short", day: "numeric" })
 }
 
 function NotificationRow({ item }: { item: NotificationItem }) {
@@ -398,143 +738,45 @@ function NotificationRow({ item }: { item: NotificationItem }) {
     .slice(0, 1)
     .toUpperCase()
 
+  const postLink =
+    item.target?.author.handle && item.target?.id
+      ? `/${item.target.author.handle}/p/${item.target.id}`
+      : null
+
   return (
-    <div
-      className={`border-b border-neutral px-4 py-3 transition-colors hover:bg-base-2/20 ${
-        !item.readAt ? "bg-subtle" : ""
-      }`}
+    <Link
+      to={postLink ?? "#"}
+      className={`block border-b border-neutral px-4 py-3.5 transition-colors hover:bg-base-2/20 ${!item.readAt ? "bg-subtle" : ""}`}
     >
       <div className="flex items-start gap-3">
-        <div
-          className={`mt-0.5 flex size-8 shrink-0 items-center justify-center rounded-full ${iconClass}`}
-        >
-          <Icon className="size-[18px]" />
+        <div className="flex size-10 shrink-0 items-center justify-center">
+          <Icon className={`size-5.5 ${iconClass}`} />
         </div>
+        <Avatar
+          initial={actorInitial}
+          src={item.actor?.avatarUrl}
+          className="size-10 shrink-0"
+        />
         <div className="min-w-0 flex-1 text-sm">
-          {actorHandle ? (
-            <Link
-              to="/$handle"
-              params={{ handle: actorHandle }}
-              className="inline-block"
-            >
-              <Avatar
-                initial={actorInitial}
-                src={item.actor?.avatarUrl}
-                className="size-8 ring-1 ring-neutral"
-              />
-            </Link>
-          ) : (
-            <Avatar
-              initial={actorInitial}
-              src={item.actor?.avatarUrl}
-              className="size-8 ring-1 ring-neutral"
-            />
-          )}
-          <p className="mt-2">
-            {actorHandle ? (
-              <Link
-                to="/$handle"
-                params={{ handle: actorHandle }}
-                className="inline-flex items-center gap-1 align-middle font-semibold hover:underline"
-              >
-                {actorLabel}
-                {item.actor?.isVerified && (
-                  <VerifiedBadge size={14} role={item.actor.role} />
-                )}
-              </Link>
-            ) : (
-              <span className="inline-flex items-center gap-1 align-middle font-semibold">
-                {actorLabel}
-                {item.actor?.isVerified && (
-                  <VerifiedBadge size={14} role={item.actor.role} />
-                )}
-              </span>
-            )}{" "}
-            <span className="text-tertiary">{verb}</span>
+          <p>
+            <span className="inline-flex items-center gap-1 align-middle font-semibold text-primary">
+              {actorLabel}
+              {item.actor?.isVerified && (
+                <VerifiedBadge size={14} role={item.actor.role} />
+              )}
+            </span>
+            <span className="text-secondary"> {verb}</span>
+            <span className="ml-1.5 text-xs text-tertiary">
+              · {formatShortTime(item.createdAt)}
+            </span>
           </p>
-          {item.target && <TargetCard post={item.target} />}
-          <time
-            className="mt-1 block text-xs text-tertiary"
-            dateTime={item.createdAt}
-          >
-            {new Date(item.createdAt).toLocaleString()}
-          </time>
-        </div>
-      </div>
-    </div>
-  )
-}
-
-/**
- * Compact preview of the post a notification refers to. For likes/reposts the post is the
- * recipient's own; for replies/mentions/quotes it's the actor's new post. We render the body
- * (or quoted body), an optional media thumbnail, and link the whole card to the post page.
- */
-function TargetCard({ post }: { post: Post }) {
-  const handle = post.author.handle
-  const thumb = post.media?.find((m) => m.processingState === "ready")
-  const variant =
-    thumb?.variants.find((v) => v.kind === "thumb") ??
-    thumb?.variants.find((v) => v.kind === "medium") ??
-    thumb?.variants[0]
-
-  const body = (
-    <div className="mt-2 overflow-hidden rounded-md border border-neutral transition hover:bg-base-2/40">
-      <div className="flex gap-3 p-3">
-        <div className="min-w-0 flex-1">
-          {post.text ? (
-            <p className="wrap-break-words line-clamp-4 text-sm leading-relaxed whitespace-pre-wrap">
-              {post.text}
-            </p>
-          ) : (
-            (() => {
-              const article = post.cards?.find(
-                (c): c is ArticleUnfurlCard => c.provider === "article"
-              )
-              if (article) {
-                return (
-                  <p className="line-clamp-2 text-sm">
-                    <span className="font-semibold">{article.title}</span>
-                    {article.subtitle && (
-                      <span className="text-tertiary">
-                        {" "}
-                        — {article.subtitle}
-                      </span>
-                    )}
-                  </p>
-                )
-              }
-              return (
-                <p className="text-sm text-tertiary italic">[media post]</p>
-              )
-            })()
+          {item.target?.text && (
+            <p className="mt-1 text-sm text-tertiary line-clamp-1">{item.target.text}</p>
           )}
         </div>
-        {variant && (
-          <div className="size-16 shrink-0 overflow-hidden rounded">
-            <img
-              src={variant.url}
-              alt=""
-              className="h-full w-full object-cover"
-            />
-          </div>
-        )}
       </div>
-    </div>
+    </Link>
   )
-
-  if (handle) {
-    return (
-      <Link
-        to="/$handle/p/$id"
-        params={{ handle, id: post.id }}
-        className="block"
-      >
-        {body}
-      </Link>
-    )
-  }
-  return body
 }
 
 function iconForKind(kind: NotificationItem["kind"]) {
@@ -560,18 +802,18 @@ function iconForKind(kind: NotificationItem["kind"]) {
 function iconClassForKind(kind: NotificationItem["kind"]): string {
   switch (kind) {
     case "like":
-      return "bg-rose-500/10 text-rose-600"
+      return "text-like"
     case "repost":
-      return "bg-emerald-500/10 text-emerald-600"
+      return "text-emerald-500"
     case "follow":
-      return "bg-sky-500/10 text-sky-600"
+      return "text-sky-500"
     case "quote":
-      return "bg-amber-500/10 text-amber-600"
+      return "text-amber-500"
     case "mention":
     case "reply":
     case "article_reply":
     default:
-      return "bg-base-2 text-foreground/80"
+      return "text-tertiary"
   }
 }
 

--- a/apps/web/src/routes/notifications.tsx
+++ b/apps/web/src/routes/notifications.tsx
@@ -24,9 +24,9 @@ import {
   UserPlusIcon,
 } from "@heroicons/react/24/solid"
 import {
+  ArrowPathIcon as ArrowPathOutline,
   BookmarkIcon as BookmarkIconOutline,
   ChatBubbleOvalLeftIcon as ChatBubbleOutline,
-  ArrowPathIcon as ArrowPathOutline,
   HeartIcon as HeartOutline,
 } from "@heroicons/react/24/outline"
 import { Button } from "@workspace/ui/components/button"
@@ -62,16 +62,16 @@ const GROUPING_THRESHOLD = 3
 
 type GroupedNotification =
   | { type: "single"; item: NotificationItem }
-  | { type: "grouped-likes"; items: NotificationItem[]; target: Post }
-  | { type: "grouped-follows"; items: NotificationItem[] }
+  | { type: "grouped-likes"; items: Array<NotificationItem>; target: Post }
+  | { type: "grouped-follows"; items: Array<NotificationItem> }
   | { type: "reply"; item: NotificationItem }
   | { type: "mention"; item: NotificationItem }
 
 function groupNotifications(
-  items: NotificationItem[]
-): GroupedNotification[] {
-  const likesByEntity = new Map<string, NotificationItem[]>()
-  const follows: NotificationItem[] = []
+  items: Array<NotificationItem>
+): Array<GroupedNotification> {
+  const likesByEntity = new Map<string, Array<NotificationItem>>()
+  const follows: Array<NotificationItem> = []
   const others: Array<{ index: number; entry: GroupedNotification }> = []
 
   for (let i = 0; i < items.length; i++) {
@@ -206,7 +206,7 @@ function Notifications() {
         queryClient.setQueryData(qk.notifications.unread(), { count: 0 })
         queryClient.invalidateQueries({ queryKey: qk.notifications.unread() })
       })
-      .catch(() => { })
+      .catch(() => {})
   }, [session, queryClient])
 
   const items = useMemo(
@@ -319,10 +319,7 @@ function NotificationsList(props: NotificationsListProps) {
     undefined
   )
 
-  const grouped = useMemo(
-    () => groupNotifications(props.items),
-    [props.items]
-  )
+  const grouped = useMemo(() => groupNotifications(props.items), [props.items])
 
   useIsoLayoutEffect(() => {
     setScrollEl(findScrollParent(probeRef.current))
@@ -360,7 +357,7 @@ function WindowNotificationsList({
   hasNextPage,
   isFetchingNextPage,
   fetchNextPage,
-}: NotificationsListProps & { grouped: GroupedNotification[] }) {
+}: NotificationsListProps & { grouped: Array<GroupedNotification> }) {
   const wrapperRef = useRef<HTMLDivElement>(null)
   const sentinelRef = useRef<HTMLDivElement>(null)
   const [scrollMargin, setScrollMargin] = useState(0)
@@ -438,7 +435,7 @@ function ContainerNotificationsList({
   fetchNextPage,
   scrollEl,
 }: NotificationsListProps & {
-  grouped: GroupedNotification[]
+  grouped: Array<GroupedNotification>
   scrollEl: HTMLElement
 }) {
   const sentinelRef = useRef<HTMLDivElement>(null)
@@ -510,15 +507,11 @@ function GroupedNotificationRow({ group }: { group: GroupedNotification }) {
   }
 }
 
-function AvatarRow({ items }: { items: NotificationItem[] }) {
+function AvatarRow({ items }: { items: Array<NotificationItem> }) {
   return (
     <div className="flex items-center gap-1.5">
       {items.slice(0, 8).map((item) => {
-        const initial = (
-          item.actor?.displayName ??
-          item.actor?.handle ??
-          "·"
-        )
+        const initial = (item.actor?.displayName ?? item.actor?.handle ?? "·")
           .slice(0, 1)
           .toUpperCase()
         return (
@@ -538,7 +531,7 @@ function GroupedLikeRow({
   items,
   target,
 }: {
-  items: NotificationItem[]
+  items: Array<NotificationItem>
   target: Post
 }) {
   const lead = items[0]
@@ -567,23 +560,24 @@ function GroupedLikeRow({
           <span className="font-semibold text-primary">
             {leadDisplayName || leadHandle || "someone"}
           </span>
-          {leadHandle && (
-            <span className="text-tertiary"> @{leadHandle}</span>
-          )}
+          {leadHandle && <span className="text-tertiary"> @{leadHandle}</span>}
           <span className="text-secondary">
-            {" "}and {items.length - 1} other{items.length - 1 !== 1 ? "s" : ""}{" "}
+            {" "}
+            and {items.length - 1} other{items.length - 1 !== 1 ? "s" : ""}{" "}
             liked your post
           </span>
         </p>
         {target.text && (
-          <p className="mt-1 text-sm text-tertiary line-clamp-1">{target.text}</p>
+          <p className="mt-1 line-clamp-1 text-sm text-tertiary">
+            {target.text}
+          </p>
         )}
       </div>
     </Link>
   )
 }
 
-function GroupedFollowRow({ items }: { items: NotificationItem[] }) {
+function GroupedFollowRow({ items }: { items: Array<NotificationItem> }) {
   const lead = items[0]
   const leadDisplayName = lead.actor?.displayName ?? null
   const leadHandle = lead.actor?.handle ?? null
@@ -614,11 +608,10 @@ function GroupedFollowRow({ items }: { items: NotificationItem[] }) {
               {leadDisplayName || "someone"}
             </span>
           )}
-          {leadHandle && (
-            <span className="text-tertiary"> @{leadHandle}</span>
-          )}
+          {leadHandle && <span className="text-tertiary"> @{leadHandle}</span>}
           <span className="text-secondary">
-            {" "}and {items.length - 1} other{items.length - 1 !== 1 ? "s" : ""}{" "}
+            {" "}
+            and {items.length - 1} other{items.length - 1 !== 1 ? "s" : ""}{" "}
             followed you
           </span>
         </p>
@@ -640,23 +633,39 @@ function ReplyRow({ item }: { item: NotificationItem }) {
   // Use chain handles if available, otherwise fall back to single parent handle
   const chainHandles = replyTarget?.replyChainHandles ?? []
   const fallbackHandle = replyTarget?.replyToId
-    ? replyTarget?.replyParent?.author.handle ?? null
+    ? (replyTarget.replyParent?.author.handle ?? null)
     : null
   const replyToHandles =
-    chainHandles.length > 0 ? chainHandles : fallbackHandle ? [fallbackHandle] : []
+    chainHandles.length > 0
+      ? chainHandles
+      : fallbackHandle
+        ? [fallbackHandle]
+        : []
 
-  function openPost() {
-    if (!replyTarget?.author.handle || !replyTarget?.id) return
+  function openPost(e: React.MouseEvent | React.KeyboardEvent) {
+    // Don't navigate if click originated from a link (e.g., @mention in RichText)
+    if ("target" in e && (e.target as HTMLElement).closest("a")) return
+    if (!replyTarget?.author.handle || !replyTarget.id) return
     navigate({
       to: "/$handle/p/$id",
       params: { handle: replyTarget.author.handle, id: replyTarget.id },
     })
   }
 
+  function handleKeyDown(e: React.KeyboardEvent) {
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault()
+      openPost(e)
+    }
+  }
+
   return (
     <div
+      role="button"
+      tabIndex={0}
       onClick={openPost}
-      className={`cursor-pointer border-b border-neutral px-4 py-3.5 transition-colors hover:bg-base-2/20 ${!item.readAt ? "bg-subtle" : ""}`}
+      onKeyDown={handleKeyDown}
+      className={`focus-visible:ring-primary cursor-pointer border-b border-neutral px-4 py-3.5 transition-colors hover:bg-base-2/20 focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-inset ${!item.readAt ? "bg-subtle" : ""}`}
     >
       <div className="flex items-start gap-3">
         <Avatar
@@ -690,14 +699,15 @@ function ReplyRow({ item }: { item: NotificationItem }) {
               ))}
               {replyToHandles.length > 2 && (
                 <span className="text-secondary">
-                  {" "}and {replyToHandles.length - 2} other
+                  {" "}
+                  and {replyToHandles.length - 2} other
                   {replyToHandles.length - 2 !== 1 ? "s" : ""}
                 </span>
               )}
             </p>
           )}
           {replyTarget?.text && (
-            <p className="mt-0.5 text-primary leading-relaxed whitespace-pre-wrap">
+            <p className="mt-0.5 leading-relaxed whitespace-pre-wrap text-primary">
               <RichText text={replyTarget.text} />
             </p>
           )}
@@ -742,18 +752,30 @@ function MentionRow({ item }: { item: NotificationItem }) {
     .toUpperCase()
   const mentionTarget = item.target
 
-  function openPost() {
-    if (!mentionTarget?.author.handle || !mentionTarget?.id) return
+  function openPost(e: React.MouseEvent | React.KeyboardEvent) {
+    // Don't navigate if click originated from a link (e.g., @mention in RichText)
+    if ("target" in e && (e.target as HTMLElement).closest("a")) return
+    if (!mentionTarget?.author.handle || !mentionTarget.id) return
     navigate({
       to: "/$handle/p/$id",
       params: { handle: mentionTarget.author.handle, id: mentionTarget.id },
     })
   }
 
+  function handleKeyDown(e: React.KeyboardEvent) {
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault()
+      openPost(e)
+    }
+  }
+
   return (
     <div
+      role="button"
+      tabIndex={0}
       onClick={openPost}
-      className={`cursor-pointer border-b border-neutral px-4 py-3.5 transition-colors hover:bg-base-2/20 ${!item.readAt ? "bg-subtle" : ""}`}
+      onKeyDown={handleKeyDown}
+      className={`focus-visible:ring-primary cursor-pointer border-b border-neutral px-4 py-3.5 transition-colors hover:bg-base-2/20 focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-inset ${!item.readAt ? "bg-subtle" : ""}`}
     >
       <div className="flex items-start gap-3">
         <Avatar
@@ -777,7 +799,7 @@ function MentionRow({ item }: { item: NotificationItem }) {
             </span>
           </div>
           {mentionTarget?.text && (
-            <p className="mt-0.5 text-primary leading-relaxed whitespace-pre-wrap">
+            <p className="mt-0.5 leading-relaxed whitespace-pre-wrap text-primary">
               <RichText text={mentionTarget.text} />
             </p>
           )}
@@ -837,7 +859,7 @@ function NotificationRow({ item }: { item: NotificationItem }) {
     .toUpperCase()
 
   const postLink =
-    item.target?.author.handle && item.target?.id
+    item.target?.author.handle && item.target.id
       ? `/${item.target.author.handle}/p/${item.target.id}`
       : null
 
@@ -872,7 +894,9 @@ function NotificationRow({ item }: { item: NotificationItem }) {
             </span>
           </p>
           {item.target?.text && (
-            <p className="mt-1 text-sm text-tertiary line-clamp-1">{item.target.text}</p>
+            <p className="mt-1 line-clamp-1 text-sm text-tertiary">
+              {item.target.text}
+            </p>
           )}
         </div>
       </div>

--- a/apps/web/src/routes/notifications.tsx
+++ b/apps/web/src/routes/notifications.tsx
@@ -858,50 +858,61 @@ function NotificationRow({ item }: { item: NotificationItem }) {
     .slice(0, 1)
     .toUpperCase()
 
-  const postLink =
-    item.target?.author.handle && item.target.id
-      ? `/${item.target.author.handle}/p/${item.target.id}`
-      : null
+  // For follow notifications, link to the actor's profile
+  // For other notifications with a target post, link to the post
+  const destination =
+    item.kind === "follow" && actorHandle
+      ? `/${actorHandle}`
+      : item.target?.author.handle && item.target.id
+        ? `/${item.target.author.handle}/p/${item.target.id}`
+        : null
 
-  return (
-    <Link
-      to={postLink ?? "#"}
-      className={`block border-b border-neutral px-4 py-3.5 transition-colors hover:bg-base-2/20 ${!item.readAt ? "bg-subtle" : ""}`}
-    >
-      <div className="flex items-start gap-3">
-        <div className="flex size-10 shrink-0 items-center justify-center">
-          <Icon className={`size-5.5 ${iconClass}`} />
-        </div>
-        <Avatar
-          initial={actorInitial}
-          src={item.actor?.avatarUrl}
-          className="size-10 shrink-0"
-        />
-        <div className="min-w-0 flex-1 text-sm">
-          <p>
-            <span className="inline-flex items-center gap-1 align-middle font-semibold text-primary">
-              {actorDisplayName || actorHandle || "someone"}
-              {item.actor?.isVerified && (
-                <VerifiedBadge size={14} role={item.actor.role} />
-              )}
-            </span>
-            {actorHandle && (
-              <span className="text-tertiary"> @{actorHandle}</span>
-            )}
-            <span className="text-secondary"> {verb}</span>
-            <span className="ml-1.5 text-xs text-tertiary">
-              · {formatShortTime(item.createdAt)}
-            </span>
-          </p>
-          {item.target?.text && (
-            <p className="mt-1 line-clamp-1 text-sm text-tertiary">
-              {item.target.text}
-            </p>
-          )}
-        </div>
+  const containerClass = `block border-b border-neutral px-4 py-3.5 transition-colors hover:bg-base-2/20 ${!item.readAt ? "bg-subtle" : ""}`
+
+  const content = (
+    <div className="flex items-start gap-3">
+      <div className="flex size-10 shrink-0 items-center justify-center">
+        <Icon className={`size-5.5 ${iconClass}`} />
       </div>
-    </Link>
+      <Avatar
+        initial={actorInitial}
+        src={item.actor?.avatarUrl}
+        className="size-10 shrink-0"
+      />
+      <div className="min-w-0 flex-1 text-sm">
+        <p>
+          <span className="inline-flex items-center gap-1 align-middle font-semibold text-primary">
+            {actorDisplayName || actorHandle || "someone"}
+            {item.actor?.isVerified && (
+              <VerifiedBadge size={14} role={item.actor.role} />
+            )}
+          </span>
+          {actorHandle && (
+            <span className="text-tertiary"> @{actorHandle}</span>
+          )}
+          <span className="text-secondary"> {verb}</span>
+          <span className="ml-1.5 text-xs text-tertiary">
+            · {formatShortTime(item.createdAt)}
+          </span>
+        </p>
+        {item.target?.text && (
+          <p className="mt-1 line-clamp-1 text-sm text-tertiary">
+            {item.target.text}
+          </p>
+        )}
+      </div>
+    </div>
   )
+
+  if (destination) {
+    return (
+      <Link to={destination} className={containerClass}>
+        {content}
+      </Link>
+    )
+  }
+
+  return <div className={containerClass}>{content}</div>
 }
 
 function iconForKind(kind: NotificationItem["kind"]) {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       POSTGRES_PASSWORD: twotter
       POSTGRES_DB: twotter
     ports:
-      - "5432:5432"
+      - "5432:5433"
     volumes:
       - twotter_pg:/var/lib/postgresql/data
       - ./packages/db/init:/docker-entrypoint-initdb.d:ro

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       POSTGRES_PASSWORD: twotter
       POSTGRES_DB: twotter
     ports:
-      - "5432:5433"
+      - "5432:5432"
     volumes:
       - twotter_pg:/var/lib/postgresql/data
       - ./packages/db/init:/docker-entrypoint-initdb.d:ro


### PR DESCRIPTION
 - moved notification type icons to the left of avatars instead of badge overlay, removed icons for reply/mention cards since context is clear from text
  - added reply chain handles for thread replies showing "replying to @user1, @user2" (max 2 displayed) with api support via `attachReplyChainHandles`
  - updated all notification cards to show display name + @handle format matching post cards, made @mentions blue and clickable using `RichText` component

  ## Test plan

  - [x] `bun run typecheck` passes
  - [x] Manually exercised the affected flow in the browser
  - [x] No new console errors / network errors

  ## Notes

  - new `replyChainHandles` field added to `PostDto` and frontend `Post` type
  - `attachReplyChainHandles` in `reply-parents.ts` walks up to 10 levels of the reply chain to collect unique author handles
<img width="1548" height="1432" alt="CleanShot 2026-05-02 at 02 37 16@2x" src="https://github.com/user-attachments/assets/4330dd87-40ae-47b5-b7ce-f1a9f2ea50cf" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Notifications now group multiple likes and follows into collapsed rows and improve virtualization for smoother scrolling.
  * Replies in notifications include reply-chain handles showing conversation context from root to parent.
  * Notification rows simplified: shorter time display and conditional linking to profiles/posts.

* **Style**
  * Updated mention/link colors and notification icon color scheme.
  * Increased top page spacing and adjusted rich-text link behavior for mentions and hashtags.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->