### PR TITLE
Fix YouTube previews in the feed

### DIFF
--- a/apps/api/src/lib/env.ts
+++ b/apps/api/src/lib/env.ts
@@ -29,11 +29,16 @@ const envSchema = z.object({
         .filter(Boolean)
     ),
   AUTH_COOKIE_DOMAIN: z.string().optional(),
-  PASSKEY_RP_ID: z.preprocess((v) => {
-    if (typeof v !== "string") return undefined
-    const t = v.trim()
-    return t.length === 0 ? undefined : t
-  }, z.string().optional()),
+  PASSKEY_RP_ID: z.optional(
+    z.preprocess(
+      (v) => {
+        if (typeof v !== "string") return undefined
+        const t = v.trim()
+        return t.length === 0 ? undefined : t
+      },
+      z.union([z.string(), z.undefined()])
+    )
+  ),
 
   PORT: z.coerce.number().default(3001),
   NODE_ENV: z
@@ -139,11 +144,16 @@ const envSchema = z.object({
   // one-time warning at boot). Network errors / timeouts also fail open. Whitespace
   // is trimmed and empty strings are coerced to undefined so a misformatted env var
   // (e.g. `OPENAI_API_KEY= `) is treated as unset rather than a bogus key.
-  OPENAI_API_KEY: z.preprocess((v) => {
-    if (typeof v !== "string") return v
-    const trimmed = v.trim()
-    return trimmed.length === 0 ? undefined : trimmed
-  }, z.string().optional()),
+  OPENAI_API_KEY: z.optional(
+    z.preprocess(
+      (v) => {
+        if (typeof v !== "string") return v
+        const trimmed = v.trim()
+        return trimmed.length === 0 ? undefined : trimmed
+      },
+      z.union([z.string(), z.undefined()])
+    )
+  ),
 })
 
 export type Env = z.infer<typeof envSchema>

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -54,7 +54,6 @@
     "sharp": "^0.34.5",
     "sonner": "^2.0.7",
     "tailwindcss": "^4.2.4",
-    "vite-tsconfig-paths": "^6.1.1",
     "zod": "^4.4.1"
   },
   "devDependencies": {

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -1,7 +1,6 @@
 import { defineConfig } from "vite"
 import { tanstackStart } from "@tanstack/react-start/plugin/vite"
 import viteReact from "@vitejs/plugin-react"
-import viteTsConfigPaths from "vite-tsconfig-paths"
 import tailwindcss from "@tailwindcss/vite"
 import { nitro } from "nitro/vite"
 
@@ -10,17 +9,10 @@ const config = defineConfig({
     port: 3000,
     strictPort: true,
   },
-  plugins: [
-    nitro(),
-    viteTsConfigPaths({
-      projects: ["./tsconfig.json"],
-    }),
-    tailwindcss(),
-    tanstackStart(),
-    viteReact(),
-  ],
+  plugins: [nitro(), tailwindcss(), tanstackStart(), viteReact()],
   resolve: {
     dedupe: ["react", "react-dom"],
+    tsconfigPaths: true,
   },
   // @vercel/og ships its own Yoga + resvg WASM. Vite's pre-bundler cannot rewrite
   // those import.meta.url WASM references, so we keep the package external on the

--- a/bun.lock
+++ b/bun.lock
@@ -92,7 +92,6 @@
         "sharp": "^0.34.5",
         "sonner": "^2.0.7",
         "tailwindcss": "^4.2.4",
-        "vite-tsconfig-paths": "^6.1.1",
         "zod": "^4.4.1",
       },
       "devDependencies": {
@@ -2363,8 +2362,6 @@
 
     "ts-declaration-location": ["ts-declaration-location@1.0.7", "", { "dependencies": { "picomatch": "^4.0.2" }, "peerDependencies": { "typescript": ">=4.0.0" } }, "sha512-EDyGAwH1gO0Ausm9gV6T2nUvBgXT5kGoCMJPllOaooZ+4VvJiKBdZE7wK18N1deEowhcUptS+5GXZK8U/fvpwA=="],
 
-    "tsconfck": ["tsconfck@3.1.6", "", { "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"], "bin": { "tsconfck": "bin/tsconfck.js" } }, "sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w=="],
-
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "tsx": ["tsx@4.21.0", "", { "dependencies": { "esbuild": "~0.27.0", "get-tsconfig": "^4.7.5" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "bin": { "tsx": "dist/cli.mjs" } }, "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw=="],
@@ -2438,8 +2435,6 @@
     "vite": ["vite@8.0.10", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.4", "postcss": "^8.5.10", "rolldown": "1.0.0-rc.17", "tinyglobby": "^0.2.16" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.0", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw=="],
 
     "vite-ssg": ["vite-ssg@0.24.3", "", { "dependencies": { "@unhead/dom": "^1.11.14", "@unhead/vue": "^1.11.14", "fs-extra": "^11.2.0", "html-minifier-terser": "^7.2.0", "html5parser": "^2.0.2", "jsdom": "^25.0.1", "kolorist": "^1.8.0", "prettier": "^3.4.2", "yargs": "^17.7.2" }, "peerDependencies": { "beasties": "^0.2.0", "critters": "^0.0.24", "vite": "^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0-0 || ^6.0.0", "vue": "^3.2.10", "vue-router": "^4.0.1" }, "optionalPeers": ["beasties", "critters", "vue-router"], "bin": { "vite-ssg": "bin/vite-ssg.js" } }, "sha512-LEoJGJD495Hol3vfPJpugee5GkBnhy5Zh67YO7ITxZrSrxqKDqIsE/l5Rtuu5dXSlXKdu+q1yk4xc+vymfzKSQ=="],
-
-    "vite-tsconfig-paths": ["vite-tsconfig-paths@6.1.1", "", { "dependencies": { "debug": "^4.1.1", "globrex": "^0.1.2", "tsconfck": "^3.0.3" }, "peerDependencies": { "vite": "*" } }, "sha512-2cihq7zliibCCZ8P9cKJrQBkfgdvcFkOOc3Y02o3GWUDLgqjWsZudaoiuOwO/gzTzy17cS5F7ZPo4bsnS4DGkg=="],
 
     "vitefu": ["vitefu@1.1.3", "", { "peerDependencies": { "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["vite"] }, "sha512-ub4okH7Z5KLjb6hDyjqrGXqWtWvoYdU3IGm/NorpgHncKoLTCfRIbvlhBm7r0YstIaQRYlp4yEbFqDcKSzXSSg=="],
 

--- a/packages/ui/src/components/link-card.tsx
+++ b/packages/ui/src/components/link-card.tsx
@@ -1,4 +1,5 @@
-import { useState } from "react"
+import { LinkIcon } from "@heroicons/react/16/solid"
+import { useEffect, useState } from "react"
 import { cn } from "../lib/utils"
 
 export const linkCardShellClasses =
@@ -37,9 +38,24 @@ function faviconServiceUrl(hostname: string): string {
 
 function safeHost(urlStr: string): string {
   try {
-    return new URL(urlStr).hostname.replace(/^www\./, "")
+    return new URL(urlStr).hostname.replace(/^www\./i, "")
   } catch {
     return ""
+  }
+}
+
+/** Host + path, no protocol, query, or hash — for compact inline link pills. */
+export function linkPillDisplayLabel(trimmedUrl: string): string {
+  try {
+    const u = new URL(trimmedUrl)
+    const host = u.hostname.replace(/^www\./i, "")
+    const path = u.pathname
+    if (!path || path === "/") return host
+    return `${host}${path}`
+  } catch {
+    const stripped = trimmedUrl.replace(/^https?:\/\//i, "")
+    const cut = stripped.split(/[?#]/)[0] ?? stripped
+    return cut.length > 0 ? cut : trimmedUrl
   }
 }
 
@@ -51,14 +67,14 @@ export function LinkPill({
   className?: string
 }) {
   const trimmed = trimTrailingPunct(url)
-  let label = trimmed
-  try {
-    label = new URL(trimmed).hostname.replace(/^www\./, "")
-  } catch {}
-  const fav =
-    label.length > 0
-      ? faviconServiceUrl(label)
-      : faviconServiceUrl(safeHost(trimmed) || "example.com")
+  const hostForFavicon = safeHost(trimmed)
+  const fav = faviconServiceUrl(hostForFavicon || "example.com")
+  const label = linkPillDisplayLabel(trimmed)
+  const [faviconFailed, setFaviconFailed] = useState(false)
+
+  useEffect(() => {
+    setFaviconFailed(false)
+  }, [trimmed])
 
   return (
     <a
@@ -69,19 +85,24 @@ export function LinkPill({
       data-post-card-ignore-open
       onClick={(e) => e.stopPropagation()}
       className={cn(
-        "inline-flex max-w-[min(100%,14rem)] items-baseline gap-1.5 rounded-md border border-neutral bg-base-2 px-1.5 py-0.5 align-middle font-semibold tracking-tight text-primary no-underline shadow-[var(--inset-shadow-primary)] transition hover:scale-[1.03] hover:bg-subtle",
+        "inline-flex max-w-[min(100%,18rem)] items-center gap-1.5 rounded-md border border-neutral bg-base-2 px-1.5 py-0.5 align-middle text-sm font-semibold tracking-tight text-primary no-underline shadow-[var(--inset-shadow-primary)] transition hover:scale-[1.03] hover:bg-subtle",
         className
       )}
     >
-      <img
-        src={fav}
-        alt=""
-        width={12}
-        height={12}
-        className="size-3 shrink-0 self-center rounded-[3px] object-cover"
-        loading="lazy"
-      />
-      <span className="truncate">{label}</span>
+      {faviconFailed ? (
+        <LinkIcon aria-hidden className="size-3 shrink-0 text-tertiary" />
+      ) : (
+        <img
+          src={fav}
+          alt=""
+          width={12}
+          height={12}
+          className="size-3 shrink-0 rounded-[3px] object-cover"
+          loading="lazy"
+          onError={() => setFaviconFailed(true)}
+        />
+      )}
+      <span className="min-w-0 truncate">{label}</span>
     </a>
   )
 }

--- a/packages/ui/src/components/link-card.tsx
+++ b/packages/ui/src/components/link-card.tsx
@@ -68,13 +68,15 @@ export function LinkPill({
 }) {
   const trimmed = trimTrailingPunct(url)
   const hostForFavicon = safeHost(trimmed)
-  const fav = faviconServiceUrl(hostForFavicon || "example.com")
+  const fav = hostForFavicon ? faviconServiceUrl(hostForFavicon) : null
   const label = linkPillDisplayLabel(trimmed)
   const [faviconFailed, setFaviconFailed] = useState(false)
 
   useEffect(() => {
     setFaviconFailed(false)
   }, [trimmed])
+
+  const showFaviconImg = Boolean(fav && !faviconFailed)
 
   return (
     <a
@@ -89,9 +91,7 @@ export function LinkPill({
         className
       )}
     >
-      {faviconFailed ? (
-        <LinkIcon aria-hidden className="size-3 shrink-0 text-tertiary" />
-      ) : (
+      {showFaviconImg && fav ? (
         <img
           src={fav}
           alt=""
@@ -101,6 +101,8 @@ export function LinkPill({
           loading="lazy"
           onError={() => setFaviconFailed(true)}
         />
+      ) : (
+        <LinkIcon aria-hidden className="size-3 shrink-0 text-tertiary" />
       )}
       <span className="min-w-0 truncate">{label}</span>
     </a>

--- a/packages/ui/src/components/post-card.tsx
+++ b/packages/ui/src/components/post-card.tsx
@@ -13,6 +13,7 @@ import {
   HeartIcon as HeartSolid,
 } from "@heroicons/react/24/solid"
 import { cn } from "@workspace/ui/lib/utils"
+import { LinkPill, trimTrailingPunct } from "@workspace/ui/components/link-card"
 import { Avatar } from "@workspace/ui/components/avatar"
 import { Button } from "@workspace/ui/components/button"
 import { DropdownMenu } from "@workspace/ui/components/dropdown-menu"
@@ -625,7 +626,7 @@ function QuoteEmbed({ quote }: { quote: PostQuoteOf }) {
           </div>
           {quote.text && (
             <p className="mt-1 line-clamp-3 text-sm leading-relaxed whitespace-pre-wrap text-primary">
-              {quote.text}
+              <PostText text={quote.text} />
             </p>
           )}
         </div>
@@ -773,20 +774,11 @@ function PostText({ text }: { text: string }) {
     <>
       {parts.map((part, i) => {
         if (part.type === "url") {
-          const trimmed = part.value.replace(/[),.;:!?]+$/, "")
+          const trimmed = trimTrailingPunct(part.value)
           const trailing = part.value.slice(trimmed.length)
           return (
             <span key={i}>
-              <a
-                href={trimmed}
-                target="_blank"
-                rel="noreferrer"
-                data-post-card-ignore-open
-                onClick={(e) => e.stopPropagation()}
-                className="text-blue-500 underline decoration-blue-500/40 underline-offset-2 hover:decoration-blue-500"
-              >
-                {trimmed}
-              </a>
+              <LinkPill url={trimmed} />
               {trailing}
             </span>
           )

--- a/packages/youtube-unfurl/src/fetcher.ts
+++ b/packages/youtube-unfurl/src/fetcher.ts
@@ -68,6 +68,118 @@ function videoWatchUrl(ref: Extract<YouTubeRef, { kind: 'video' }>): string {
   return base
 }
 
+type OEmbedVideoPayload = {
+  title?: string
+  author_name?: string
+  author_url?: string
+  thumbnail_url?: string
+  thumbnail_width?: number
+  thumbnail_height?: number
+}
+
+function channelMetaFromAuthorUrl(authorUrl: string | undefined): {
+  channelId: string
+  channelHandle: string | null
+} {
+  if (!authorUrl) return { channelId: '', channelHandle: null }
+  try {
+    const u = new URL(authorUrl)
+    const ch = u.pathname.match(/\/channel\/(UC[A-Za-z0-9_-]{10,})/i)
+    if (ch?.[1]) return { channelId: ch[1], channelHandle: null }
+    const h = u.pathname.match(/^\/@([^/?#]+)/)
+    if (h?.[1]) return { channelId: '', channelHandle: decodeURIComponent(h[1]) }
+  } catch {}
+  return { channelId: '', channelHandle: null }
+}
+
+async function fetchVideoOEmbed(
+  ref: Extract<YouTubeRef, { kind: 'video' }>,
+): Promise<FetchOutcome<YouTubeVideoCard>> {
+  const cardUrl = videoWatchUrl(ref)
+  const oembedUrl = new URL('https://www.youtube.com/oembed')
+  oembedUrl.searchParams.set('url', cardUrl)
+  oembedUrl.searchParams.set('format', 'json')
+
+  let res: Response
+  try {
+    res = await fetch(oembedUrl.toString(), { redirect: 'follow' })
+  } catch (err) {
+    return { ok: false, ...classifyHttpError(err) }
+  }
+
+  if (res.status === 404) {
+    return { ok: false, reason: 'not_found', message: 'video_not_found' }
+  }
+  if (!res.ok) {
+    return {
+      ok: false,
+      reason: res.status === 401 || res.status === 403 ? 'unauthorized' : 'unknown',
+      message: `oembed_http_${res.status}`,
+    }
+  }
+
+  let body: unknown
+  try {
+    body = await res.json()
+  } catch {
+    return { ok: false, reason: 'unknown', message: 'oembed_json_invalid' }
+  }
+
+  const j = body as OEmbedVideoPayload
+  const thumb = j.thumbnail_url?.trim() ?? ''
+  if (!thumb) return { ok: false, reason: 'not_found', message: 'oembed_no_thumbnail' }
+
+  const { channelId, channelHandle } = channelMetaFromAuthorUrl(j.author_url)
+  const title = (j.title ?? '').trim() || cardUrl
+  const channelTitle = (j.author_name ?? '').trim()
+  const tw = typeof j.thumbnail_width === 'number' ? j.thumbnail_width : null
+  const th = typeof j.thumbnail_height === 'number' ? j.thumbnail_height : null
+  const isShortGuess =
+    Boolean(ref.inferredShort) ||
+    (typeof tw === 'number' &&
+      typeof th === 'number' &&
+      th > 0 &&
+      tw > 0 &&
+      th > tw)
+
+  const startSec: number | null = ref.startSec !== undefined ? ref.startSec : null
+
+  const card: YouTubeVideoCard = {
+    kind: 'youtube_video',
+    url: cardUrl,
+    videoId: ref.videoId,
+    title,
+    description: null,
+    channelId,
+    channelTitle,
+    channelHandle,
+    channelAvatarUrl: null,
+    thumbnailUrl: thumb,
+    thumbnailWidth: tw,
+    thumbnailHeight: th,
+    durationSec: null,
+    viewCount: null,
+    likeCount: null,
+    commentCount: null,
+    publishedAt: null,
+    isShort: isShortGuess,
+    isLive: false,
+    embeddable: true,
+    startSec,
+    playlistId: ref.playlistId ?? null,
+  }
+
+  return {
+    ok: true,
+    result: {
+      card,
+      title,
+      description: null,
+      imageUrl: thumb,
+    },
+  }
+}
+
 async function fetchVideo(
   ref: Extract<YouTubeRef, { kind: 'video' }>,
   apiKey: string,
@@ -271,6 +383,7 @@ export async function fetchYouTubeCard(
   apiKey: string | undefined,
 ): Promise<FetchOutcome<YouTubeCard>> {
   if (!apiKey || apiKey.length === 0) {
+    if (ref.kind === 'video') return await fetchVideoOEmbed(ref)
     return { ok: false, reason: 'unauthorized', message: 'unfurl_token_missing' }
   }
 

--- a/packages/youtube-unfurl/src/fetcher.ts
+++ b/packages/youtube-unfurl/src/fetcher.ts
@@ -109,6 +109,8 @@ type OEmbedVideoPayload = {
   thumbnail_height?: number
 }
 
+const OEMBED_FETCH_TIMEOUT_MS = 5000
+
 function channelMetaFromAuthorUrl(authorUrl: string | undefined): {
   channelId: string
   channelHandle: string | null
@@ -133,11 +135,24 @@ async function fetchVideoOEmbed(
   oembedUrl.searchParams.set("url", cardUrl)
   oembedUrl.searchParams.set("format", "json")
 
+  const controller = new AbortController()
+  const timeoutId = setTimeout(
+    () => controller.abort(),
+    OEMBED_FETCH_TIMEOUT_MS
+  )
   let res: Response
   try {
-    res = await fetch(oembedUrl.toString(), { redirect: "follow" })
+    res = await fetch(oembedUrl.toString(), {
+      redirect: "follow",
+      signal: controller.signal,
+    })
   } catch (err) {
+    if (err instanceof Error && err.name === "AbortError") {
+      return { ok: false, reason: "unknown", message: "oembed_timeout" }
+    }
     return { ok: false, ...classifyHttpError(err) }
+  } finally {
+    clearTimeout(timeoutId)
   }
 
   if (res.status === 404) {
@@ -447,16 +462,16 @@ export async function fetchYouTubeCard(
   ref: YouTubeRef,
   apiKey: string | undefined
 ): Promise<FetchOutcome<YouTubeCard>> {
-  if (!apiKey || apiKey.length === 0) {
-    if (ref.kind === "video") return await fetchVideoOEmbed(ref)
-    return {
-      ok: false,
-      reason: "unauthorized",
-      message: "unfurl_token_missing",
-    }
-  }
-
   try {
+    if (!apiKey || apiKey.length === 0) {
+      if (ref.kind === "video") return await fetchVideoOEmbed(ref)
+      return {
+        ok: false,
+        reason: "unauthorized",
+        message: "unfurl_token_missing",
+      }
+    }
+
     if (ref.kind === "video") return await fetchVideo(ref, apiKey)
     if (ref.kind === "playlist") return await fetchPlaylist(ref, apiKey)
     return await fetchChannel(ref, apiKey)

--- a/packages/youtube-unfurl/src/fetcher.ts
+++ b/packages/youtube-unfurl/src/fetcher.ts
@@ -100,15 +100,6 @@ function guessIsYoutubeShortVideo(
   return meta.durationSec !== null && meta.durationSec <= 62
 }
 
-type OEmbedVideoPayload = {
-  title?: string
-  author_name?: string
-  author_url?: string
-  thumbnail_url?: string
-  thumbnail_width?: number
-  thumbnail_height?: number
-}
-
 const OEMBED_FETCH_TIMEOUT_MS = 5000
 
 function channelMetaFromAuthorUrl(authorUrl: string | undefined): {
@@ -174,16 +165,33 @@ async function fetchVideoOEmbed(
     return { ok: false, reason: "unknown", message: "oembed_json_invalid" }
   }
 
-  const j = body as OEmbedVideoPayload
-  const thumb = j.thumbnail_url?.trim() ?? ""
-  if (!thumb)
-    return { ok: false, reason: "not_found", message: "oembed_no_thumbnail" }
+  if (typeof body !== "object" || body === null) {
+    return { ok: false, reason: "unknown", message: "oembed_json_invalid" }
+  }
 
-  const { channelId, channelHandle } = channelMetaFromAuthorUrl(j.author_url)
-  const title = (j.title ?? "").trim() || cardUrl
-  const channelTitle = (j.author_name ?? "").trim()
-  const tw = typeof j.thumbnail_width === "number" ? j.thumbnail_width : null
-  const th = typeof j.thumbnail_height === "number" ? j.thumbnail_height : null
+  const j = body as Record<string, unknown>
+  const rawThumb = j["thumbnail_url"]
+  if (typeof rawThumb !== "string" || rawThumb.trim().length === 0) {
+    return { ok: false, reason: "unknown", message: "oembed_json_invalid" }
+  }
+  const thumb = rawThumb.trim()
+
+  const rawAuthorUrl = j["author_url"]
+  const authorUrlStr =
+    typeof rawAuthorUrl === "string" ? rawAuthorUrl : undefined
+  const { channelId, channelHandle } = channelMetaFromAuthorUrl(authorUrlStr)
+
+  const rawTitle = j["title"]
+  const title = (typeof rawTitle === "string" ? rawTitle.trim() : "") || cardUrl
+
+  const rawAuthorName = j["author_name"]
+  const channelTitle =
+    typeof rawAuthorName === "string" ? rawAuthorName.trim() : ""
+
+  const rawTw = j["thumbnail_width"]
+  const rawTh = j["thumbnail_height"]
+  const tw = typeof rawTw === "number" ? rawTw : null
+  const th = typeof rawTh === "number" ? rawTh : null
   const isShortGuess = guessIsYoutubeShortVideo(ref, {
     thumbnailWidth: tw,
     thumbnailHeight: th,

--- a/packages/youtube-unfurl/src/fetcher.ts
+++ b/packages/youtube-unfurl/src/fetcher.ts
@@ -1,10 +1,10 @@
-import type { Database } from '@workspace/db'
+import type { Database } from "@workspace/db"
 import {
   applyUnfurlSuccess,
   classifyHttpError,
   persistFailureOnly,
   type FetchOutcome as CoreFetchOutcome,
-} from '@workspace/url-unfurl-core'
+} from "@workspace/url-unfurl-core"
 import {
   listChannels,
   listPlaylistItems,
@@ -17,28 +17,40 @@ import {
   type YtPlaylistsResponse,
   type YtPlaylistItemsResponse,
   type YtVideosResponse,
-} from './api.ts'
-import type { YouTubeCard, YouTubeChannelCard, YouTubePlaylistCard, YouTubeVideoCard } from './card.ts'
-import { canonicalizeYouTubeUrl, type YouTubeRef } from './urls.ts'
+} from "./api.ts"
+import type {
+  YouTubeCard,
+  YouTubeChannelCard,
+  YouTubePlaylistCard,
+  YouTubeVideoCard,
+} from "./card.ts"
+import { canonicalizeYouTubeUrl, type YouTubeRef } from "./urls.ts"
 
-export type FetchOutcome<TCard extends YouTubeCard = YouTubeCard> = CoreFetchOutcome<TCard>
+export type FetchOutcome<TCard extends YouTubeCard = YouTubeCard> =
+  CoreFetchOutcome<TCard>
 
 async function ytOk<T>(p: Promise<unknown>): Promise<T> {
   const j = await p
   const o = j as { error?: { code?: number; message?: string } }
   if (o?.error?.code)
-    throw Object.assign(new Error(o.error.message ?? 'youtube_api_error'), { status: o.error.code })
+    throw Object.assign(new Error(o.error.message ?? "youtube_api_error"), {
+      status: o.error.code,
+    })
   return j as T
 }
 
-function bestThumb(thumbs?: Record<string, YtThumbnail | undefined>): YtThumbnail {
-  const keys = ['maxres', 'standard', 'high', 'medium', 'default']
+function bestThumb(
+  thumbs?: Record<string, YtThumbnail | undefined>
+): YtThumbnail {
+  const keys = ["maxres", "standard", "high", "medium", "default"]
   for (const k of keys) {
     const v = thumbs?.[k]
     if (v?.url) return v
   }
-  const hit = thumbs ? Object.values(thumbs).find((x): x is YtThumbnail => Boolean(x?.url)) : undefined
-  return hit ?? { url: '' }
+  const hit = thumbs
+    ? Object.values(thumbs).find((x): x is YtThumbnail => Boolean(x?.url))
+    : undefined
+  return hit ?? { url: "" }
 }
 
 function excerpt(body: string | null | undefined, max = 400): string | null {
@@ -49,23 +61,43 @@ function excerpt(body: string | null | undefined, max = 400): string | null {
 }
 
 function ttlSecForCard(card: YouTubeCard): number {
-  if (card.kind === 'youtube_playlist') return 60 * 60
-  if (card.kind === 'youtube_channel') return 60 * 60 * 24
-  return card.kind === 'youtube_video' && card.isLive ? 60 * 5 : 60 * 60 * 24
+  if (card.kind === "youtube_playlist") return 60 * 60
+  if (card.kind === "youtube_channel") return 60 * 60 * 24
+  return card.kind === "youtube_video" && card.isLive ? 60 * 5 : 60 * 60 * 24
 }
 
-function videoWatchUrl(ref: Extract<YouTubeRef, { kind: 'video' }>): string {
+function videoWatchUrl(ref: Extract<YouTubeRef, { kind: "video" }>): string {
   const base = canonicalizeYouTubeUrl(ref)
   if (ref.playlistId) {
     try {
       const u = new URL(base)
-      u.searchParams.set('list', ref.playlistId)
+      u.searchParams.set("list", ref.playlistId)
       return u.toString()
     } catch {
       return base
     }
   }
   return base
+}
+
+/** Portrait thumbnail heuristic; API path also requires short duration when known. */
+function guessIsYoutubeShortVideo(
+  ref: Extract<YouTubeRef, { kind: "video" }>,
+  meta: {
+    thumbnailWidth: number | null | undefined
+    thumbnailHeight: number | null | undefined
+    /** When set (including null), duration must be ≤62s for the portrait thumb to count. */
+    durationSec?: number | null
+  }
+): boolean {
+  if (ref.inferredShort) return true
+  const w = meta.thumbnailWidth
+  const h = meta.thumbnailHeight
+  const portrait =
+    typeof w === "number" && typeof h === "number" && h > 0 && w > 0 && h > w
+  if (!portrait) return false
+  if (meta.durationSec === undefined) return true
+  return meta.durationSec !== null && meta.durationSec <= 62
 }
 
 type OEmbedVideoPayload = {
@@ -81,39 +113,41 @@ function channelMetaFromAuthorUrl(authorUrl: string | undefined): {
   channelId: string
   channelHandle: string | null
 } {
-  if (!authorUrl) return { channelId: '', channelHandle: null }
+  if (!authorUrl) return { channelId: "", channelHandle: null }
   try {
     const u = new URL(authorUrl)
     const ch = u.pathname.match(/\/channel\/(UC[A-Za-z0-9_-]{10,})/i)
     if (ch?.[1]) return { channelId: ch[1], channelHandle: null }
     const h = u.pathname.match(/^\/@([^/?#]+)/)
-    if (h?.[1]) return { channelId: '', channelHandle: decodeURIComponent(h[1]) }
+    if (h?.[1])
+      return { channelId: "", channelHandle: decodeURIComponent(h[1]) }
   } catch {}
-  return { channelId: '', channelHandle: null }
+  return { channelId: "", channelHandle: null }
 }
 
 async function fetchVideoOEmbed(
-  ref: Extract<YouTubeRef, { kind: 'video' }>,
+  ref: Extract<YouTubeRef, { kind: "video" }>
 ): Promise<FetchOutcome<YouTubeVideoCard>> {
   const cardUrl = videoWatchUrl(ref)
-  const oembedUrl = new URL('https://www.youtube.com/oembed')
-  oembedUrl.searchParams.set('url', cardUrl)
-  oembedUrl.searchParams.set('format', 'json')
+  const oembedUrl = new URL("https://www.youtube.com/oembed")
+  oembedUrl.searchParams.set("url", cardUrl)
+  oembedUrl.searchParams.set("format", "json")
 
   let res: Response
   try {
-    res = await fetch(oembedUrl.toString(), { redirect: 'follow' })
+    res = await fetch(oembedUrl.toString(), { redirect: "follow" })
   } catch (err) {
     return { ok: false, ...classifyHttpError(err) }
   }
 
   if (res.status === 404) {
-    return { ok: false, reason: 'not_found', message: 'video_not_found' }
+    return { ok: false, reason: "not_found", message: "video_not_found" }
   }
   if (!res.ok) {
     return {
       ok: false,
-      reason: res.status === 401 || res.status === 403 ? 'unauthorized' : 'unknown',
+      reason:
+        res.status === 401 || res.status === 403 ? "unauthorized" : "unknown",
       message: `oembed_http_${res.status}`,
     }
   }
@@ -122,30 +156,29 @@ async function fetchVideoOEmbed(
   try {
     body = await res.json()
   } catch {
-    return { ok: false, reason: 'unknown', message: 'oembed_json_invalid' }
+    return { ok: false, reason: "unknown", message: "oembed_json_invalid" }
   }
 
   const j = body as OEmbedVideoPayload
-  const thumb = j.thumbnail_url?.trim() ?? ''
-  if (!thumb) return { ok: false, reason: 'not_found', message: 'oembed_no_thumbnail' }
+  const thumb = j.thumbnail_url?.trim() ?? ""
+  if (!thumb)
+    return { ok: false, reason: "not_found", message: "oembed_no_thumbnail" }
 
   const { channelId, channelHandle } = channelMetaFromAuthorUrl(j.author_url)
-  const title = (j.title ?? '').trim() || cardUrl
-  const channelTitle = (j.author_name ?? '').trim()
-  const tw = typeof j.thumbnail_width === 'number' ? j.thumbnail_width : null
-  const th = typeof j.thumbnail_height === 'number' ? j.thumbnail_height : null
-  const isShortGuess =
-    Boolean(ref.inferredShort) ||
-    (typeof tw === 'number' &&
-      typeof th === 'number' &&
-      th > 0 &&
-      tw > 0 &&
-      th > tw)
+  const title = (j.title ?? "").trim() || cardUrl
+  const channelTitle = (j.author_name ?? "").trim()
+  const tw = typeof j.thumbnail_width === "number" ? j.thumbnail_width : null
+  const th = typeof j.thumbnail_height === "number" ? j.thumbnail_height : null
+  const isShortGuess = guessIsYoutubeShortVideo(ref, {
+    thumbnailWidth: tw,
+    thumbnailHeight: th,
+  })
 
-  const startSec: number | null = ref.startSec !== undefined ? ref.startSec : null
+  const startSec: number | null =
+    ref.startSec !== undefined ? ref.startSec : null
 
   const card: YouTubeVideoCard = {
-    kind: 'youtube_video',
+    kind: "youtube_video",
     url: cardUrl,
     videoId: ref.videoId,
     title,
@@ -181,19 +214,26 @@ async function fetchVideoOEmbed(
 }
 
 async function fetchVideo(
-  ref: Extract<YouTubeRef, { kind: 'video' }>,
-  apiKey: string,
+  ref: Extract<YouTubeRef, { kind: "video" }>,
+  apiKey: string
 ): Promise<FetchOutcome<YouTubeVideoCard>> {
   const raw = await ytOk<YtVideosResponse>(
     listVideos(
-      ['snippet', 'contentDetails', 'statistics', 'status', 'liveStreamingDetails'],
+      [
+        "snippet",
+        "contentDetails",
+        "statistics",
+        "status",
+        "liveStreamingDetails",
+      ],
       ref.videoId,
-      apiKey,
-    ),
+      apiKey
+    )
   )
   const it = raw.items?.[0]
   const snip = it?.snippet
-  if (!it || !snip) return { ok: false, reason: 'not_found', message: 'video_not_found' }
+  if (!it || !snip)
+    return { ok: false, reason: "not_found", message: "video_not_found" }
 
   const t = bestThumb(snip.thumbnails ?? {})
 
@@ -201,7 +241,9 @@ async function fetchVideo(
   let channelHandle: string | null = null
   if (snip.channelId) {
     try {
-      const ch = await ytOk<YtChannelsResponse>(listChannels(['snippet'], apiKey, { id: snip.channelId }))
+      const ch = await ytOk<YtChannelsResponse>(
+        listChannels(["snippet"], apiKey, { id: snip.channelId })
+      )
       const ch0 = ch.items?.[0]
       channelAvatarUrl = bestThumb(ch0?.snippet?.thumbnails)?.url ?? null
       channelHandle = ch0?.snippet?.channelHandle ?? null
@@ -214,39 +256,44 @@ async function fetchVideo(
   const durationSec = parseISO8601Duration(durationIso)
   const liveState = snip.liveBroadcastContent
   const isLive =
-    liveState === 'live' || liveState === 'upcoming' || Boolean(it.liveStreamingDetails)
+    liveState === "live" ||
+    liveState === "upcoming" ||
+    Boolean(it.liveStreamingDetails)
 
-  const isShortGuess =
-    Boolean(ref.inferredShort) ||
-    (durationSec !== null &&
-      durationSec <= 62 &&
-      typeof t.height === 'number' &&
-      typeof t.width === 'number' &&
-      t.height > t.width)
+  const isShortGuess = guessIsYoutubeShortVideo(ref, {
+    thumbnailWidth: t.width,
+    thumbnailHeight: t.height,
+    durationSec,
+  })
 
   const embeddable = it.status?.embeddable !== false
-  const startSec: number | null = ref.startSec !== undefined ? ref.startSec : null
+  const startSec: number | null =
+    ref.startSec !== undefined ? ref.startSec : null
   const cardUrl = videoWatchUrl(ref)
-  const title = snip.title ?? ''
+  const title = snip.title ?? ""
 
   const card: YouTubeVideoCard = {
-    kind: 'youtube_video',
+    kind: "youtube_video",
     url: cardUrl,
     videoId: ref.videoId,
     title,
     description: excerpt(snip.description),
-    channelId: snip.channelId ?? '',
-    channelTitle: snip.channelTitle ?? '',
+    channelId: snip.channelId ?? "",
+    channelTitle: snip.channelTitle ?? "",
     channelHandle,
     channelAvatarUrl,
     thumbnailUrl: t.url,
     thumbnailWidth: t.width ?? null,
     thumbnailHeight: t.height ?? null,
     durationSec,
-    viewCount: it.statistics?.viewCount != null ? Number(it.statistics.viewCount) : null,
-    likeCount: it.statistics?.likeCount != null ? Number(it.statistics.likeCount) : null,
+    viewCount:
+      it.statistics?.viewCount != null ? Number(it.statistics.viewCount) : null,
+    likeCount:
+      it.statistics?.likeCount != null ? Number(it.statistics.likeCount) : null,
     commentCount:
-      it.statistics?.commentCount != null ? Number(it.statistics.commentCount) : null,
+      it.statistics?.commentCount != null
+        ? Number(it.statistics.commentCount)
+        : null,
     publishedAt: snip.publishedAt ?? null,
     isShort: isShortGuess,
     isLive,
@@ -267,33 +314,37 @@ async function fetchVideo(
 }
 
 async function fetchPlaylist(
-  ref: Extract<YouTubeRef, { kind: 'playlist' }>,
-  apiKey: string,
+  ref: Extract<YouTubeRef, { kind: "playlist" }>,
+  apiKey: string
 ): Promise<FetchOutcome<YouTubePlaylistCard>> {
-  const raw = await ytOk<YtPlaylistsResponse>(listPlaylists(['snippet', 'contentDetails'], ref.playlistId, apiKey))
+  const raw = await ytOk<YtPlaylistsResponse>(
+    listPlaylists(["snippet", "contentDetails"], ref.playlistId, apiKey)
+  )
   const pl = raw.items?.[0]
   const snip = pl?.snippet
-  if (!pl || !snip) return { ok: false, reason: 'not_found', message: 'playlist_not_found' }
+  if (!pl || !snip)
+    return { ok: false, reason: "not_found", message: "playlist_not_found" }
 
   const items = await ytOk<YtPlaylistItemsResponse>(
-    listPlaylistItems(['snippet', 'contentDetails'], ref.playlistId, apiKey),
+    listPlaylistItems(["snippet", "contentDetails"], ref.playlistId, apiKey)
   )
   const row0 = items.items?.[0]
-  const firstVid = row0?.contentDetails?.videoId ?? row0?.snippet?.resourceId?.videoId ?? null
+  const firstVid =
+    row0?.contentDetails?.videoId ?? row0?.snippet?.resourceId?.videoId ?? null
 
   const thumbs = snip.thumbnails ?? {}
   const t = bestThumb(thumbs)
 
   let itemCount: number | null = null
   const ic = pl.contentDetails?.itemCount
-  if (typeof ic === 'number') itemCount = ic
-  else if (typeof ic === 'string') itemCount = Number(ic) || null
+  if (typeof ic === "number") itemCount = ic
+  else if (typeof ic === "string") itemCount = Number(ic) || null
 
   const cardUrl = canonicalizeYouTubeUrl(ref)
-  const title = snip.title ?? ''
+  const title = snip.title ?? ""
 
   const card: YouTubePlaylistCard = {
-    kind: 'youtube_playlist',
+    kind: "youtube_playlist",
     url: cardUrl,
     playlistId: ref.playlistId,
     title,
@@ -317,45 +368,59 @@ async function fetchPlaylist(
 }
 
 async function fetchChannel(
-  ref: Extract<YouTubeRef, { kind: 'channel' }>,
-  apiKey: string,
+  ref: Extract<YouTubeRef, { kind: "channel" }>,
+  apiKey: string
 ): Promise<FetchOutcome<YouTubeChannelCard>> {
   const spec = ref.channelSpecifier
   let channelId: string | undefined
-  if (spec.type === 'id') channelId = spec.id
-  else if (spec.type === 'handle') {
+  if (spec.type === "id") channelId = spec.id
+  else if (spec.type === "handle") {
     const r = await ytOk<YtChannelsResponse>(
-      listChannels(['snippet', 'statistics', 'brandingSettings'], apiKey, { forHandle: spec.handle }),
+      listChannels(["snippet", "statistics", "brandingSettings"], apiKey, {
+        forHandle: spec.handle,
+      })
     )
     channelId = r.items?.[0]?.id
   } else {
-    const q = spec.path.replace(/^\//, '').split('/').filter(Boolean).join(' ')
-    const s = await ytOk(
-      searchList(['snippet'], apiKey, { type: 'channel', q, maxResults: '1' }),
-    ) as { items?: Array<{ id?: { channelId?: string } }> }
+    const q = spec.path.replace(/^\//, "").split("/").filter(Boolean).join(" ")
+    const s = (await ytOk(
+      searchList(["snippet"], apiKey, { type: "channel", q, maxResults: "1" })
+    )) as { items?: Array<{ id?: { channelId?: string } }> }
     channelId = s.items?.[0]?.id?.channelId
   }
-  if (!channelId) return { ok: false, reason: 'not_found', message: 'channel_not_found' }
+  if (!channelId)
+    return { ok: false, reason: "not_found", message: "channel_not_found" }
 
   const full = await ytOk<YtChannelsResponse>(
-    listChannels(['snippet', 'statistics', 'brandingSettings'], apiKey, { id: channelId }),
+    listChannels(["snippet", "statistics", "brandingSettings"], apiKey, {
+      id: channelId,
+    })
   )
 
   const ch = full.items?.[0]
   const snip = ch?.snippet
-  if (!ch?.id || !snip) return { ok: false, reason: 'not_found', message: 'channel_resolve_failed' }
+  if (!ch?.id || !snip)
+    return { ok: false, reason: "not_found", message: "channel_resolve_failed" }
 
   const av = bestThumb(snip.thumbnails)
-  const bannerUrl = snip.bannerExternalUrl ?? ch.brandingSettings?.image?.bannerExternalUrl ?? null
+  const bannerUrl =
+    snip.bannerExternalUrl ??
+    ch.brandingSettings?.image?.bannerExternalUrl ??
+    null
   const handleOut: string | null = snip.channelHandle ?? null
-  const cardUrl = canonicalizeYouTubeUrl({ kind: 'channel', channelSpecifier: { type: 'id', id: ch.id } })
-  const title = snip.localized?.title ?? snip.title ?? handleOut ?? ''
+  const cardUrl = canonicalizeYouTubeUrl({
+    kind: "channel",
+    channelSpecifier: { type: "id", id: ch.id },
+  })
+  const title = snip.localized?.title ?? snip.title ?? handleOut ?? ""
   const desc = excerpt(snip.localized?.description ?? snip.description)
-  const subs = ch.statistics?.subscriberCount ? Number(ch.statistics.subscriberCount) : null
+  const subs = ch.statistics?.subscriberCount
+    ? Number(ch.statistics.subscriberCount)
+    : null
   const vc = ch.statistics?.videoCount ? Number(ch.statistics.videoCount) : null
 
   const card: YouTubeChannelCard = {
-    kind: 'youtube_channel',
+    kind: "youtube_channel",
     url: cardUrl,
     channelId: ch.id,
     handle: handleOut,
@@ -380,16 +445,20 @@ async function fetchChannel(
 
 export async function fetchYouTubeCard(
   ref: YouTubeRef,
-  apiKey: string | undefined,
+  apiKey: string | undefined
 ): Promise<FetchOutcome<YouTubeCard>> {
   if (!apiKey || apiKey.length === 0) {
-    if (ref.kind === 'video') return await fetchVideoOEmbed(ref)
-    return { ok: false, reason: 'unauthorized', message: 'unfurl_token_missing' }
+    if (ref.kind === "video") return await fetchVideoOEmbed(ref)
+    return {
+      ok: false,
+      reason: "unauthorized",
+      message: "unfurl_token_missing",
+    }
   }
 
   try {
-    if (ref.kind === 'video') return await fetchVideo(ref, apiKey)
-    if (ref.kind === 'playlist') return await fetchPlaylist(ref, apiKey)
+    if (ref.kind === "video") return await fetchVideo(ref, apiKey)
+    if (ref.kind === "playlist") return await fetchPlaylist(ref, apiKey)
     return await fetchChannel(ref, apiKey)
   } catch (err) {
     return { ok: false, ...classifyHttpError(err) }
@@ -399,16 +468,22 @@ export async function fetchYouTubeCard(
 export async function persistYoutubeCardOutcome(
   db: Database,
   rowId: string,
-  outcome: FetchOutcome<YouTubeCard>,
+  outcome: FetchOutcome<YouTubeCard>
 ): Promise<void> {
   if (!outcome.ok) {
     await persistFailureOnly(db, rowId, outcome.reason, outcome.message)
     return
   }
-  await applyUnfurlSuccess(db, rowId, ttlSecForCard(outcome.result.card), outcome.result, {
-    siteName: 'YouTube',
-    providerName: 'YouTube',
-  })
+  await applyUnfurlSuccess(
+    db,
+    rowId,
+    ttlSecForCard(outcome.result.card),
+    outcome.result,
+    {
+      siteName: "YouTube",
+      providerName: "YouTube",
+    }
+  )
 }
 
-export { persistFailureOnly } from '@workspace/url-unfurl-core'
+export { persistFailureOnly } from "@workspace/url-unfurl-core"


### PR DESCRIPTION
## Summary

YouTube links in the timeline were only showing as tiny inline domain chips, not as proper video cards. That mostly happened when no YouTube Data API key was set: the unfurl would fail and the API never returned a ready card.

We now use YouTube’s public oEmbed for **videos** when the API key is missing, so you still get title, thumbnail, and channel name from the embed. Playlists and channels still need a key.

While touching the feed experience, inline links in the shared post card now use the same **LinkPill** treatment as elsewhere: favicon (with a simple link icon if the favicon fails), and a short label without `https://` or query strings. Quoted posts get the same link styling in the quote body.

## Test plan

- [x] `bun run typecheck` passes
- [x] `bun run lint` passes
- [x] `bun run format:check` passes
- [x] `bun run build` passes

## Notes

Posts that already failed YouTube unfurl before this change may still be missing cards until they’re re-unfurled (for example after an edit). New posts should pick up previews without a key for standard watch / youtu.be video URLs.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * YouTube unfurling now works without an API key via an oEmbed fallback.

* **Improvements**
  * Link pills show cleaner host/URL labels, more reliable favicon handling, and better error fallback.
  * Post text URL rendering unified for consistent display and trailing-punctuation handling.
  * Improved short-video detection for YouTube previews.

* **Chores**
  * Simplified web build config and removed an unused dev dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->