### PR TITLE
Improve feed chain previews and back navigation

### DIFF
--- a/apps/api/src/lib/feed-chain-preview.ts
+++ b/apps/api/src/lib/feed-chain-preview.ts
@@ -154,6 +154,20 @@ export async function attachFeedChainPreviews(args: {
   }
 }
 
+export function linkSamePageReplies(posts: Array<PostDto>): void {
+  const byId = new Map<string, PostDto>()
+  for (const p of posts) byId.set(p.id, p)
+
+  for (const p of posts) {
+    if (p.chainPreview) continue
+    if (!p.replyToId) continue
+    const parent = byId.get(p.replyToId)
+    if (!parent) continue
+    p.chainPreview = { root: parent, omittedCount: 0 }
+    delete p.replyParent
+  }
+}
+
 export function filterChainIntermediates(
   posts: Array<PostDto>
 ): Array<PostDto> {

--- a/apps/api/src/lib/feed-chain-preview.ts
+++ b/apps/api/src/lib/feed-chain-preview.ts
@@ -160,13 +160,11 @@ export function filterChainIntermediates(
   const hasChildInFeed = new Set<string>()
   const shownAsChainRoot = new Set<string>()
   for (const p of posts) {
-    const displayed = p.repostOf ?? p
-    if (displayed.replyToId) hasChildInFeed.add(displayed.replyToId)
+    if (p.replyToId) hasChildInFeed.add(p.replyToId)
     if (p.chainPreview) shownAsChainRoot.add(p.chainPreview.root.id)
   }
   return posts.filter((p) => {
-    const displayed = p.repostOf ?? p
-    if (displayed.replyToId) return !hasChildInFeed.has(displayed.id)
-    return !shownAsChainRoot.has(displayed.id)
+    if (p.replyToId) return !hasChildInFeed.has(p.id)
+    return !shownAsChainRoot.has(p.id)
   })
 }

--- a/apps/api/src/lib/feed-chain-preview.ts
+++ b/apps/api/src/lib/feed-chain-preview.ts
@@ -147,3 +147,16 @@ export async function attachFeedChainPreviews(args: {
     delete t.displayed.replyParent
   }
 }
+
+export function filterChainIntermediates(posts: Array<PostDto>): Array<PostDto> {
+  const hasChildInFeed = new Set<string>()
+  for (const p of posts) {
+    const displayed = p.repostOf ?? p
+    if (displayed.replyToId) hasChildInFeed.add(displayed.replyToId)
+  }
+  return posts.filter((p) => {
+    const displayed = p.repostOf ?? p
+    if (!displayed.replyToId) return true
+    return !hasChildInFeed.has(displayed.id)
+  })
+}

--- a/apps/api/src/lib/feed-chain-preview.ts
+++ b/apps/api/src/lib/feed-chain-preview.ts
@@ -51,7 +51,9 @@ export async function attachFeedChainPreviews(args: {
     .select({ post: schema.posts, author: schema.users })
     .from(schema.posts)
     .innerJoin(schema.users, eq(schema.users.id, schema.posts.authorId))
-    .where(and(inArray(schema.posts.id, rootIds), isNull(schema.posts.deletedAt)))
+    .where(
+      and(inArray(schema.posts.id, rootIds), isNull(schema.posts.deletedAt))
+    )
 
   const rootById = new Map(rootRows.map((r) => [r.post.id, r]))
 
@@ -61,8 +63,8 @@ export async function attachFeedChainPreviews(args: {
       rootIds
         .map((id) => rootById.get(id))
         .filter((r) => r?.post.visibility === "followers")
-        .map((r) => r!.post.authorId),
-    ),
+        .map((r) => r!.post.authorId)
+    )
   )
 
   if (followersOnlyAuthorIds.length > 0 && viewerId) {
@@ -72,8 +74,8 @@ export async function attachFeedChainPreviews(args: {
       .where(
         and(
           eq(schema.follows.followerId, viewerId),
-          inArray(schema.follows.followeeId, followersOnlyAuthorIds),
-        ),
+          inArray(schema.follows.followeeId, followersOnlyAuthorIds)
+        )
       )
     for (const fr of followRows) visibleRootAuthorIds.add(fr.followeeId)
   }
@@ -95,30 +97,31 @@ export async function attachFeedChainPreviews(args: {
   if (rootsToLoad.length === 0) return
 
   const loadIds = rootsToLoad.map((r) => r.post.id)
-  const [flags, mediaMap, articleMap, repostMap, quoteMap, pollMap] = await Promise.all([
-    loadViewerFlags(db, viewerId, loadIds),
-    loadPostMedia(db, loadIds),
-    loadArticleCards(db, loadIds),
-    loadRepostTargets({
-      db,
-      viewerId,
-      env,
-      repostRows: rootsToLoad.map((r) => ({
-        id: r.post.id,
-        repostOfId: r.post.repostOfId,
-      })),
-    }),
-    loadQuoteTargets({
-      db,
-      viewerId,
-      env,
-      quoteRows: rootsToLoad.map((r) => ({
-        id: r.post.id,
-        quoteOfId: r.post.quoteOfId,
-      })),
-    }),
-    loadPolls(db, viewerId, loadIds),
-  ])
+  const [flags, mediaMap, articleMap, repostMap, quoteMap, pollMap] =
+    await Promise.all([
+      loadViewerFlags(db, viewerId, loadIds),
+      loadPostMedia(db, loadIds),
+      loadArticleCards(db, loadIds),
+      loadRepostTargets({
+        db,
+        viewerId,
+        env,
+        repostRows: rootsToLoad.map((r) => ({
+          id: r.post.id,
+          repostOfId: r.post.repostOfId,
+        })),
+      }),
+      loadQuoteTargets({
+        db,
+        viewerId,
+        env,
+        quoteRows: rootsToLoad.map((r) => ({
+          id: r.post.id,
+          quoteOfId: r.post.quoteOfId,
+        })),
+      }),
+      loadPolls(db, viewerId, loadIds),
+    ])
   const unfurlCardsMap = await loadUnfurlCards(db, loadIds, articleMap)
 
   const rootDtoById = new Map<string, PostDto>()
@@ -134,8 +137,8 @@ export async function attachFeedChainPreviews(args: {
         unfurlCardsMap.get(r.post.id),
         repostMap.get(r.post.id),
         quoteMap.get(r.post.id),
-        pollMap.get(r.post.id),
-      ),
+        pollMap.get(r.post.id)
+      )
     )
   }
 
@@ -143,20 +146,27 @@ export async function attachFeedChainPreviews(args: {
     const rootDto = rootDtoById.get(t.rootId)
     if (!rootDto) continue
     const omitted = Math.max(0, t.depth - 1)
-    ;(t.outer as PostDto).chainPreview = { root: rootDto, omittedCount: omitted }
+    ;(t.outer as PostDto).chainPreview = {
+      root: rootDto,
+      omittedCount: omitted,
+    }
     delete t.displayed.replyParent
   }
 }
 
-export function filterChainIntermediates(posts: Array<PostDto>): Array<PostDto> {
+export function filterChainIntermediates(
+  posts: Array<PostDto>
+): Array<PostDto> {
   const hasChildInFeed = new Set<string>()
+  const shownAsChainRoot = new Set<string>()
   for (const p of posts) {
     const displayed = p.repostOf ?? p
     if (displayed.replyToId) hasChildInFeed.add(displayed.replyToId)
+    if (p.chainPreview) shownAsChainRoot.add(p.chainPreview.root.id)
   }
   return posts.filter((p) => {
     const displayed = p.repostOf ?? p
-    if (!displayed.replyToId) return true
-    return !hasChildInFeed.has(displayed.id)
+    if (displayed.replyToId) return !hasChildInFeed.has(displayed.id)
+    return !shownAsChainRoot.has(displayed.id)
   })
 }

--- a/apps/api/src/lib/feed-chain-preview.ts
+++ b/apps/api/src/lib/feed-chain-preview.ts
@@ -168,7 +168,7 @@ export function linkSamePageReplies(posts: Array<PostDto>): void {
   }
 }
 
-export function filterChainIntermediates(
+export function filterRedundantChainPosts(
   posts: Array<PostDto>
 ): Array<PostDto> {
   const hasChildInFeed = new Set<string>()

--- a/apps/api/src/routes/feed.ts
+++ b/apps/api/src/routes/feed.ts
@@ -1,22 +1,18 @@
-import { Hono } from "hono"
-import { and, desc, eq, inArray, isNull, lt, sql } from "@workspace/db"
-import { schema } from "@workspace/db"
-import { requireHandle, type HonoEnv } from "../middleware/session.ts"
-import { toPostDto } from "../lib/post-dto.ts"
-import { loadViewerFlags } from "../lib/viewer-flags.ts"
-import { loadPostMedia } from "../lib/post-media.ts"
-import { loadArticleCards } from "../lib/article-cards.ts"
-import { loadRepostTargets } from "../lib/repost-targets.ts"
-import { loadQuoteTargets } from "../lib/quote-targets.ts"
-import {
-  attachFeedChainPreviews,
-  linkSamePageReplies,
-  filterRedundantChainPosts,
-} from "../lib/feed-chain-preview.ts"
-import { attachReplyParents } from "../lib/reply-parents.ts"
-import { loadPolls } from "../lib/polls.ts"
-import { loadUnfurlCards } from "../lib/unfurl-cards.ts"
-import { parseCursor } from "../lib/cursor.ts"
+import { Hono } from 'hono'
+import { and, desc, eq, inArray, isNull, lt, sql } from '@workspace/db'
+import { schema } from '@workspace/db'
+import { requireHandle, type HonoEnv } from '../middleware/session.ts'
+import { toPostDto } from '../lib/post-dto.ts'
+import { loadViewerFlags } from '../lib/viewer-flags.ts'
+import { loadPostMedia } from '../lib/post-media.ts'
+import { loadArticleCards } from '../lib/article-cards.ts'
+import { loadRepostTargets } from '../lib/repost-targets.ts'
+import { loadQuoteTargets } from '../lib/quote-targets.ts'
+import { attachFeedChainPreviews, linkSamePageReplies, filterRedundantChainPosts } from '../lib/feed-chain-preview.ts'
+import { attachReplyParents } from '../lib/reply-parents.ts'
+import { loadPolls } from '../lib/polls.ts'
+import { loadUnfurlCards } from '../lib/unfurl-cards.ts'
+import { parseCursor } from '../lib/cursor.ts'
 
 export const feedRoute = new Hono<HonoEnv>()
 
@@ -37,23 +33,21 @@ export function profileFeedCacheKey(authorId: string) {
 }
 
 // Home feed: reverse-chrono from follows, excluding blocks and muted-feed users.
-feedRoute.get("/", requireHandle(), async (c) => {
-  const session = c.get("session")!
-  const { db, mediaEnv, cache, rateLimit } = c.get("ctx")
-  await rateLimit(c, "reads.feed")
-  const limit = Math.min(Number(c.req.query("limit") ?? 40), 100)
-  const cursor = parseCursor(c.req.query("cursor"))
+feedRoute.get('/', requireHandle(), async (c) => {
+  const session = c.get('session')!
+  const { db, mediaEnv, cache, rateLimit } = c.get('ctx')
+  await rateLimit(c, 'reads.feed')
+  const limit = Math.min(Number(c.req.query('limit') ?? 40), 100)
+  const cursor = parseCursor(c.req.query('cursor'))
   const me = session.user.id
 
   // Cache only page 0 (no cursor) with default limit. Deeper pages are rarely fetched and
   // caching every (cursor, limit) combo isn't worth the keyspace.
   const cacheable = !cursor && limit === 40
   if (cacheable) {
-    const hit = await cache.get<{ posts: unknown; nextCursor: string | null }>(
-      homeFeedCacheKey(me)
-    )
+    const hit = await cache.get<{ posts: unknown; nextCursor: string | null }>(homeFeedCacheKey(me))
     if (hit) {
-      c.header("x-cache", "hit")
+      c.header('x-cache', 'hit')
       return c.json(hit)
     }
   }
@@ -62,48 +56,38 @@ feedRoute.get("/", requireHandle(), async (c) => {
     .select({ post: schema.posts, author: schema.users })
     .from(schema.posts)
     .innerJoin(schema.users, eq(schema.users.id, schema.posts.authorId))
-    .innerJoin(
-      schema.follows,
-      eq(schema.follows.followeeId, schema.posts.authorId)
-    )
+    .innerJoin(schema.follows, eq(schema.follows.followeeId, schema.posts.authorId))
     .where(
       and(
         eq(schema.follows.followerId, me),
         isNull(schema.posts.deletedAt),
         cursor ? lt(schema.posts.createdAt, cursor) : undefined,
         sql`NOT EXISTS (SELECT 1 FROM ${schema.blocks} b WHERE (b.blocker_id = ${me} AND b.blocked_id = ${schema.posts.authorId}) OR (b.blocker_id = ${schema.posts.authorId} AND b.blocked_id = ${me}))`,
-        sql`NOT EXISTS (SELECT 1 FROM ${schema.mutes} m WHERE m.muter_id = ${me} AND m.muted_id = ${schema.posts.authorId} AND (m.scope = 'feed' OR m.scope = 'both'))`
-      )
+        sql`NOT EXISTS (SELECT 1 FROM ${schema.mutes} m WHERE m.muter_id = ${me} AND m.muted_id = ${schema.posts.authorId} AND (m.scope = 'feed' OR m.scope = 'both'))`,
+      ),
     )
     .orderBy(desc(schema.posts.createdAt))
     .limit(limit)
 
   const ids = rows.map((r) => r.post.id)
-  const [flags, mediaMap, articleMap, repostMap, quoteMap, pollMap] =
-    await Promise.all([
-      loadViewerFlags(db, me, ids),
-      loadPostMedia(db, ids),
-      loadArticleCards(db, ids),
-      loadRepostTargets({
-        db,
-        viewerId: me,
-        env: mediaEnv,
-        repostRows: rows.map((r) => ({
-          id: r.post.id,
-          repostOfId: r.post.repostOfId,
-        })),
-      }),
-      loadQuoteTargets({
-        db,
-        viewerId: me,
-        env: mediaEnv,
-        quoteRows: rows.map((r) => ({
-          id: r.post.id,
-          quoteOfId: r.post.quoteOfId,
-        })),
-      }),
-      loadPolls(db, me, ids),
-    ])
+  const [flags, mediaMap, articleMap, repostMap, quoteMap, pollMap] = await Promise.all([
+    loadViewerFlags(db, me, ids),
+    loadPostMedia(db, ids),
+    loadArticleCards(db, ids),
+    loadRepostTargets({
+      db,
+      viewerId: me,
+      env: mediaEnv,
+      repostRows: rows.map((r) => ({ id: r.post.id, repostOfId: r.post.repostOfId })),
+    }),
+    loadQuoteTargets({
+      db,
+      viewerId: me,
+      env: mediaEnv,
+      quoteRows: rows.map((r) => ({ id: r.post.id, quoteOfId: r.post.quoteOfId })),
+    }),
+    loadPolls(db, me, ids),
+  ])
   const unfurlCardsMap = await loadUnfurlCards(db, ids, articleMap)
   const posts = rows.map((r) =>
     toPostDto(
@@ -115,22 +99,20 @@ feedRoute.get("/", requireHandle(), async (c) => {
       unfurlCardsMap.get(r.post.id),
       repostMap.get(r.post.id),
       quoteMap.get(r.post.id),
-      pollMap.get(r.post.id)
-    )
+      pollMap.get(r.post.id),
+    ),
   )
   await attachReplyParents({ db, viewerId: me, env: mediaEnv, posts })
   await attachFeedChainPreviews({ db, viewerId: me, env: mediaEnv, posts })
   linkSamePageReplies(posts)
   const filtered = filterRedundantChainPosts(posts)
   const hasMore = rows.length === limit
-  const nextCursor = hasMore
-    ? rows[rows.length - 1]!.post.createdAt.toISOString()
-    : null
+  const nextCursor = hasMore ? rows[rows.length - 1]!.post.createdAt.toISOString() : null
   const response = { posts: filtered, nextCursor }
 
   if (cacheable) {
     await cache.set(homeFeedCacheKey(me), response, HOME_FEED_TTL_SEC)
-    c.header("x-cache", "miss")
+    c.header('x-cache', 'miss')
   }
   return c.json(response)
 })
@@ -141,12 +123,12 @@ feedRoute.get("/", requireHandle(), async (c) => {
 // viewer's blocks/mutes and any post by a blocked author.
 const NETWORK_FEED_TTL_SEC = 60
 
-feedRoute.get("/network", requireHandle(), async (c) => {
-  const session = c.get("session")!
-  const { db, mediaEnv, rateLimit } = c.get("ctx")
-  await rateLimit(c, "reads.feed")
-  const limit = Math.min(Number(c.req.query("limit") ?? 40), 100)
-  const cursor = parseCursor(c.req.query("cursor"))
+feedRoute.get('/network', requireHandle(), async (c) => {
+  const session = c.get('session')!
+  const { db, mediaEnv, rateLimit } = c.get('ctx')
+  await rateLimit(c, 'reads.feed')
+  const limit = Math.min(Number(c.req.query('limit') ?? 40), 100)
+  const cursor = parseCursor(c.req.query('cursor'))
   const me = session.user.id
 
   // The activity that surfaced the post is one of: a like by a follow,
@@ -173,23 +155,23 @@ feedRoute.get("/network", requireHandle(), async (c) => {
       schema.follows,
       and(
         eq(schema.follows.followerId, me),
-        eq(schema.follows.followeeId, schema.likes.userId)
-      )
+        eq(schema.follows.followeeId, schema.likes.userId),
+      ),
     )
     .innerJoin(schema.posts, eq(schema.posts.id, schema.likes.postId))
     .innerJoin(schema.users, eq(schema.users.id, schema.posts.authorId))
     .where(
       and(
         isNull(schema.posts.deletedAt),
-        eq(schema.posts.visibility, "public"),
+        eq(schema.posts.visibility, 'public'),
         // Skip posts by people the viewer already follows; those belong on
         // the home feed. Skip viewer's own posts too.
         sql`NOT EXISTS (SELECT 1 FROM ${schema.follows} ff WHERE ff.follower_id = ${me} AND ff.followee_id = ${schema.posts.authorId})`,
         sql`${schema.posts.authorId} <> ${me}`,
         sql`NOT EXISTS (SELECT 1 FROM ${schema.blocks} b WHERE (b.blocker_id = ${me} AND b.blocked_id = ${schema.posts.authorId}) OR (b.blocker_id = ${schema.posts.authorId} AND b.blocked_id = ${me}))`,
         sql`NOT EXISTS (SELECT 1 FROM ${schema.mutes} m WHERE m.muter_id = ${me} AND m.muted_id = ${schema.posts.authorId} AND (m.scope = 'feed' OR m.scope = 'both'))`,
-        cursor ? lt(schema.likes.createdAt, cursor) : undefined
-      )
+        cursor ? lt(schema.likes.createdAt, cursor) : undefined,
+      ),
     )
     .orderBy(desc(schema.likes.createdAt))
     .limit(limit * 2)
@@ -200,8 +182,8 @@ feedRoute.get("/network", requireHandle(), async (c) => {
     .select({
       post: schema.posts,
       author: schema.users,
-      activityAt: sql<Date>`reposters.created_at`.as("activity_at"),
-      actorId: sql<string>`reposters.author_id`.as("actor_id"),
+      activityAt: sql<Date>`reposters.created_at`.as('activity_at'),
+      actorId: sql<string>`reposters.author_id`.as('actor_id'),
     })
     .from(
       sql`(
@@ -214,19 +196,19 @@ feedRoute.get("/network", requireHandle(), async (c) => {
           ${cursor ? sql`AND r.created_at < ${cursor}` : sql``}
         ORDER BY r.created_at DESC
         LIMIT ${limit * 2}
-      ) reposters`
+      ) reposters`,
     )
     .innerJoin(schema.posts, sql`${schema.posts.id} = reposters.post_id`)
     .innerJoin(schema.users, eq(schema.users.id, schema.posts.authorId))
     .where(
       and(
         isNull(schema.posts.deletedAt),
-        eq(schema.posts.visibility, "public"),
+        eq(schema.posts.visibility, 'public'),
         sql`NOT EXISTS (SELECT 1 FROM ${schema.follows} ff WHERE ff.follower_id = ${me} AND ff.followee_id = ${schema.posts.authorId})`,
         sql`${schema.posts.authorId} <> ${me}`,
         sql`NOT EXISTS (SELECT 1 FROM ${schema.blocks} b WHERE (b.blocker_id = ${me} AND b.blocked_id = ${schema.posts.authorId}) OR (b.blocker_id = ${schema.posts.authorId} AND b.blocked_id = ${me}))`,
-        sql`NOT EXISTS (SELECT 1 FROM ${schema.mutes} m WHERE m.muter_id = ${me} AND m.muted_id = ${schema.posts.authorId} AND (m.scope = 'feed' OR m.scope = 'both'))`
-      )
+        sql`NOT EXISTS (SELECT 1 FROM ${schema.mutes} m WHERE m.muter_id = ${me} AND m.muted_id = ${schema.posts.authorId} AND (m.scope = 'feed' OR m.scope = 'both'))`,
+      ),
     )
 
   // Merge by post id, keeping the most recent activity for ordering and
@@ -243,16 +225,13 @@ feedRoute.get("/network", requireHandle(), async (c) => {
         actorIds: [row.actorId],
       })
     } else {
-      if (row.activityAt > existing.activityAt)
-        existing.activityAt = row.activityAt
-      if (!existing.actorIds.includes(row.actorId))
-        existing.actorIds.push(row.actorId)
+      if (row.activityAt > existing.activityAt) existing.activityAt = row.activityAt
+      if (!existing.actorIds.includes(row.actorId)) existing.actorIds.push(row.actorId)
     }
   }
   for (const row of repostRows) {
     const existing = byId.get(row.post.id)
-    const at =
-      row.activityAt instanceof Date ? row.activityAt : new Date(row.activityAt)
+    const at = row.activityAt instanceof Date ? row.activityAt : new Date(row.activityAt)
     if (!existing) {
       byId.set(row.post.id, {
         post: row.post,
@@ -262,8 +241,7 @@ feedRoute.get("/network", requireHandle(), async (c) => {
       })
     } else {
       if (at > existing.activityAt) existing.activityAt = at
-      if (!existing.actorIds.includes(row.actorId))
-        existing.actorIds.push(row.actorId)
+      if (!existing.actorIds.includes(row.actorId)) existing.actorIds.push(row.actorId)
     }
   }
 
@@ -272,38 +250,30 @@ feedRoute.get("/network", requireHandle(), async (c) => {
     .slice(0, limit)
 
   const ids = merged.map((r) => r.post.id)
-  const [flags, mediaMap, articleMap, repostMapPost, quoteMapPost, pollMap] =
-    await Promise.all([
-      loadViewerFlags(db, me, ids),
-      loadPostMedia(db, ids),
-      loadArticleCards(db, ids),
-      loadRepostTargets({
-        db,
-        viewerId: me,
-        env: mediaEnv,
-        repostRows: merged.map((r) => ({
-          id: r.post.id,
-          repostOfId: r.post.repostOfId,
-        })),
-      }),
-      loadQuoteTargets({
-        db,
-        viewerId: me,
-        env: mediaEnv,
-        quoteRows: merged.map((r) => ({
-          id: r.post.id,
-          quoteOfId: r.post.quoteOfId,
-        })),
-      }),
-      loadPolls(db, me, ids),
-    ])
+  const [flags, mediaMap, articleMap, repostMapPost, quoteMapPost, pollMap] = await Promise.all([
+    loadViewerFlags(db, me, ids),
+    loadPostMedia(db, ids),
+    loadArticleCards(db, ids),
+    loadRepostTargets({
+      db,
+      viewerId: me,
+      env: mediaEnv,
+      repostRows: merged.map((r) => ({ id: r.post.id, repostOfId: r.post.repostOfId })),
+    }),
+    loadQuoteTargets({
+      db,
+      viewerId: me,
+      env: mediaEnv,
+      quoteRows: merged.map((r) => ({ id: r.post.id, quoteOfId: r.post.quoteOfId })),
+    }),
+    loadPolls(db, me, ids),
+  ])
   const unfurlCardsMapNetwork = await loadUnfurlCards(db, ids, articleMap)
   // Pull the triggering actors' handles for the "Lucas + 2 others liked this"
   // banner. We cap at 3 ids per post; the count beyond that is shown as
   // "+N others" in the UI.
   const allActorIds = new Set<string>()
-  for (const r of merged)
-    for (const id of r.actorIds.slice(0, 3)) allActorIds.add(id)
+  for (const r of merged) for (const id of r.actorIds.slice(0, 3)) allActorIds.add(id)
   const actorMap = new Map<
     string,
     { id: string; handle: string | null; displayName: string | null }
@@ -335,7 +305,7 @@ feedRoute.get("/network", requireHandle(), async (c) => {
       unfurlCardsMapNetwork.get(r.post.id),
       repostMapPost.get(r.post.id),
       quoteMapPost.get(r.post.id),
-      pollMap.get(r.post.id)
+      pollMap.get(r.post.id),
     ),
     networkActors: r.actorIds
       .slice(0, 3)
@@ -346,9 +316,7 @@ feedRoute.get("/network", requireHandle(), async (c) => {
   }))
   await attachReplyParents({ db, viewerId: me, env: mediaEnv, posts })
   const nextCursor =
-    posts.length === limit
-      ? merged[merged.length - 1]!.activityAt.toISOString()
-      : null
+    posts.length === limit ? merged[merged.length - 1]!.activityAt.toISOString() : null
   // Suppress unused TTL constant warning (kept for future caching hooks).
   void NETWORK_FEED_TTL_SEC
   return c.json({ posts, nextCursor })

--- a/apps/api/src/routes/feed.ts
+++ b/apps/api/src/routes/feed.ts
@@ -8,7 +8,7 @@ import { loadPostMedia } from '../lib/post-media.ts'
 import { loadArticleCards } from '../lib/article-cards.ts'
 import { loadRepostTargets } from '../lib/repost-targets.ts'
 import { loadQuoteTargets } from '../lib/quote-targets.ts'
-import { attachFeedChainPreviews } from '../lib/feed-chain-preview.ts'
+import { attachFeedChainPreviews, filterChainIntermediates } from '../lib/feed-chain-preview.ts'
 import { attachReplyParents } from '../lib/reply-parents.ts'
 import { loadPolls } from '../lib/polls.ts'
 import { loadUnfurlCards } from '../lib/unfurl-cards.ts'
@@ -104,8 +104,10 @@ feedRoute.get('/', requireHandle(), async (c) => {
   )
   await attachReplyParents({ db, viewerId: me, env: mediaEnv, posts })
   await attachFeedChainPreviews({ db, viewerId: me, env: mediaEnv, posts })
-  const nextCursor = posts.length === limit ? posts[posts.length - 1]!.createdAt : null
-  const response = { posts, nextCursor }
+  const filtered = filterChainIntermediates(posts)
+  const hasMore = rows.length === limit
+  const nextCursor = hasMore ? rows[rows.length - 1]!.post.createdAt.toISOString() : null
+  const response = { posts: filtered, nextCursor }
 
   if (cacheable) {
     await cache.set(homeFeedCacheKey(me), response, HOME_FEED_TTL_SEC)

--- a/apps/api/src/routes/feed.ts
+++ b/apps/api/src/routes/feed.ts
@@ -1,18 +1,22 @@
-import { Hono } from 'hono'
-import { and, desc, eq, inArray, isNull, lt, sql } from '@workspace/db'
-import { schema } from '@workspace/db'
-import { requireHandle, type HonoEnv } from '../middleware/session.ts'
-import { toPostDto } from '../lib/post-dto.ts'
-import { loadViewerFlags } from '../lib/viewer-flags.ts'
-import { loadPostMedia } from '../lib/post-media.ts'
-import { loadArticleCards } from '../lib/article-cards.ts'
-import { loadRepostTargets } from '../lib/repost-targets.ts'
-import { loadQuoteTargets } from '../lib/quote-targets.ts'
-import { attachFeedChainPreviews, linkSamePageReplies, filterChainIntermediates } from '../lib/feed-chain-preview.ts'
-import { attachReplyParents } from '../lib/reply-parents.ts'
-import { loadPolls } from '../lib/polls.ts'
-import { loadUnfurlCards } from '../lib/unfurl-cards.ts'
-import { parseCursor } from '../lib/cursor.ts'
+import { Hono } from "hono"
+import { and, desc, eq, inArray, isNull, lt, sql } from "@workspace/db"
+import { schema } from "@workspace/db"
+import { requireHandle, type HonoEnv } from "../middleware/session.ts"
+import { toPostDto } from "../lib/post-dto.ts"
+import { loadViewerFlags } from "../lib/viewer-flags.ts"
+import { loadPostMedia } from "../lib/post-media.ts"
+import { loadArticleCards } from "../lib/article-cards.ts"
+import { loadRepostTargets } from "../lib/repost-targets.ts"
+import { loadQuoteTargets } from "../lib/quote-targets.ts"
+import {
+  attachFeedChainPreviews,
+  linkSamePageReplies,
+  filterRedundantChainPosts,
+} from "../lib/feed-chain-preview.ts"
+import { attachReplyParents } from "../lib/reply-parents.ts"
+import { loadPolls } from "../lib/polls.ts"
+import { loadUnfurlCards } from "../lib/unfurl-cards.ts"
+import { parseCursor } from "../lib/cursor.ts"
 
 export const feedRoute = new Hono<HonoEnv>()
 
@@ -33,21 +37,23 @@ export function profileFeedCacheKey(authorId: string) {
 }
 
 // Home feed: reverse-chrono from follows, excluding blocks and muted-feed users.
-feedRoute.get('/', requireHandle(), async (c) => {
-  const session = c.get('session')!
-  const { db, mediaEnv, cache, rateLimit } = c.get('ctx')
-  await rateLimit(c, 'reads.feed')
-  const limit = Math.min(Number(c.req.query('limit') ?? 40), 100)
-  const cursor = parseCursor(c.req.query('cursor'))
+feedRoute.get("/", requireHandle(), async (c) => {
+  const session = c.get("session")!
+  const { db, mediaEnv, cache, rateLimit } = c.get("ctx")
+  await rateLimit(c, "reads.feed")
+  const limit = Math.min(Number(c.req.query("limit") ?? 40), 100)
+  const cursor = parseCursor(c.req.query("cursor"))
   const me = session.user.id
 
   // Cache only page 0 (no cursor) with default limit. Deeper pages are rarely fetched and
   // caching every (cursor, limit) combo isn't worth the keyspace.
   const cacheable = !cursor && limit === 40
   if (cacheable) {
-    const hit = await cache.get<{ posts: unknown; nextCursor: string | null }>(homeFeedCacheKey(me))
+    const hit = await cache.get<{ posts: unknown; nextCursor: string | null }>(
+      homeFeedCacheKey(me)
+    )
     if (hit) {
-      c.header('x-cache', 'hit')
+      c.header("x-cache", "hit")
       return c.json(hit)
     }
   }
@@ -56,38 +62,48 @@ feedRoute.get('/', requireHandle(), async (c) => {
     .select({ post: schema.posts, author: schema.users })
     .from(schema.posts)
     .innerJoin(schema.users, eq(schema.users.id, schema.posts.authorId))
-    .innerJoin(schema.follows, eq(schema.follows.followeeId, schema.posts.authorId))
+    .innerJoin(
+      schema.follows,
+      eq(schema.follows.followeeId, schema.posts.authorId)
+    )
     .where(
       and(
         eq(schema.follows.followerId, me),
         isNull(schema.posts.deletedAt),
         cursor ? lt(schema.posts.createdAt, cursor) : undefined,
         sql`NOT EXISTS (SELECT 1 FROM ${schema.blocks} b WHERE (b.blocker_id = ${me} AND b.blocked_id = ${schema.posts.authorId}) OR (b.blocker_id = ${schema.posts.authorId} AND b.blocked_id = ${me}))`,
-        sql`NOT EXISTS (SELECT 1 FROM ${schema.mutes} m WHERE m.muter_id = ${me} AND m.muted_id = ${schema.posts.authorId} AND (m.scope = 'feed' OR m.scope = 'both'))`,
-      ),
+        sql`NOT EXISTS (SELECT 1 FROM ${schema.mutes} m WHERE m.muter_id = ${me} AND m.muted_id = ${schema.posts.authorId} AND (m.scope = 'feed' OR m.scope = 'both'))`
+      )
     )
     .orderBy(desc(schema.posts.createdAt))
     .limit(limit)
 
   const ids = rows.map((r) => r.post.id)
-  const [flags, mediaMap, articleMap, repostMap, quoteMap, pollMap] = await Promise.all([
-    loadViewerFlags(db, me, ids),
-    loadPostMedia(db, ids),
-    loadArticleCards(db, ids),
-    loadRepostTargets({
-      db,
-      viewerId: me,
-      env: mediaEnv,
-      repostRows: rows.map((r) => ({ id: r.post.id, repostOfId: r.post.repostOfId })),
-    }),
-    loadQuoteTargets({
-      db,
-      viewerId: me,
-      env: mediaEnv,
-      quoteRows: rows.map((r) => ({ id: r.post.id, quoteOfId: r.post.quoteOfId })),
-    }),
-    loadPolls(db, me, ids),
-  ])
+  const [flags, mediaMap, articleMap, repostMap, quoteMap, pollMap] =
+    await Promise.all([
+      loadViewerFlags(db, me, ids),
+      loadPostMedia(db, ids),
+      loadArticleCards(db, ids),
+      loadRepostTargets({
+        db,
+        viewerId: me,
+        env: mediaEnv,
+        repostRows: rows.map((r) => ({
+          id: r.post.id,
+          repostOfId: r.post.repostOfId,
+        })),
+      }),
+      loadQuoteTargets({
+        db,
+        viewerId: me,
+        env: mediaEnv,
+        quoteRows: rows.map((r) => ({
+          id: r.post.id,
+          quoteOfId: r.post.quoteOfId,
+        })),
+      }),
+      loadPolls(db, me, ids),
+    ])
   const unfurlCardsMap = await loadUnfurlCards(db, ids, articleMap)
   const posts = rows.map((r) =>
     toPostDto(
@@ -99,20 +115,22 @@ feedRoute.get('/', requireHandle(), async (c) => {
       unfurlCardsMap.get(r.post.id),
       repostMap.get(r.post.id),
       quoteMap.get(r.post.id),
-      pollMap.get(r.post.id),
-    ),
+      pollMap.get(r.post.id)
+    )
   )
   await attachReplyParents({ db, viewerId: me, env: mediaEnv, posts })
   await attachFeedChainPreviews({ db, viewerId: me, env: mediaEnv, posts })
   linkSamePageReplies(posts)
-  const filtered = filterChainIntermediates(posts)
+  const filtered = filterRedundantChainPosts(posts)
   const hasMore = rows.length === limit
-  const nextCursor = hasMore ? rows[rows.length - 1]!.post.createdAt.toISOString() : null
+  const nextCursor = hasMore
+    ? rows[rows.length - 1]!.post.createdAt.toISOString()
+    : null
   const response = { posts: filtered, nextCursor }
 
   if (cacheable) {
     await cache.set(homeFeedCacheKey(me), response, HOME_FEED_TTL_SEC)
-    c.header('x-cache', 'miss')
+    c.header("x-cache", "miss")
   }
   return c.json(response)
 })
@@ -123,12 +141,12 @@ feedRoute.get('/', requireHandle(), async (c) => {
 // viewer's blocks/mutes and any post by a blocked author.
 const NETWORK_FEED_TTL_SEC = 60
 
-feedRoute.get('/network', requireHandle(), async (c) => {
-  const session = c.get('session')!
-  const { db, mediaEnv, rateLimit } = c.get('ctx')
-  await rateLimit(c, 'reads.feed')
-  const limit = Math.min(Number(c.req.query('limit') ?? 40), 100)
-  const cursor = parseCursor(c.req.query('cursor'))
+feedRoute.get("/network", requireHandle(), async (c) => {
+  const session = c.get("session")!
+  const { db, mediaEnv, rateLimit } = c.get("ctx")
+  await rateLimit(c, "reads.feed")
+  const limit = Math.min(Number(c.req.query("limit") ?? 40), 100)
+  const cursor = parseCursor(c.req.query("cursor"))
   const me = session.user.id
 
   // The activity that surfaced the post is one of: a like by a follow,
@@ -155,23 +173,23 @@ feedRoute.get('/network', requireHandle(), async (c) => {
       schema.follows,
       and(
         eq(schema.follows.followerId, me),
-        eq(schema.follows.followeeId, schema.likes.userId),
-      ),
+        eq(schema.follows.followeeId, schema.likes.userId)
+      )
     )
     .innerJoin(schema.posts, eq(schema.posts.id, schema.likes.postId))
     .innerJoin(schema.users, eq(schema.users.id, schema.posts.authorId))
     .where(
       and(
         isNull(schema.posts.deletedAt),
-        eq(schema.posts.visibility, 'public'),
+        eq(schema.posts.visibility, "public"),
         // Skip posts by people the viewer already follows; those belong on
         // the home feed. Skip viewer's own posts too.
         sql`NOT EXISTS (SELECT 1 FROM ${schema.follows} ff WHERE ff.follower_id = ${me} AND ff.followee_id = ${schema.posts.authorId})`,
         sql`${schema.posts.authorId} <> ${me}`,
         sql`NOT EXISTS (SELECT 1 FROM ${schema.blocks} b WHERE (b.blocker_id = ${me} AND b.blocked_id = ${schema.posts.authorId}) OR (b.blocker_id = ${schema.posts.authorId} AND b.blocked_id = ${me}))`,
         sql`NOT EXISTS (SELECT 1 FROM ${schema.mutes} m WHERE m.muter_id = ${me} AND m.muted_id = ${schema.posts.authorId} AND (m.scope = 'feed' OR m.scope = 'both'))`,
-        cursor ? lt(schema.likes.createdAt, cursor) : undefined,
-      ),
+        cursor ? lt(schema.likes.createdAt, cursor) : undefined
+      )
     )
     .orderBy(desc(schema.likes.createdAt))
     .limit(limit * 2)
@@ -182,8 +200,8 @@ feedRoute.get('/network', requireHandle(), async (c) => {
     .select({
       post: schema.posts,
       author: schema.users,
-      activityAt: sql<Date>`reposters.created_at`.as('activity_at'),
-      actorId: sql<string>`reposters.author_id`.as('actor_id'),
+      activityAt: sql<Date>`reposters.created_at`.as("activity_at"),
+      actorId: sql<string>`reposters.author_id`.as("actor_id"),
     })
     .from(
       sql`(
@@ -196,19 +214,19 @@ feedRoute.get('/network', requireHandle(), async (c) => {
           ${cursor ? sql`AND r.created_at < ${cursor}` : sql``}
         ORDER BY r.created_at DESC
         LIMIT ${limit * 2}
-      ) reposters`,
+      ) reposters`
     )
     .innerJoin(schema.posts, sql`${schema.posts.id} = reposters.post_id`)
     .innerJoin(schema.users, eq(schema.users.id, schema.posts.authorId))
     .where(
       and(
         isNull(schema.posts.deletedAt),
-        eq(schema.posts.visibility, 'public'),
+        eq(schema.posts.visibility, "public"),
         sql`NOT EXISTS (SELECT 1 FROM ${schema.follows} ff WHERE ff.follower_id = ${me} AND ff.followee_id = ${schema.posts.authorId})`,
         sql`${schema.posts.authorId} <> ${me}`,
         sql`NOT EXISTS (SELECT 1 FROM ${schema.blocks} b WHERE (b.blocker_id = ${me} AND b.blocked_id = ${schema.posts.authorId}) OR (b.blocker_id = ${schema.posts.authorId} AND b.blocked_id = ${me}))`,
-        sql`NOT EXISTS (SELECT 1 FROM ${schema.mutes} m WHERE m.muter_id = ${me} AND m.muted_id = ${schema.posts.authorId} AND (m.scope = 'feed' OR m.scope = 'both'))`,
-      ),
+        sql`NOT EXISTS (SELECT 1 FROM ${schema.mutes} m WHERE m.muter_id = ${me} AND m.muted_id = ${schema.posts.authorId} AND (m.scope = 'feed' OR m.scope = 'both'))`
+      )
     )
 
   // Merge by post id, keeping the most recent activity for ordering and
@@ -225,13 +243,16 @@ feedRoute.get('/network', requireHandle(), async (c) => {
         actorIds: [row.actorId],
       })
     } else {
-      if (row.activityAt > existing.activityAt) existing.activityAt = row.activityAt
-      if (!existing.actorIds.includes(row.actorId)) existing.actorIds.push(row.actorId)
+      if (row.activityAt > existing.activityAt)
+        existing.activityAt = row.activityAt
+      if (!existing.actorIds.includes(row.actorId))
+        existing.actorIds.push(row.actorId)
     }
   }
   for (const row of repostRows) {
     const existing = byId.get(row.post.id)
-    const at = row.activityAt instanceof Date ? row.activityAt : new Date(row.activityAt)
+    const at =
+      row.activityAt instanceof Date ? row.activityAt : new Date(row.activityAt)
     if (!existing) {
       byId.set(row.post.id, {
         post: row.post,
@@ -241,7 +262,8 @@ feedRoute.get('/network', requireHandle(), async (c) => {
       })
     } else {
       if (at > existing.activityAt) existing.activityAt = at
-      if (!existing.actorIds.includes(row.actorId)) existing.actorIds.push(row.actorId)
+      if (!existing.actorIds.includes(row.actorId))
+        existing.actorIds.push(row.actorId)
     }
   }
 
@@ -250,30 +272,38 @@ feedRoute.get('/network', requireHandle(), async (c) => {
     .slice(0, limit)
 
   const ids = merged.map((r) => r.post.id)
-  const [flags, mediaMap, articleMap, repostMapPost, quoteMapPost, pollMap] = await Promise.all([
-    loadViewerFlags(db, me, ids),
-    loadPostMedia(db, ids),
-    loadArticleCards(db, ids),
-    loadRepostTargets({
-      db,
-      viewerId: me,
-      env: mediaEnv,
-      repostRows: merged.map((r) => ({ id: r.post.id, repostOfId: r.post.repostOfId })),
-    }),
-    loadQuoteTargets({
-      db,
-      viewerId: me,
-      env: mediaEnv,
-      quoteRows: merged.map((r) => ({ id: r.post.id, quoteOfId: r.post.quoteOfId })),
-    }),
-    loadPolls(db, me, ids),
-  ])
+  const [flags, mediaMap, articleMap, repostMapPost, quoteMapPost, pollMap] =
+    await Promise.all([
+      loadViewerFlags(db, me, ids),
+      loadPostMedia(db, ids),
+      loadArticleCards(db, ids),
+      loadRepostTargets({
+        db,
+        viewerId: me,
+        env: mediaEnv,
+        repostRows: merged.map((r) => ({
+          id: r.post.id,
+          repostOfId: r.post.repostOfId,
+        })),
+      }),
+      loadQuoteTargets({
+        db,
+        viewerId: me,
+        env: mediaEnv,
+        quoteRows: merged.map((r) => ({
+          id: r.post.id,
+          quoteOfId: r.post.quoteOfId,
+        })),
+      }),
+      loadPolls(db, me, ids),
+    ])
   const unfurlCardsMapNetwork = await loadUnfurlCards(db, ids, articleMap)
   // Pull the triggering actors' handles for the "Lucas + 2 others liked this"
   // banner. We cap at 3 ids per post; the count beyond that is shown as
   // "+N others" in the UI.
   const allActorIds = new Set<string>()
-  for (const r of merged) for (const id of r.actorIds.slice(0, 3)) allActorIds.add(id)
+  for (const r of merged)
+    for (const id of r.actorIds.slice(0, 3)) allActorIds.add(id)
   const actorMap = new Map<
     string,
     { id: string; handle: string | null; displayName: string | null }
@@ -305,7 +335,7 @@ feedRoute.get('/network', requireHandle(), async (c) => {
       unfurlCardsMapNetwork.get(r.post.id),
       repostMapPost.get(r.post.id),
       quoteMapPost.get(r.post.id),
-      pollMap.get(r.post.id),
+      pollMap.get(r.post.id)
     ),
     networkActors: r.actorIds
       .slice(0, 3)
@@ -316,7 +346,9 @@ feedRoute.get('/network', requireHandle(), async (c) => {
   }))
   await attachReplyParents({ db, viewerId: me, env: mediaEnv, posts })
   const nextCursor =
-    posts.length === limit ? merged[merged.length - 1]!.activityAt.toISOString() : null
+    posts.length === limit
+      ? merged[merged.length - 1]!.activityAt.toISOString()
+      : null
   // Suppress unused TTL constant warning (kept for future caching hooks).
   void NETWORK_FEED_TTL_SEC
   return c.json({ posts, nextCursor })

--- a/apps/api/src/routes/feed.ts
+++ b/apps/api/src/routes/feed.ts
@@ -8,7 +8,7 @@ import { loadPostMedia } from '../lib/post-media.ts'
 import { loadArticleCards } from '../lib/article-cards.ts'
 import { loadRepostTargets } from '../lib/repost-targets.ts'
 import { loadQuoteTargets } from '../lib/quote-targets.ts'
-import { attachFeedChainPreviews, filterChainIntermediates } from '../lib/feed-chain-preview.ts'
+import { attachFeedChainPreviews, linkSamePageReplies, filterChainIntermediates } from '../lib/feed-chain-preview.ts'
 import { attachReplyParents } from '../lib/reply-parents.ts'
 import { loadPolls } from '../lib/polls.ts'
 import { loadUnfurlCards } from '../lib/unfurl-cards.ts'
@@ -104,6 +104,7 @@ feedRoute.get('/', requireHandle(), async (c) => {
   )
   await attachReplyParents({ db, viewerId: me, env: mediaEnv, posts })
   await attachFeedChainPreviews({ db, viewerId: me, env: mediaEnv, posts })
+  linkSamePageReplies(posts)
   const filtered = filterChainIntermediates(posts)
   const hasMore = rows.length === limit
   const nextCursor = hasMore ? rows[rows.length - 1]!.post.createdAt.toISOString() : null

--- a/apps/api/src/routes/posts.ts
+++ b/apps/api/src/routes/posts.ts
@@ -2,7 +2,11 @@ import { Hono } from 'hono'
 import { and, asc, desc, eq, inArray, isNull, lt, sql } from '@workspace/db'
 import { schema } from '@workspace/db'
 import { publicUrl } from '@workspace/media/s3'
-import { createPostSchema, editPostSchema } from '@workspace/validators'
+import {
+  createPostSchema,
+  editPostSchema,
+  paginationSchema,
+} from '@workspace/validators'
 import { handleRateLimitError } from '@workspace/rate-limit'
 import { requireHandle, type HonoEnv } from '../middleware/session.ts'
 import { toPostDto } from '../lib/post-dto.ts'
@@ -918,8 +922,11 @@ postsRoute.get('/', async (c) => {
   const { db, mediaEnv, rateLimit } = c.get('ctx')
   await rateLimit(c, 'reads.feed')
   const viewerId = c.get('session')?.user.id
-  const limit = Math.min(Number(c.req.query('limit') ?? 40), 100)
-  const cursor = parseCursor(c.req.query('cursor'))
+  const { limit, cursor: cursorRaw } = paginationSchema.parse({
+    limit: c.req.query('limit'),
+    cursor: c.req.query('cursor'),
+  })
+  const cursor = parseCursor(cursorRaw)
 
   const rows = await db
     .select({ post: schema.posts, author: schema.users })
@@ -972,8 +979,11 @@ postsRoute.get('/', async (c) => {
   await attachFeedChainPreviews({ db, viewerId, env: mediaEnv, posts })
   linkSamePageReplies(posts)
   const filtered = filterRedundantChainPosts(posts)
-  const hasMore = rows.length === limit
-  const nextCursor = hasMore ? rows[rows.length - 1]!.post.createdAt.toISOString() : null
+  const hasMore = limit > 0 && rows.length === limit
+  const nextCursor =
+    hasMore && rows.length > 0
+      ? rows[rows.length - 1].post.createdAt.toISOString()
+      : null
   return c.json({ posts: filtered, nextCursor })
 })
 

--- a/apps/api/src/routes/posts.ts
+++ b/apps/api/src/routes/posts.ts
@@ -1,65 +1,85 @@
-import { Hono } from 'hono'
-import { and, asc, desc, eq, inArray, isNull, lt, sql } from '@workspace/db'
-import { schema } from '@workspace/db'
-import { publicUrl } from '@workspace/media/s3'
-import { createPostSchema, editPostSchema } from '@workspace/validators'
-import { handleRateLimitError } from '@workspace/rate-limit'
-import { requireHandle, type HonoEnv } from '../middleware/session.ts'
-import { toPostDto } from '../lib/post-dto.ts'
-import { loadViewerFlags } from '../lib/viewer-flags.ts'
-import { loadPostMedia } from '../lib/post-media.ts'
-import { loadArticleCards } from '../lib/article-cards.ts'
-import { loadRepostTargets } from '../lib/repost-targets.ts'
-import { loadQuoteTargets } from '../lib/quote-targets.ts'
-import { attachFeedChainPreviews, linkSamePageReplies, filterChainIntermediates } from '../lib/feed-chain-preview.ts'
-import { attachReplyParents } from '../lib/reply-parents.ts'
-import { loadPolls } from '../lib/polls.ts'
-import { linkHashtags } from '../lib/hashtags.ts'
-import { linkMentions } from '../lib/mentions.ts'
-import { notify, invalidateUnreadCounts } from '../lib/notify.ts'
-import { parseCursor } from '../lib/cursor.ts'
-import { homeFeedCacheKey, profileFeedCacheKey } from './feed.ts'
-import { attachPostUnfurls, runInlineUnfurls } from '../lib/post-unfurls.ts'
-import { loadUnfurlCards } from '../lib/unfurl-cards.ts'
+import { Hono } from "hono"
+import { and, asc, desc, eq, inArray, isNull, lt, sql } from "@workspace/db"
+import { schema } from "@workspace/db"
+import { publicUrl } from "@workspace/media/s3"
+import { createPostSchema, editPostSchema } from "@workspace/validators"
+import { handleRateLimitError } from "@workspace/rate-limit"
+import { requireHandle, type HonoEnv } from "../middleware/session.ts"
+import { toPostDto } from "../lib/post-dto.ts"
+import { loadViewerFlags } from "../lib/viewer-flags.ts"
+import { loadPostMedia } from "../lib/post-media.ts"
+import { loadArticleCards } from "../lib/article-cards.ts"
+import { loadRepostTargets } from "../lib/repost-targets.ts"
+import { loadQuoteTargets } from "../lib/quote-targets.ts"
+import {
+  attachFeedChainPreviews,
+  linkSamePageReplies,
+  filterRedundantChainPosts,
+} from "../lib/feed-chain-preview.ts"
+import { attachReplyParents } from "../lib/reply-parents.ts"
+import { loadPolls } from "../lib/polls.ts"
+import { linkHashtags } from "../lib/hashtags.ts"
+import { linkMentions } from "../lib/mentions.ts"
+import { notify, invalidateUnreadCounts } from "../lib/notify.ts"
+import { parseCursor } from "../lib/cursor.ts"
+import { homeFeedCacheKey, profileFeedCacheKey } from "./feed.ts"
+import { attachPostUnfurls, runInlineUnfurls } from "../lib/post-unfurls.ts"
+import { loadUnfurlCards } from "../lib/unfurl-cards.ts"
 
 export const postsRoute = new Hono<HonoEnv>()
 
 const EDIT_WINDOW_MS = 5 * 60 * 1000
 
 // Create a post (top-level, reply, or quote).
-postsRoute.post('/', requireHandle(), async (c) => {
-  const session = c.get('session')!
-  const { db, cache, rateLimit, moderate, log, mediaEnv } = c.get('ctx')
+postsRoute.post("/", requireHandle(), async (c) => {
+  const session = c.get("session")!
+  const { db, cache, rateLimit, moderate, log, mediaEnv } = c.get("ctx")
   const body = createPostSchema.parse(await c.req.json())
-  await rateLimit(c, body.replyToId ? 'posts.reply' : 'posts.create')
+  await rateLimit(c, body.replyToId ? "posts.reply" : "posts.create")
 
   let imageUrls: string[] = []
   if (body.mediaIds && body.mediaIds.length > 0) {
     const rows = await db
-      .select({ kind: schema.media.kind, originalKey: schema.media.originalKey })
+      .select({
+        kind: schema.media.kind,
+        originalKey: schema.media.originalKey,
+      })
       .from(schema.media)
       .where(
         and(
           inArray(schema.media.id, body.mediaIds),
-          eq(schema.media.ownerId, session.user.id),
-        ),
+          eq(schema.media.ownerId, session.user.id)
+        )
       )
     imageUrls = rows
-      .filter((r) => r.kind === 'image' || r.kind === 'gif')
+      .filter((r) => r.kind === "image" || r.kind === "gif")
       .map((r) => publicUrl(mediaEnv, r.originalKey))
   }
 
   const verdict = await moderate(body.text, imageUrls)
-  if (verdict.verdict === 'block') {
+  if (verdict.verdict === "block") {
     log.info(
-      { userId: session.user.id, categories: verdict.categories, hadImages: imageUrls.length > 0 },
-      'post_blocked_by_moderation',
+      {
+        userId: session.user.id,
+        categories: verdict.categories,
+        hadImages: imageUrls.length > 0,
+      },
+      "post_blocked_by_moderation"
     )
-    return c.json({ error: 'moderation_blocked', message: verdict.message }, 422)
+    return c.json(
+      { error: "moderation_blocked", message: verdict.message },
+      422
+    )
   }
 
   if (body.replyToId && body.quoteOfId) {
-    return c.json({ error: 'invalid_combo', message: 'reply and quote are mutually exclusive' }, 400)
+    return c.json(
+      {
+        error: "invalid_combo",
+        message: "reply and quote are mutually exclusive",
+      },
+      400
+    )
   }
 
   const result = await db.transaction(async (tx) => {
@@ -73,9 +93,14 @@ postsRoute.post('/', requireHandle(), async (c) => {
       const [parent] = await tx
         .select()
         .from(schema.posts)
-        .where(and(eq(schema.posts.id, body.replyToId), isNull(schema.posts.deletedAt)))
+        .where(
+          and(
+            eq(schema.posts.id, body.replyToId),
+            isNull(schema.posts.deletedAt)
+          )
+        )
         .limit(1)
-      if (!parent) throw new HttpError(404, 'reply_target_not_found')
+      if (!parent) throw new HttpError(404, "reply_target_not_found")
 
       replyToId = parent.id
       rootId = parent.rootId ?? parent.id
@@ -96,30 +121,32 @@ postsRoute.post('/', requireHandle(), async (c) => {
               .where(eq(schema.posts.id, rootPostId))
               .limit(1)
       if (root && root.authorId !== session.user.id) {
-        if (root.replyRestriction === 'following') {
+        if (root.replyRestriction === "following") {
           const [followRow] = await tx
             .select({ x: sql<number>`1` })
             .from(schema.follows)
             .where(
               and(
                 eq(schema.follows.followerId, root.authorId),
-                eq(schema.follows.followeeId, session.user.id),
-              ),
+                eq(schema.follows.followeeId, session.user.id)
+              )
             )
             .limit(1)
-          if (!followRow) throw new HttpError(403, 'replies_limited_to_following')
-        } else if (root.replyRestriction === 'mentioned') {
+          if (!followRow)
+            throw new HttpError(403, "replies_limited_to_following")
+        } else if (root.replyRestriction === "mentioned") {
           const [mentionRow] = await tx
             .select({ x: sql<number>`1` })
             .from(schema.mentions)
             .where(
               and(
                 eq(schema.mentions.postId, root.id),
-                eq(schema.mentions.mentionedUserId, session.user.id),
-              ),
+                eq(schema.mentions.mentionedUserId, session.user.id)
+              )
             )
             .limit(1)
-          if (!mentionRow) throw new HttpError(403, 'replies_limited_to_mentioned')
+          if (!mentionRow)
+            throw new HttpError(403, "replies_limited_to_mentioned")
         }
       }
 
@@ -134,9 +161,14 @@ postsRoute.post('/', requireHandle(), async (c) => {
       const [target] = await tx
         .select({ id: schema.posts.id, authorId: schema.posts.authorId })
         .from(schema.posts)
-        .where(and(eq(schema.posts.id, body.quoteOfId), isNull(schema.posts.deletedAt)))
+        .where(
+          and(
+            eq(schema.posts.id, body.quoteOfId),
+            isNull(schema.posts.deletedAt)
+          )
+        )
         .limit(1)
-      if (!target) throw new HttpError(404, 'quote_target_not_found')
+      if (!target) throw new HttpError(404, "quote_target_not_found")
       quoteOfId = target.id
       quoteTargetAuthorId = target.authorId
       await tx
@@ -161,7 +193,7 @@ postsRoute.post('/', requireHandle(), async (c) => {
         contentWarning: body.contentWarning,
       })
       .returning()
-    if (!post) throw new HttpError(500, 'insert_failed')
+    if (!post) throw new HttpError(500, "insert_failed")
 
     if (body.mediaIds && body.mediaIds.length > 0) {
       const ownedMedia = await tx
@@ -170,19 +202,19 @@ postsRoute.post('/', requireHandle(), async (c) => {
         .where(
           and(
             inArray(schema.media.id, body.mediaIds),
-            eq(schema.media.ownerId, session.user.id),
-          ),
+            eq(schema.media.ownerId, session.user.id)
+          )
         )
       const ownedSet = new Set(ownedMedia.map((m) => m.id))
       const invalid = body.mediaIds.filter((id) => !ownedSet.has(id))
-      if (invalid.length > 0) throw new HttpError(400, 'invalid_media_ids')
+      if (invalid.length > 0) throw new HttpError(400, "invalid_media_ids")
 
       await tx.insert(schema.postMedia).values(
         body.mediaIds.map((mediaId, position) => ({
           postId: post.id,
           mediaId,
           position,
-        })),
+        }))
       )
     }
 
@@ -196,18 +228,23 @@ postsRoute.post('/', requireHandle(), async (c) => {
           allowMultiple: body.poll.allowMultiple,
         })
         .returning({ id: schema.polls.id })
-      if (!pollRow) throw new HttpError(500, 'poll_insert_failed')
+      if (!pollRow) throw new HttpError(500, "poll_insert_failed")
       await tx.insert(schema.pollOptions).values(
         body.poll.options.map((text, position) => ({
           pollId: pollRow.id,
           position,
           text: text.trim(),
-        })),
+        }))
       )
     }
 
     await linkHashtags(tx, post.id, post.text)
-    const mentionedUserIds = await linkMentions(tx, post.id, session.user.id, post.text)
+    const mentionedUserIds = await linkMentions(
+      tx,
+      post.id,
+      session.user.id,
+      post.text
+    )
     const { toEnqueue: unfurlJobs } = await attachPostUnfurls({
       tx: tx as never,
       postId: post.id,
@@ -222,8 +259,8 @@ postsRoute.post('/', requireHandle(), async (c) => {
       toNotify.push({
         userId: replyTargetAuthorId,
         actorId: session.user.id,
-        kind: 'reply',
-        entityType: 'post',
+        kind: "reply",
+        entityType: "post",
         entityId: post.id,
       })
       notifiedForStructure.add(replyTargetAuthorId)
@@ -232,8 +269,8 @@ postsRoute.post('/', requireHandle(), async (c) => {
       toNotify.push({
         userId: quoteTargetAuthorId,
         actorId: session.user.id,
-        kind: 'quote',
-        entityType: 'post',
+        kind: "quote",
+        entityType: "post",
         entityId: post.id,
       })
       notifiedForStructure.add(quoteTargetAuthorId)
@@ -243,15 +280,19 @@ postsRoute.post('/', requireHandle(), async (c) => {
       toNotify.push({
         userId: uid,
         actorId: session.user.id,
-        kind: 'mention',
-        entityType: 'post',
+        kind: "mention",
+        entityType: "post",
         entityId: post.id,
       })
     }
     const notified = await notify(tx, toNotify)
 
-    const [author] = await tx.select().from(schema.users).where(eq(schema.users.id, post.authorId)).limit(1)
-    if (!author) throw new HttpError(500, 'author_missing')
+    const [author] = await tx
+      .select()
+      .from(schema.users)
+      .where(eq(schema.users.id, post.authorId))
+      .limit(1)
+    if (!author) throw new HttpError(500, "author_missing")
 
     return { post, author, notified, unfurlJobs }
   })
@@ -262,32 +303,38 @@ postsRoute.post('/', requireHandle(), async (c) => {
   // create response — runInlineUnfurls falls back to the worker on per-ref timeout. Done
   // after the tx commits so a rollback can't leave behind half-fetched rows.
   await Promise.all([
-    cache.del(homeFeedCacheKey(session.user.id), profileFeedCacheKey(session.user.id)),
+    cache.del(
+      homeFeedCacheKey(session.user.id),
+      profileFeedCacheKey(session.user.id)
+    ),
     invalidateUnreadCounts(cache, result.notified),
-    runInlineUnfurls(db, c.get('ctx').boss, result.unfurlJobs, {
-      youtubeApiKey: c.get('ctx').env.YOUTUBE_API_KEY,
-      fxtwitterApiBaseUrl: c.get('ctx').env.FXTWITTER_API_BASE_URL,
+    runInlineUnfurls(db, c.get("ctx").boss, result.unfurlJobs, {
+      youtubeApiKey: c.get("ctx").env.YOUTUBE_API_KEY,
+      fxtwitterApiBaseUrl: c.get("ctx").env.FXTWITTER_API_BASE_URL,
     }),
   ])
 
-  const env = c.get('ctx').mediaEnv
-  const [mediaMap, articleMap, repostMap, quoteMap, pollMap] = await Promise.all([
-    loadPostMedia(db, [result.post.id]),
-    loadArticleCards(db, [result.post.id]),
-    loadRepostTargets({
-      db,
-      viewerId: session.user.id,
-      env,
-      repostRows: [{ id: result.post.id, repostOfId: result.post.repostOfId }],
-    }),
-    loadQuoteTargets({
-      db,
-      viewerId: session.user.id,
-      env,
-      quoteRows: [{ id: result.post.id, quoteOfId: result.post.quoteOfId }],
-    }),
-    loadPolls(db, session.user.id, [result.post.id]),
-  ])
+  const env = c.get("ctx").mediaEnv
+  const [mediaMap, articleMap, repostMap, quoteMap, pollMap] =
+    await Promise.all([
+      loadPostMedia(db, [result.post.id]),
+      loadArticleCards(db, [result.post.id]),
+      loadRepostTargets({
+        db,
+        viewerId: session.user.id,
+        env,
+        repostRows: [
+          { id: result.post.id, repostOfId: result.post.repostOfId },
+        ],
+      }),
+      loadQuoteTargets({
+        db,
+        viewerId: session.user.id,
+        env,
+        quoteRows: [{ id: result.post.id, quoteOfId: result.post.quoteOfId }],
+      }),
+      loadPolls(db, session.user.id, [result.post.id]),
+    ])
   const unfurlCardsMap = await loadUnfurlCards(db, [result.post.id], articleMap)
   const dto = toPostDto(
     result.post,
@@ -298,10 +345,10 @@ postsRoute.post('/', requireHandle(), async (c) => {
     unfurlCardsMap.get(result.post.id),
     repostMap.get(result.post.id),
     quoteMap.get(result.post.id),
-    pollMap.get(result.post.id),
+    pollMap.get(result.post.id)
   )
   await attachReplyParents({ db, viewerId: session.user.id, env, posts: [dto] })
-  c.get('ctx').track('post_created', session.user.id, {
+  c.get("ctx").track("post_created", session.user.id, {
     has_media: !!body.mediaIds?.length,
     has_poll: !!body.poll,
     is_reply: !!body.replyToId,
@@ -311,11 +358,11 @@ postsRoute.post('/', requireHandle(), async (c) => {
 })
 
 // Repost (creates a posts row with repostOfId set, empty text).
-postsRoute.post('/:id/repost', requireHandle(), async (c) => {
-  const session = c.get('session')!
-  const { db, cache, rateLimit } = c.get('ctx')
-  const id = c.req.param('id')
-  await rateLimit(c, 'posts.repost')
+postsRoute.post("/:id/repost", requireHandle(), async (c) => {
+  const session = c.get("session")!
+  const { db, cache, rateLimit } = c.get("ctx")
+  const id = c.req.param("id")
+  await rateLimit(c, "posts.repost")
 
   const result = await db.transaction(async (tx) => {
     const [target] = await tx
@@ -323,7 +370,7 @@ postsRoute.post('/:id/repost', requireHandle(), async (c) => {
       .from(schema.posts)
       .where(and(eq(schema.posts.id, id), isNull(schema.posts.deletedAt)))
       .limit(1)
-    if (!target) throw new HttpError(404, 'not_found')
+    if (!target) throw new HttpError(404, "not_found")
 
     const [existing] = await tx
       .select({ id: schema.posts.id })
@@ -332,15 +379,15 @@ postsRoute.post('/:id/repost', requireHandle(), async (c) => {
         and(
           eq(schema.posts.authorId, session.user.id),
           eq(schema.posts.repostOfId, target.id),
-          isNull(schema.posts.deletedAt),
-        ),
+          isNull(schema.posts.deletedAt)
+        )
       )
       .limit(1)
     if (existing) return { notified: new Set<string>() }
 
     await tx.insert(schema.posts).values({
       authorId: session.user.id,
-      text: '',
+      text: "",
       repostOfId: target.id,
     })
 
@@ -353,8 +400,8 @@ postsRoute.post('/:id/repost', requireHandle(), async (c) => {
       {
         userId: target.authorId,
         actorId: session.user.id,
-        kind: 'repost',
-        entityType: 'post',
+        kind: "repost",
+        entityType: "post",
         entityId: target.id,
       },
     ])
@@ -362,17 +409,20 @@ postsRoute.post('/:id/repost', requireHandle(), async (c) => {
   })
 
   await Promise.all([
-    cache.del(homeFeedCacheKey(session.user.id), profileFeedCacheKey(session.user.id)),
+    cache.del(
+      homeFeedCacheKey(session.user.id),
+      profileFeedCacheKey(session.user.id)
+    ),
     invalidateUnreadCounts(cache, result.notified),
   ])
-  c.get('ctx').track('post_reposted', session.user.id)
+  c.get("ctx").track("post_reposted", session.user.id)
   return c.json({ ok: true })
 })
 
-postsRoute.delete('/:id/repost', requireHandle(), async (c) => {
-  const session = c.get('session')!
-  const { db } = c.get('ctx')
-  const id = c.req.param('id')
+postsRoute.delete("/:id/repost", requireHandle(), async (c) => {
+  const session = c.get("session")!
+  const { db } = c.get("ctx")
+  const id = c.req.param("id")
 
   await db.transaction(async (tx) => {
     const [existing] = await tx
@@ -382,28 +432,31 @@ postsRoute.delete('/:id/repost', requireHandle(), async (c) => {
         and(
           eq(schema.posts.authorId, session.user.id),
           eq(schema.posts.repostOfId, id),
-          isNull(schema.posts.deletedAt),
-        ),
+          isNull(schema.posts.deletedAt)
+        )
       )
       .limit(1)
     if (!existing) return
-    await tx.update(schema.posts).set({ deletedAt: new Date() }).where(eq(schema.posts.id, existing.id))
+    await tx
+      .update(schema.posts)
+      .set({ deletedAt: new Date() })
+      .where(eq(schema.posts.id, existing.id))
     await tx
       .update(schema.posts)
       .set({ repostCount: sql`GREATEST(${schema.posts.repostCount} - 1, 0)` })
       .where(eq(schema.posts.id, id))
   })
 
-  c.get('ctx').track('post_unreposted', session.user.id)
+  c.get("ctx").track("post_unreposted", session.user.id)
   return c.json({ ok: true })
 })
 
 // Like / unlike.
-postsRoute.post('/:id/like', requireHandle(), async (c) => {
-  const session = c.get('session')!
-  const { db, rateLimit } = c.get('ctx')
-  const id = c.req.param('id')
-  await rateLimit(c, 'posts.like')
+postsRoute.post("/:id/like", requireHandle(), async (c) => {
+  const session = c.get("session")!
+  const { db, rateLimit } = c.get("ctx")
+  const id = c.req.param("id")
+  await rateLimit(c, "posts.like")
 
   const notified = await db.transaction(async (tx) => {
     const inserted = await tx
@@ -430,36 +483,41 @@ postsRoute.post('/:id/like', requireHandle(), async (c) => {
         and(
           eq(schema.notifications.userId, target.authorId),
           eq(schema.notifications.actorId, session.user.id),
-          eq(schema.notifications.kind, 'like'),
-          eq(schema.notifications.entityType, 'post'),
-          eq(schema.notifications.entityId, id),
-        ),
+          eq(schema.notifications.kind, "like"),
+          eq(schema.notifications.entityType, "post"),
+          eq(schema.notifications.entityId, id)
+        )
       )
     return notify(tx, [
       {
         userId: target.authorId,
         actorId: session.user.id,
-        kind: 'like',
-        entityType: 'post',
+        kind: "like",
+        entityType: "post",
         entityId: id,
       },
     ])
   })
 
-  await invalidateUnreadCounts(c.get('ctx').cache, notified)
-  c.get('ctx').track('post_liked', session.user.id)
+  await invalidateUnreadCounts(c.get("ctx").cache, notified)
+  c.get("ctx").track("post_liked", session.user.id)
   return c.json({ ok: true })
 })
 
-postsRoute.delete('/:id/like', requireHandle(), async (c) => {
-  const session = c.get('session')!
-  const { db } = c.get('ctx')
-  const id = c.req.param('id')
+postsRoute.delete("/:id/like", requireHandle(), async (c) => {
+  const session = c.get("session")!
+  const { db } = c.get("ctx")
+  const id = c.req.param("id")
 
   await db.transaction(async (tx) => {
     const deleted = await tx
       .delete(schema.likes)
-      .where(and(eq(schema.likes.userId, session.user.id), eq(schema.likes.postId, id)))
+      .where(
+        and(
+          eq(schema.likes.userId, session.user.id),
+          eq(schema.likes.postId, id)
+        )
+      )
       .returning({ postId: schema.likes.postId })
     if (deleted.length > 0) {
       await tx
@@ -469,16 +527,16 @@ postsRoute.delete('/:id/like', requireHandle(), async (c) => {
     }
   })
 
-  c.get('ctx').track('post_unliked', session.user.id)
+  c.get("ctx").track("post_unliked", session.user.id)
   return c.json({ ok: true })
 })
 
 // Bookmark / unbookmark.
-postsRoute.post('/:id/bookmark', requireHandle(), async (c) => {
-  const session = c.get('session')!
-  const { db, rateLimit } = c.get('ctx')
-  const id = c.req.param('id')
-  await rateLimit(c, 'posts.bookmark')
+postsRoute.post("/:id/bookmark", requireHandle(), async (c) => {
+  const session = c.get("session")!
+  const { db, rateLimit } = c.get("ctx")
+  const id = c.req.param("id")
+  await rateLimit(c, "posts.bookmark")
 
   await db.transaction(async (tx) => {
     const inserted = await tx
@@ -494,55 +552,61 @@ postsRoute.post('/:id/bookmark', requireHandle(), async (c) => {
     }
   })
 
-  c.get('ctx').track('post_bookmarked', session.user.id)
+  c.get("ctx").track("post_bookmarked", session.user.id)
   return c.json({ ok: true })
 })
 
-postsRoute.delete('/:id/bookmark', requireHandle(), async (c) => {
-  const session = c.get('session')!
-  const { db } = c.get('ctx')
-  const id = c.req.param('id')
+postsRoute.delete("/:id/bookmark", requireHandle(), async (c) => {
+  const session = c.get("session")!
+  const { db } = c.get("ctx")
+  const id = c.req.param("id")
 
   await db.transaction(async (tx) => {
     const deleted = await tx
       .delete(schema.bookmarks)
-      .where(and(eq(schema.bookmarks.userId, session.user.id), eq(schema.bookmarks.postId, id)))
+      .where(
+        and(
+          eq(schema.bookmarks.userId, session.user.id),
+          eq(schema.bookmarks.postId, id)
+        )
+      )
       .returning({ postId: schema.bookmarks.postId })
     if (deleted.length > 0) {
       await tx
         .update(schema.posts)
-        .set({ bookmarkCount: sql`GREATEST(${schema.posts.bookmarkCount} - 1, 0)` })
+        .set({
+          bookmarkCount: sql`GREATEST(${schema.posts.bookmarkCount} - 1, 0)`,
+        })
         .where(eq(schema.posts.id, id))
     }
   })
 
-  c.get('ctx').track('post_unbookmarked', session.user.id)
+  c.get("ctx").track("post_unbookmarked", session.user.id)
   return c.json({ ok: true })
 })
 
 // Thread: ancestors + target + immediate replies.
 const THREAD_MAX_ANCESTORS = 30
 
-postsRoute.get('/:id/thread', async (c) => {
-  const { db, rateLimit } = c.get('ctx')
-  await rateLimit(c, 'reads.thread')
-  const viewerId = c.get('session')?.user.id
-  const id = c.req.param('id')
+postsRoute.get("/:id/thread", async (c) => {
+  const { db, rateLimit } = c.get("ctx")
+  await rateLimit(c, "reads.thread")
+  const viewerId = c.get("session")?.user.id
+  const id = c.req.param("id")
 
   const [target] = await db
     .select()
     .from(schema.posts)
     .where(and(eq(schema.posts.id, id), isNull(schema.posts.deletedAt)))
     .limit(1)
-  if (!target) return c.json({ error: 'not_found' }, 404)
+  if (!target) return c.json({ error: "not_found" }, 404)
 
   // Walk ancestors via a single recursive CTE instead of N sequential round-trips. Bounded
   // depth keeps the planner honest for pathological reply chains. The `depth` column orders
   // results child-first; we reverse to render root-first.
   type AncestorIdRow = { id: string; depth: number }
   const ancestorRows: Array<AncestorIdRow> = target.replyToId
-    ? ((
-        await db.execute(sql<{ id: string; depth: number }>`
+    ? ((await db.execute(sql<{ id: string; depth: number }>`
           WITH RECURSIVE ancestors(id, reply_to_id, depth) AS (
             SELECT id, reply_to_id, 0
               FROM posts
@@ -554,8 +618,7 @@ postsRoute.get('/:id/thread', async (c) => {
               WHERE p.deleted_at IS NULL AND a.depth < ${THREAD_MAX_ANCESTORS - 1}
           )
           SELECT id, depth FROM ancestors ORDER BY depth DESC
-        `)
-      ) as unknown as Array<AncestorIdRow>)
+        `)) as unknown as Array<AncestorIdRow>)
     : []
   const ancestorIds = ancestorRows.map((r) => r.id)
 
@@ -564,7 +627,12 @@ postsRoute.get('/:id/thread', async (c) => {
         .select({ post: schema.posts, author: schema.users })
         .from(schema.posts)
         .innerJoin(schema.users, eq(schema.users.id, schema.posts.authorId))
-        .where(and(inArray(schema.posts.id, ancestorIds), isNull(schema.posts.deletedAt)))
+        .where(
+          and(
+            inArray(schema.posts.id, ancestorIds),
+            isNull(schema.posts.deletedAt)
+          )
+        )
     : []
 
   const [targetWithAuthor] = await db
@@ -578,7 +646,9 @@ postsRoute.get('/:id/thread', async (c) => {
     .select({ post: schema.posts, author: schema.users })
     .from(schema.posts)
     .innerJoin(schema.users, eq(schema.users.id, schema.posts.authorId))
-    .where(and(eq(schema.posts.replyToId, target.id), isNull(schema.posts.deletedAt)))
+    .where(
+      and(eq(schema.posts.replyToId, target.id), isNull(schema.posts.deletedAt))
+    )
     .orderBy(asc(schema.posts.createdAt))
     .limit(100)
 
@@ -597,33 +667,44 @@ postsRoute.get('/:id/thread', async (c) => {
       .where(
         and(
           inArray(schema.posts.replyToId, replyIds),
-          isNull(schema.posts.deletedAt),
-        ),
+          isNull(schema.posts.deletedAt)
+        )
       )
       .groupBy(schema.posts.replyToId)
     for (const r of rows) if (r.id) descendantCounts.set(r.id, r.n)
   }
 
-  const allIds = [...ancestorPostRows.map((r) => r.post.id), target.id, ...replies.map((r) => r.post.id)]
-  const env = c.get('ctx').mediaEnv
+  const allIds = [
+    ...ancestorPostRows.map((r) => r.post.id),
+    target.id,
+    ...replies.map((r) => r.post.id),
+  ]
+  const env = c.get("ctx").mediaEnv
   const allRepostRows = [
-    ...ancestorPostRows.map((r) => ({ id: r.post.id, repostOfId: r.post.repostOfId })),
+    ...ancestorPostRows.map((r) => ({
+      id: r.post.id,
+      repostOfId: r.post.repostOfId,
+    })),
     { id: target.id, repostOfId: target.repostOfId },
     ...replies.map((r) => ({ id: r.post.id, repostOfId: r.post.repostOfId })),
   ]
   const allQuoteRows = [
-    ...ancestorPostRows.map((r) => ({ id: r.post.id, quoteOfId: r.post.quoteOfId })),
+    ...ancestorPostRows.map((r) => ({
+      id: r.post.id,
+      quoteOfId: r.post.quoteOfId,
+    })),
     { id: target.id, quoteOfId: target.quoteOfId },
     ...replies.map((r) => ({ id: r.post.id, quoteOfId: r.post.quoteOfId })),
   ]
-  const [flags, mediaMap, articleMap, repostMap, quoteMap, pollMap] = await Promise.all([
-    loadViewerFlags(db, viewerId, allIds),
-    loadPostMedia(db, allIds),
-    loadArticleCards(db, allIds),
-    loadRepostTargets({ db, viewerId, env, repostRows: allRepostRows }),
-    loadQuoteTargets({ db, viewerId, env, quoteRows: allQuoteRows }),
-    loadPolls(db, viewerId, allIds),
-  ])
+  const [flags, mediaMap, articleMap, repostMap, quoteMap, pollMap] =
+    await Promise.all([
+      loadViewerFlags(db, viewerId, allIds),
+      loadPostMedia(db, allIds),
+      loadArticleCards(db, allIds),
+      loadRepostTargets({ db, viewerId, env, repostRows: allRepostRows }),
+      loadQuoteTargets({ db, viewerId, env, quoteRows: allQuoteRows }),
+      loadPolls(db, viewerId, allIds),
+    ])
   const unfurlCardsMap = await loadUnfurlCards(db, allIds, articleMap)
 
   const byId = new Map(ancestorPostRows.map((r) => [r.post.id, r]))
@@ -640,8 +721,8 @@ postsRoute.get('/:id/thread', async (c) => {
         unfurlCardsMap.get(r.post.id),
         repostMap.get(r.post.id),
         quoteMap.get(r.post.id),
-        pollMap.get(r.post.id),
-      ),
+        pollMap.get(r.post.id)
+      )
     ),
     post: targetWithAuthor
       ? toPostDto(
@@ -653,7 +734,7 @@ postsRoute.get('/:id/thread', async (c) => {
           unfurlCardsMap.get(target.id),
           repostMap.get(target.id),
           quoteMap.get(target.id),
-          pollMap.get(target.id),
+          pollMap.get(target.id)
         )
       : null,
     replies: replies.map((r) => ({
@@ -666,7 +747,7 @@ postsRoute.get('/:id/thread', async (c) => {
         unfurlCardsMap.get(r.post.id),
         repostMap.get(r.post.id),
         quoteMap.get(r.post.id),
-        pollMap.get(r.post.id),
+        pollMap.get(r.post.id)
       ),
       descendantReplyCount: descendantCounts.get(r.post.id) ?? 0,
     })),
@@ -674,11 +755,11 @@ postsRoute.get('/:id/thread', async (c) => {
 })
 
 // Fetch a single post.
-postsRoute.get('/:id', async (c) => {
-  const { db, mediaEnv, rateLimit } = c.get('ctx')
-  await rateLimit(c, 'reads.thread')
-  const viewerId = c.get('session')?.user.id
-  const id = c.req.param('id')
+postsRoute.get("/:id", async (c) => {
+  const { db, mediaEnv, rateLimit } = c.get("ctx")
+  await rateLimit(c, "reads.thread")
+  const viewerId = c.get("session")?.user.id
+  const id = c.req.param("id")
   const rows = await db
     .select({ post: schema.posts, author: schema.users })
     .from(schema.posts)
@@ -686,25 +767,26 @@ postsRoute.get('/:id', async (c) => {
     .where(and(eq(schema.posts.id, id), isNull(schema.posts.deletedAt)))
     .limit(1)
   const row = rows[0]
-  if (!row) return c.json({ error: 'not_found' }, 404)
-  const [flags, mediaMap, articleMap, repostMap, quoteMap, pollMap] = await Promise.all([
-    loadViewerFlags(db, viewerId, [row.post.id]),
-    loadPostMedia(db, [row.post.id]),
-    loadArticleCards(db, [row.post.id]),
-    loadRepostTargets({
-      db,
-      viewerId,
-      env: mediaEnv,
-      repostRows: [{ id: row.post.id, repostOfId: row.post.repostOfId }],
-    }),
-    loadQuoteTargets({
-      db,
-      viewerId,
-      env: mediaEnv,
-      quoteRows: [{ id: row.post.id, quoteOfId: row.post.quoteOfId }],
-    }),
-    loadPolls(db, viewerId, [row.post.id]),
-  ])
+  if (!row) return c.json({ error: "not_found" }, 404)
+  const [flags, mediaMap, articleMap, repostMap, quoteMap, pollMap] =
+    await Promise.all([
+      loadViewerFlags(db, viewerId, [row.post.id]),
+      loadPostMedia(db, [row.post.id]),
+      loadArticleCards(db, [row.post.id]),
+      loadRepostTargets({
+        db,
+        viewerId,
+        env: mediaEnv,
+        repostRows: [{ id: row.post.id, repostOfId: row.post.repostOfId }],
+      }),
+      loadQuoteTargets({
+        db,
+        viewerId,
+        env: mediaEnv,
+        quoteRows: [{ id: row.post.id, quoteOfId: row.post.quoteOfId }],
+      }),
+      loadPolls(db, viewerId, [row.post.id]),
+    ])
   const unfurlCardsMap = await loadUnfurlCards(db, [row.post.id], articleMap)
   return c.json({
     post: toPostDto(
@@ -716,25 +798,29 @@ postsRoute.get('/:id', async (c) => {
       unfurlCardsMap.get(row.post.id),
       repostMap.get(row.post.id),
       quoteMap.get(row.post.id),
-      pollMap.get(row.post.id),
+      pollMap.get(row.post.id)
     ),
   })
 })
 
 // Edit (within 5 min of creation).
-postsRoute.patch('/:id', requireHandle(), async (c) => {
-  const session = c.get('session')!
-  const { db, rateLimit } = c.get('ctx')
-  await rateLimit(c, 'posts.edit')
-  const id = c.req.param('id')
+postsRoute.patch("/:id", requireHandle(), async (c) => {
+  const session = c.get("session")!
+  const { db, rateLimit } = c.get("ctx")
+  await rateLimit(c, "posts.edit")
+  const id = c.req.param("id")
   const body = editPostSchema.parse(await c.req.json())
 
   const result = await db.transaction(async (tx) => {
-    const [post] = await tx.select().from(schema.posts).where(eq(schema.posts.id, id)).limit(1)
-    if (!post || post.deletedAt) throw new HttpError(404, 'not_found')
-    if (post.authorId !== session.user.id) throw new HttpError(403, 'forbidden')
+    const [post] = await tx
+      .select()
+      .from(schema.posts)
+      .where(eq(schema.posts.id, id))
+      .limit(1)
+    if (!post || post.deletedAt) throw new HttpError(404, "not_found")
+    if (post.authorId !== session.user.id) throw new HttpError(403, "forbidden")
     const ageMs = Date.now() - post.createdAt.getTime()
-    if (ageMs > EDIT_WINDOW_MS) throw new HttpError(409, 'edit_window_expired')
+    if (ageMs > EDIT_WINDOW_MS) throw new HttpError(409, "edit_window_expired")
     if (post.text === body.text) return { post, unchanged: true as const }
 
     await tx.insert(schema.postEdits).values({
@@ -758,34 +844,41 @@ postsRoute.patch('/:id', requireHandle(), async (c) => {
   })
 
   if (!result.unchanged) {
-    await runInlineUnfurls(db, c.get('ctx').boss, result.unfurlJobs, {
-      youtubeApiKey: c.get('ctx').env.YOUTUBE_API_KEY,
-      fxtwitterApiBaseUrl: c.get('ctx').env.FXTWITTER_API_BASE_URL,
+    await runInlineUnfurls(db, c.get("ctx").boss, result.unfurlJobs, {
+      youtubeApiKey: c.get("ctx").env.YOUTUBE_API_KEY,
+      fxtwitterApiBaseUrl: c.get("ctx").env.FXTWITTER_API_BASE_URL,
     })
   }
 
-  const [author] = await db.select().from(schema.users).where(eq(schema.users.id, result.post.authorId)).limit(1)
-  const env = c.get('ctx').mediaEnv
-  const [flags, mediaMap, articleMap, repostMap, quoteMap, pollMap] = await Promise.all([
-    loadViewerFlags(db, session.user.id, [result.post.id]),
-    loadPostMedia(db, [result.post.id]),
-    loadArticleCards(db, [result.post.id]),
-    loadRepostTargets({
-      db,
-      viewerId: session.user.id,
-      env,
-      repostRows: [{ id: result.post.id, repostOfId: result.post.repostOfId }],
-    }),
-    loadQuoteTargets({
-      db,
-      viewerId: session.user.id,
-      env,
-      quoteRows: [{ id: result.post.id, quoteOfId: result.post.quoteOfId }],
-    }),
-    loadPolls(db, session.user.id, [result.post.id]),
-  ])
+  const [author] = await db
+    .select()
+    .from(schema.users)
+    .where(eq(schema.users.id, result.post.authorId))
+    .limit(1)
+  const env = c.get("ctx").mediaEnv
+  const [flags, mediaMap, articleMap, repostMap, quoteMap, pollMap] =
+    await Promise.all([
+      loadViewerFlags(db, session.user.id, [result.post.id]),
+      loadPostMedia(db, [result.post.id]),
+      loadArticleCards(db, [result.post.id]),
+      loadRepostTargets({
+        db,
+        viewerId: session.user.id,
+        env,
+        repostRows: [
+          { id: result.post.id, repostOfId: result.post.repostOfId },
+        ],
+      }),
+      loadQuoteTargets({
+        db,
+        viewerId: session.user.id,
+        env,
+        quoteRows: [{ id: result.post.id, quoteOfId: result.post.quoteOfId }],
+      }),
+      loadPolls(db, session.user.id, [result.post.id]),
+    ])
   const unfurlCardsMap = await loadUnfurlCards(db, [result.post.id], articleMap)
-  c.get('ctx').track('post_edited', session.user.id)
+  c.get("ctx").track("post_edited", session.user.id)
   return c.json({
     post: toPostDto(
       result.post,
@@ -796,7 +889,7 @@ postsRoute.patch('/:id', requireHandle(), async (c) => {
       unfurlCardsMap.get(result.post.id),
       repostMap.get(result.post.id),
       quoteMap.get(result.post.id),
-      pollMap.get(result.post.id),
+      pollMap.get(result.post.id)
     ),
   })
 })
@@ -804,59 +897,70 @@ postsRoute.patch('/:id', requireHandle(), async (c) => {
 // Soft delete (author only). Decrements parent counters.
 // Pin a post to the author's profile. Atomic clear-then-set in a tx so only one pinned post
 // per author exists at a time. Reposts/replies/quotes can't be pinned — only originals.
-postsRoute.post('/:id/pin', requireHandle(), async (c) => {
-  const session = c.get('session')!
-  const { db, rateLimit } = c.get('ctx')
-  await rateLimit(c, 'posts.pin')
-  const id = c.req.param('id')
+postsRoute.post("/:id/pin", requireHandle(), async (c) => {
+  const session = c.get("session")!
+  const { db, rateLimit } = c.get("ctx")
+  await rateLimit(c, "posts.pin")
+  const id = c.req.param("id")
   const me = session.user.id
 
-  const [post] = await db.select().from(schema.posts).where(eq(schema.posts.id, id)).limit(1)
-  if (!post || post.deletedAt) return c.json({ error: 'not_found' }, 404)
-  if (post.authorId !== me) return c.json({ error: 'forbidden' }, 403)
+  const [post] = await db
+    .select()
+    .from(schema.posts)
+    .where(eq(schema.posts.id, id))
+    .limit(1)
+  if (!post || post.deletedAt) return c.json({ error: "not_found" }, 404)
+  if (post.authorId !== me) return c.json({ error: "forbidden" }, 403)
   if (post.replyToId || post.repostOfId || post.quoteOfId) {
-    return c.json({ error: 'pin_originals_only' }, 400)
+    return c.json({ error: "pin_originals_only" }, 400)
   }
 
   await db.transaction(async (tx) => {
     await tx
       .update(schema.posts)
       .set({ pinnedAt: null })
-      .where(and(eq(schema.posts.authorId, me), sql`${schema.posts.pinnedAt} IS NOT NULL`))
+      .where(
+        and(
+          eq(schema.posts.authorId, me),
+          sql`${schema.posts.pinnedAt} IS NOT NULL`
+        )
+      )
     await tx
       .update(schema.posts)
       .set({ pinnedAt: new Date() })
       .where(eq(schema.posts.id, id))
   })
-  c.get('ctx').track('post_pinned', session.user.id)
+  c.get("ctx").track("post_pinned", session.user.id)
   return c.json({ ok: true })
 })
 
-postsRoute.delete('/:id/pin', requireHandle(), async (c) => {
-  const session = c.get('session')!
-  const { db, rateLimit } = c.get('ctx')
-  await rateLimit(c, 'posts.pin')
-  const id = c.req.param('id')
+postsRoute.delete("/:id/pin", requireHandle(), async (c) => {
+  const session = c.get("session")!
+  const { db, rateLimit } = c.get("ctx")
+  await rateLimit(c, "posts.pin")
+  const id = c.req.param("id")
   await db
     .update(schema.posts)
     .set({ pinnedAt: null })
-    .where(and(eq(schema.posts.id, id), eq(schema.posts.authorId, session.user.id)))
-  c.get('ctx').track('post_unpinned', session.user.id)
+    .where(
+      and(eq(schema.posts.id, id), eq(schema.posts.authorId, session.user.id))
+    )
+  c.get("ctx").track("post_unpinned", session.user.id)
   return c.json({ ok: true })
 })
 
 // Read the prior versions of a post — newest first. We expose this to anyone
 // who can already see the post (i.e. it isn't deleted) so the "edited" badge
 // can link to a "View edit history" sheet, mirroring X's UX.
-postsRoute.get('/:id/edits', async (c) => {
-  const { db } = c.get('ctx')
-  const id = c.req.param('id')
+postsRoute.get("/:id/edits", async (c) => {
+  const { db } = c.get("ctx")
+  const id = c.req.param("id")
   const [post] = await db
     .select({ id: schema.posts.id, deletedAt: schema.posts.deletedAt })
     .from(schema.posts)
     .where(eq(schema.posts.id, id))
     .limit(1)
-  if (!post || post.deletedAt) return c.json({ error: 'not_found' }, 404)
+  if (!post || post.deletedAt) return c.json({ error: "not_found" }, 404)
   const edits = await db
     .select({
       id: schema.postEdits.id,
@@ -876,17 +980,24 @@ postsRoute.get('/:id/edits', async (c) => {
   })
 })
 
-postsRoute.delete('/:id', requireHandle(), async (c) => {
-  const session = c.get('session')!
-  const { db, cache } = c.get('ctx')
-  const id = c.req.param('id')
+postsRoute.delete("/:id", requireHandle(), async (c) => {
+  const session = c.get("session")!
+  const { db, cache } = c.get("ctx")
+  const id = c.req.param("id")
 
   await db.transaction(async (tx) => {
-    const [post] = await tx.select().from(schema.posts).where(eq(schema.posts.id, id)).limit(1)
-    if (!post || post.deletedAt) throw new HttpError(404, 'not_found')
-    if (post.authorId !== session.user.id) throw new HttpError(403, 'forbidden')
+    const [post] = await tx
+      .select()
+      .from(schema.posts)
+      .where(eq(schema.posts.id, id))
+      .limit(1)
+    if (!post || post.deletedAt) throw new HttpError(404, "not_found")
+    if (post.authorId !== session.user.id) throw new HttpError(403, "forbidden")
 
-    await tx.update(schema.posts).set({ deletedAt: new Date() }).where(eq(schema.posts.id, post.id))
+    await tx
+      .update(schema.posts)
+      .set({ deletedAt: new Date() })
+      .where(eq(schema.posts.id, post.id))
 
     if (post.replyToId) {
       await tx
@@ -909,17 +1020,17 @@ postsRoute.delete('/:id', requireHandle(), async (c) => {
   })
 
   await cache.del(homeFeedCacheKey(session.user.id))
-  c.get('ctx').track('post_deleted', session.user.id)
+  c.get("ctx").track("post_deleted", session.user.id)
   return c.json({ ok: true })
 })
 
 // Global public timeline.
-postsRoute.get('/', async (c) => {
-  const { db, mediaEnv, rateLimit } = c.get('ctx')
-  await rateLimit(c, 'reads.feed')
-  const viewerId = c.get('session')?.user.id
-  const limit = Math.min(Number(c.req.query('limit') ?? 40), 100)
-  const cursor = parseCursor(c.req.query('cursor'))
+postsRoute.get("/", async (c) => {
+  const { db, mediaEnv, rateLimit } = c.get("ctx")
+  await rateLimit(c, "reads.feed")
+  const viewerId = c.get("session")?.user.id
+  const limit = Math.min(Number(c.req.query("limit") ?? 40), 100)
+  const cursor = parseCursor(c.req.query("cursor"))
 
   const rows = await db
     .select({ post: schema.posts, author: schema.users })
@@ -928,32 +1039,39 @@ postsRoute.get('/', async (c) => {
     .where(
       and(
         isNull(schema.posts.deletedAt),
-        eq(schema.posts.visibility, 'public'),
-        cursor ? lt(schema.posts.createdAt, cursor) : undefined,
-      ),
+        eq(schema.posts.visibility, "public"),
+        cursor ? lt(schema.posts.createdAt, cursor) : undefined
+      )
     )
     .orderBy(desc(schema.posts.createdAt))
     .limit(limit)
 
   const ids = rows.map((r) => r.post.id)
-  const [flags, mediaMap, articleMap, repostMap, quoteMap, pollMap] = await Promise.all([
-    loadViewerFlags(db, viewerId, ids),
-    loadPostMedia(db, ids),
-    loadArticleCards(db, ids),
-    loadRepostTargets({
-      db,
-      viewerId,
-      env: mediaEnv,
-      repostRows: rows.map((r) => ({ id: r.post.id, repostOfId: r.post.repostOfId })),
-    }),
-    loadQuoteTargets({
-      db,
-      viewerId,
-      env: mediaEnv,
-      quoteRows: rows.map((r) => ({ id: r.post.id, quoteOfId: r.post.quoteOfId })),
-    }),
-    loadPolls(db, viewerId, ids),
-  ])
+  const [flags, mediaMap, articleMap, repostMap, quoteMap, pollMap] =
+    await Promise.all([
+      loadViewerFlags(db, viewerId, ids),
+      loadPostMedia(db, ids),
+      loadArticleCards(db, ids),
+      loadRepostTargets({
+        db,
+        viewerId,
+        env: mediaEnv,
+        repostRows: rows.map((r) => ({
+          id: r.post.id,
+          repostOfId: r.post.repostOfId,
+        })),
+      }),
+      loadQuoteTargets({
+        db,
+        viewerId,
+        env: mediaEnv,
+        quoteRows: rows.map((r) => ({
+          id: r.post.id,
+          quoteOfId: r.post.quoteOfId,
+        })),
+      }),
+      loadPolls(db, viewerId, ids),
+    ])
   const unfurlCardsMap = await loadUnfurlCards(db, ids, articleMap)
   const posts = rows.map((r) =>
     toPostDto(
@@ -965,15 +1083,17 @@ postsRoute.get('/', async (c) => {
       unfurlCardsMap.get(r.post.id),
       repostMap.get(r.post.id),
       quoteMap.get(r.post.id),
-      pollMap.get(r.post.id),
-    ),
+      pollMap.get(r.post.id)
+    )
   )
   await attachReplyParents({ db, viewerId, env: mediaEnv, posts })
   await attachFeedChainPreviews({ db, viewerId, env: mediaEnv, posts })
   linkSamePageReplies(posts)
-  const filtered = filterChainIntermediates(posts)
+  const filtered = filterRedundantChainPosts(posts)
   const hasMore = rows.length === limit
-  const nextCursor = hasMore ? rows[rows.length - 1]!.post.createdAt.toISOString() : null
+  const nextCursor = hasMore
+    ? rows[rows.length - 1]!.post.createdAt.toISOString()
+    : null
   return c.json({ posts: filtered, nextCursor })
 })
 
@@ -982,80 +1102,87 @@ postsRoute.get('/', async (c) => {
 // reply's author still sees it on their own profile and direct links still
 // resolve, but the thread route collapses it behind a "Show hidden replies"
 // affordance — same UX as X.
-postsRoute.post('/:id/hide', requireHandle(), async (c) => {
-  const session = c.get('session')!
-  const { db } = c.get('ctx')
-  const id = c.req.param('id')
+postsRoute.post("/:id/hide", requireHandle(), async (c) => {
+  const session = c.get("session")!
+  const { db } = c.get("ctx")
+  const id = c.req.param("id")
   const [post] = await db
     .select()
     .from(schema.posts)
     .where(and(eq(schema.posts.id, id), isNull(schema.posts.deletedAt)))
     .limit(1)
-  if (!post) return c.json({ error: 'not_found' }, 404)
-  if (!post.replyToId) return c.json({ error: 'cannot_hide_root' }, 400)
+  if (!post) return c.json({ error: "not_found" }, 404)
+  if (!post.replyToId) return c.json({ error: "cannot_hide_root" }, 400)
   const rootId = post.rootId ?? post.replyToId
   const [root] = await db
     .select({ authorId: schema.posts.authorId })
     .from(schema.posts)
     .where(eq(schema.posts.id, rootId))
     .limit(1)
-  if (!root) return c.json({ error: 'not_found' }, 404)
+  if (!root) return c.json({ error: "not_found" }, 404)
   const me = session.user.id
   const [meRow] = await db
     .select({ role: schema.users.role })
     .from(schema.users)
     .where(eq(schema.users.id, me))
     .limit(1)
-  const isMod = meRow?.role === 'admin' || meRow?.role === 'owner'
+  const isMod = meRow?.role === "admin" || meRow?.role === "owner"
   if (root.authorId !== me && !isMod) {
-    return c.json({ error: 'forbidden' }, 403)
+    return c.json({ error: "forbidden" }, 403)
   }
   await db
     .update(schema.posts)
     .set({ hiddenAt: new Date() })
     .where(eq(schema.posts.id, post.id))
-  c.get('ctx').track('post_hidden', session.user.id)
+  c.get("ctx").track("post_hidden", session.user.id)
   return c.json({ ok: true })
 })
 
-postsRoute.delete('/:id/hide', requireHandle(), async (c) => {
-  const session = c.get('session')!
-  const { db } = c.get('ctx')
-  const id = c.req.param('id')
+postsRoute.delete("/:id/hide", requireHandle(), async (c) => {
+  const session = c.get("session")!
+  const { db } = c.get("ctx")
+  const id = c.req.param("id")
   const [post] = await db
-    .select({ id: schema.posts.id, rootId: schema.posts.rootId, replyToId: schema.posts.replyToId })
+    .select({
+      id: schema.posts.id,
+      rootId: schema.posts.rootId,
+      replyToId: schema.posts.replyToId,
+    })
     .from(schema.posts)
     .where(eq(schema.posts.id, id))
     .limit(1)
-  if (!post) return c.json({ error: 'not_found' }, 404)
+  if (!post) return c.json({ error: "not_found" }, 404)
   const rootId = post.rootId ?? post.replyToId
-  if (!rootId) return c.json({ error: 'cannot_hide_root' }, 400)
+  if (!rootId) return c.json({ error: "cannot_hide_root" }, 400)
   const [root] = await db
     .select({ authorId: schema.posts.authorId })
     .from(schema.posts)
     .where(eq(schema.posts.id, rootId))
     .limit(1)
-  if (!root) return c.json({ error: 'not_found' }, 404)
+  if (!root) return c.json({ error: "not_found" }, 404)
   const me = session.user.id
   const [meRow] = await db
     .select({ role: schema.users.role })
     .from(schema.users)
     .where(eq(schema.users.id, me))
     .limit(1)
-  const isMod = meRow?.role === 'admin' || meRow?.role === 'owner'
+  const isMod = meRow?.role === "admin" || meRow?.role === "owner"
   if (root.authorId !== me && !isMod) {
-    return c.json({ error: 'forbidden' }, 403)
+    return c.json({ error: "forbidden" }, 403)
   }
   await db
     .update(schema.posts)
     .set({ hiddenAt: null })
     .where(eq(schema.posts.id, post.id))
-  c.get('ctx').track('post_unhidden', session.user.id)
+  c.get("ctx").track("post_unhidden", session.user.id)
   return c.json({ ok: true })
 })
 
 class HttpError extends Error {
-  constructor(public status: number, public code: string) {
+  constructor(
+    public status: number,
+    public code: string
+  ) {
     super(code)
   }
 }
@@ -1063,7 +1190,8 @@ class HttpError extends Error {
 postsRoute.onError((err, c) => {
   const rl = handleRateLimitError(err, c)
   if (rl) return rl
-  if (err instanceof HttpError) return c.json({ error: err.code }, err.status as never)
+  if (err instanceof HttpError)
+    return c.json({ error: err.code }, err.status as never)
   console.error(err)
-  return c.json({ error: 'internal_error', message: err.message }, 500)
+  return c.json({ error: "internal_error", message: err.message }, 500)
 })

--- a/apps/api/src/routes/posts.ts
+++ b/apps/api/src/routes/posts.ts
@@ -980,10 +980,9 @@ postsRoute.get('/', async (c) => {
   linkSamePageReplies(posts)
   const filtered = filterRedundantChainPosts(posts)
   const hasMore = limit > 0 && rows.length === limit
-  const nextCursor =
-    hasMore && rows.length > 0
-      ? rows[rows.length - 1].post.createdAt.toISOString()
-      : null
+  const nextCursor = hasMore
+    ? (rows.at(-1)?.post.createdAt.toISOString() ?? null)
+    : null
   return c.json({ posts: filtered, nextCursor })
 })
 

--- a/apps/api/src/routes/posts.ts
+++ b/apps/api/src/routes/posts.ts
@@ -1,85 +1,65 @@
-import { Hono } from "hono"
-import { and, asc, desc, eq, inArray, isNull, lt, sql } from "@workspace/db"
-import { schema } from "@workspace/db"
-import { publicUrl } from "@workspace/media/s3"
-import { createPostSchema, editPostSchema } from "@workspace/validators"
-import { handleRateLimitError } from "@workspace/rate-limit"
-import { requireHandle, type HonoEnv } from "../middleware/session.ts"
-import { toPostDto } from "../lib/post-dto.ts"
-import { loadViewerFlags } from "../lib/viewer-flags.ts"
-import { loadPostMedia } from "../lib/post-media.ts"
-import { loadArticleCards } from "../lib/article-cards.ts"
-import { loadRepostTargets } from "../lib/repost-targets.ts"
-import { loadQuoteTargets } from "../lib/quote-targets.ts"
-import {
-  attachFeedChainPreviews,
-  linkSamePageReplies,
-  filterRedundantChainPosts,
-} from "../lib/feed-chain-preview.ts"
-import { attachReplyParents } from "../lib/reply-parents.ts"
-import { loadPolls } from "../lib/polls.ts"
-import { linkHashtags } from "../lib/hashtags.ts"
-import { linkMentions } from "../lib/mentions.ts"
-import { notify, invalidateUnreadCounts } from "../lib/notify.ts"
-import { parseCursor } from "../lib/cursor.ts"
-import { homeFeedCacheKey, profileFeedCacheKey } from "./feed.ts"
-import { attachPostUnfurls, runInlineUnfurls } from "../lib/post-unfurls.ts"
-import { loadUnfurlCards } from "../lib/unfurl-cards.ts"
+import { Hono } from 'hono'
+import { and, asc, desc, eq, inArray, isNull, lt, sql } from '@workspace/db'
+import { schema } from '@workspace/db'
+import { publicUrl } from '@workspace/media/s3'
+import { createPostSchema, editPostSchema } from '@workspace/validators'
+import { handleRateLimitError } from '@workspace/rate-limit'
+import { requireHandle, type HonoEnv } from '../middleware/session.ts'
+import { toPostDto } from '../lib/post-dto.ts'
+import { loadViewerFlags } from '../lib/viewer-flags.ts'
+import { loadPostMedia } from '../lib/post-media.ts'
+import { loadArticleCards } from '../lib/article-cards.ts'
+import { loadRepostTargets } from '../lib/repost-targets.ts'
+import { loadQuoteTargets } from '../lib/quote-targets.ts'
+import { attachFeedChainPreviews, linkSamePageReplies, filterRedundantChainPosts } from '../lib/feed-chain-preview.ts'
+import { attachReplyParents } from '../lib/reply-parents.ts'
+import { loadPolls } from '../lib/polls.ts'
+import { linkHashtags } from '../lib/hashtags.ts'
+import { linkMentions } from '../lib/mentions.ts'
+import { notify, invalidateUnreadCounts } from '../lib/notify.ts'
+import { parseCursor } from '../lib/cursor.ts'
+import { homeFeedCacheKey, profileFeedCacheKey } from './feed.ts'
+import { attachPostUnfurls, runInlineUnfurls } from '../lib/post-unfurls.ts'
+import { loadUnfurlCards } from '../lib/unfurl-cards.ts'
 
 export const postsRoute = new Hono<HonoEnv>()
 
 const EDIT_WINDOW_MS = 5 * 60 * 1000
 
 // Create a post (top-level, reply, or quote).
-postsRoute.post("/", requireHandle(), async (c) => {
-  const session = c.get("session")!
-  const { db, cache, rateLimit, moderate, log, mediaEnv } = c.get("ctx")
+postsRoute.post('/', requireHandle(), async (c) => {
+  const session = c.get('session')!
+  const { db, cache, rateLimit, moderate, log, mediaEnv } = c.get('ctx')
   const body = createPostSchema.parse(await c.req.json())
-  await rateLimit(c, body.replyToId ? "posts.reply" : "posts.create")
+  await rateLimit(c, body.replyToId ? 'posts.reply' : 'posts.create')
 
   let imageUrls: string[] = []
   if (body.mediaIds && body.mediaIds.length > 0) {
     const rows = await db
-      .select({
-        kind: schema.media.kind,
-        originalKey: schema.media.originalKey,
-      })
+      .select({ kind: schema.media.kind, originalKey: schema.media.originalKey })
       .from(schema.media)
       .where(
         and(
           inArray(schema.media.id, body.mediaIds),
-          eq(schema.media.ownerId, session.user.id)
-        )
+          eq(schema.media.ownerId, session.user.id),
+        ),
       )
     imageUrls = rows
-      .filter((r) => r.kind === "image" || r.kind === "gif")
+      .filter((r) => r.kind === 'image' || r.kind === 'gif')
       .map((r) => publicUrl(mediaEnv, r.originalKey))
   }
 
   const verdict = await moderate(body.text, imageUrls)
-  if (verdict.verdict === "block") {
+  if (verdict.verdict === 'block') {
     log.info(
-      {
-        userId: session.user.id,
-        categories: verdict.categories,
-        hadImages: imageUrls.length > 0,
-      },
-      "post_blocked_by_moderation"
+      { userId: session.user.id, categories: verdict.categories, hadImages: imageUrls.length > 0 },
+      'post_blocked_by_moderation',
     )
-    return c.json(
-      { error: "moderation_blocked", message: verdict.message },
-      422
-    )
+    return c.json({ error: 'moderation_blocked', message: verdict.message }, 422)
   }
 
   if (body.replyToId && body.quoteOfId) {
-    return c.json(
-      {
-        error: "invalid_combo",
-        message: "reply and quote are mutually exclusive",
-      },
-      400
-    )
+    return c.json({ error: 'invalid_combo', message: 'reply and quote are mutually exclusive' }, 400)
   }
 
   const result = await db.transaction(async (tx) => {
@@ -93,14 +73,9 @@ postsRoute.post("/", requireHandle(), async (c) => {
       const [parent] = await tx
         .select()
         .from(schema.posts)
-        .where(
-          and(
-            eq(schema.posts.id, body.replyToId),
-            isNull(schema.posts.deletedAt)
-          )
-        )
+        .where(and(eq(schema.posts.id, body.replyToId), isNull(schema.posts.deletedAt)))
         .limit(1)
-      if (!parent) throw new HttpError(404, "reply_target_not_found")
+      if (!parent) throw new HttpError(404, 'reply_target_not_found')
 
       replyToId = parent.id
       rootId = parent.rootId ?? parent.id
@@ -121,32 +96,30 @@ postsRoute.post("/", requireHandle(), async (c) => {
               .where(eq(schema.posts.id, rootPostId))
               .limit(1)
       if (root && root.authorId !== session.user.id) {
-        if (root.replyRestriction === "following") {
+        if (root.replyRestriction === 'following') {
           const [followRow] = await tx
             .select({ x: sql<number>`1` })
             .from(schema.follows)
             .where(
               and(
                 eq(schema.follows.followerId, root.authorId),
-                eq(schema.follows.followeeId, session.user.id)
-              )
+                eq(schema.follows.followeeId, session.user.id),
+              ),
             )
             .limit(1)
-          if (!followRow)
-            throw new HttpError(403, "replies_limited_to_following")
-        } else if (root.replyRestriction === "mentioned") {
+          if (!followRow) throw new HttpError(403, 'replies_limited_to_following')
+        } else if (root.replyRestriction === 'mentioned') {
           const [mentionRow] = await tx
             .select({ x: sql<number>`1` })
             .from(schema.mentions)
             .where(
               and(
                 eq(schema.mentions.postId, root.id),
-                eq(schema.mentions.mentionedUserId, session.user.id)
-              )
+                eq(schema.mentions.mentionedUserId, session.user.id),
+              ),
             )
             .limit(1)
-          if (!mentionRow)
-            throw new HttpError(403, "replies_limited_to_mentioned")
+          if (!mentionRow) throw new HttpError(403, 'replies_limited_to_mentioned')
         }
       }
 
@@ -161,14 +134,9 @@ postsRoute.post("/", requireHandle(), async (c) => {
       const [target] = await tx
         .select({ id: schema.posts.id, authorId: schema.posts.authorId })
         .from(schema.posts)
-        .where(
-          and(
-            eq(schema.posts.id, body.quoteOfId),
-            isNull(schema.posts.deletedAt)
-          )
-        )
+        .where(and(eq(schema.posts.id, body.quoteOfId), isNull(schema.posts.deletedAt)))
         .limit(1)
-      if (!target) throw new HttpError(404, "quote_target_not_found")
+      if (!target) throw new HttpError(404, 'quote_target_not_found')
       quoteOfId = target.id
       quoteTargetAuthorId = target.authorId
       await tx
@@ -193,7 +161,7 @@ postsRoute.post("/", requireHandle(), async (c) => {
         contentWarning: body.contentWarning,
       })
       .returning()
-    if (!post) throw new HttpError(500, "insert_failed")
+    if (!post) throw new HttpError(500, 'insert_failed')
 
     if (body.mediaIds && body.mediaIds.length > 0) {
       const ownedMedia = await tx
@@ -202,19 +170,19 @@ postsRoute.post("/", requireHandle(), async (c) => {
         .where(
           and(
             inArray(schema.media.id, body.mediaIds),
-            eq(schema.media.ownerId, session.user.id)
-          )
+            eq(schema.media.ownerId, session.user.id),
+          ),
         )
       const ownedSet = new Set(ownedMedia.map((m) => m.id))
       const invalid = body.mediaIds.filter((id) => !ownedSet.has(id))
-      if (invalid.length > 0) throw new HttpError(400, "invalid_media_ids")
+      if (invalid.length > 0) throw new HttpError(400, 'invalid_media_ids')
 
       await tx.insert(schema.postMedia).values(
         body.mediaIds.map((mediaId, position) => ({
           postId: post.id,
           mediaId,
           position,
-        }))
+        })),
       )
     }
 
@@ -228,23 +196,18 @@ postsRoute.post("/", requireHandle(), async (c) => {
           allowMultiple: body.poll.allowMultiple,
         })
         .returning({ id: schema.polls.id })
-      if (!pollRow) throw new HttpError(500, "poll_insert_failed")
+      if (!pollRow) throw new HttpError(500, 'poll_insert_failed')
       await tx.insert(schema.pollOptions).values(
         body.poll.options.map((text, position) => ({
           pollId: pollRow.id,
           position,
           text: text.trim(),
-        }))
+        })),
       )
     }
 
     await linkHashtags(tx, post.id, post.text)
-    const mentionedUserIds = await linkMentions(
-      tx,
-      post.id,
-      session.user.id,
-      post.text
-    )
+    const mentionedUserIds = await linkMentions(tx, post.id, session.user.id, post.text)
     const { toEnqueue: unfurlJobs } = await attachPostUnfurls({
       tx: tx as never,
       postId: post.id,
@@ -259,8 +222,8 @@ postsRoute.post("/", requireHandle(), async (c) => {
       toNotify.push({
         userId: replyTargetAuthorId,
         actorId: session.user.id,
-        kind: "reply",
-        entityType: "post",
+        kind: 'reply',
+        entityType: 'post',
         entityId: post.id,
       })
       notifiedForStructure.add(replyTargetAuthorId)
@@ -269,8 +232,8 @@ postsRoute.post("/", requireHandle(), async (c) => {
       toNotify.push({
         userId: quoteTargetAuthorId,
         actorId: session.user.id,
-        kind: "quote",
-        entityType: "post",
+        kind: 'quote',
+        entityType: 'post',
         entityId: post.id,
       })
       notifiedForStructure.add(quoteTargetAuthorId)
@@ -280,19 +243,15 @@ postsRoute.post("/", requireHandle(), async (c) => {
       toNotify.push({
         userId: uid,
         actorId: session.user.id,
-        kind: "mention",
-        entityType: "post",
+        kind: 'mention',
+        entityType: 'post',
         entityId: post.id,
       })
     }
     const notified = await notify(tx, toNotify)
 
-    const [author] = await tx
-      .select()
-      .from(schema.users)
-      .where(eq(schema.users.id, post.authorId))
-      .limit(1)
-    if (!author) throw new HttpError(500, "author_missing")
+    const [author] = await tx.select().from(schema.users).where(eq(schema.users.id, post.authorId)).limit(1)
+    if (!author) throw new HttpError(500, 'author_missing')
 
     return { post, author, notified, unfurlJobs }
   })
@@ -303,38 +262,32 @@ postsRoute.post("/", requireHandle(), async (c) => {
   // create response — runInlineUnfurls falls back to the worker on per-ref timeout. Done
   // after the tx commits so a rollback can't leave behind half-fetched rows.
   await Promise.all([
-    cache.del(
-      homeFeedCacheKey(session.user.id),
-      profileFeedCacheKey(session.user.id)
-    ),
+    cache.del(homeFeedCacheKey(session.user.id), profileFeedCacheKey(session.user.id)),
     invalidateUnreadCounts(cache, result.notified),
-    runInlineUnfurls(db, c.get("ctx").boss, result.unfurlJobs, {
-      youtubeApiKey: c.get("ctx").env.YOUTUBE_API_KEY,
-      fxtwitterApiBaseUrl: c.get("ctx").env.FXTWITTER_API_BASE_URL,
+    runInlineUnfurls(db, c.get('ctx').boss, result.unfurlJobs, {
+      youtubeApiKey: c.get('ctx').env.YOUTUBE_API_KEY,
+      fxtwitterApiBaseUrl: c.get('ctx').env.FXTWITTER_API_BASE_URL,
     }),
   ])
 
-  const env = c.get("ctx").mediaEnv
-  const [mediaMap, articleMap, repostMap, quoteMap, pollMap] =
-    await Promise.all([
-      loadPostMedia(db, [result.post.id]),
-      loadArticleCards(db, [result.post.id]),
-      loadRepostTargets({
-        db,
-        viewerId: session.user.id,
-        env,
-        repostRows: [
-          { id: result.post.id, repostOfId: result.post.repostOfId },
-        ],
-      }),
-      loadQuoteTargets({
-        db,
-        viewerId: session.user.id,
-        env,
-        quoteRows: [{ id: result.post.id, quoteOfId: result.post.quoteOfId }],
-      }),
-      loadPolls(db, session.user.id, [result.post.id]),
-    ])
+  const env = c.get('ctx').mediaEnv
+  const [mediaMap, articleMap, repostMap, quoteMap, pollMap] = await Promise.all([
+    loadPostMedia(db, [result.post.id]),
+    loadArticleCards(db, [result.post.id]),
+    loadRepostTargets({
+      db,
+      viewerId: session.user.id,
+      env,
+      repostRows: [{ id: result.post.id, repostOfId: result.post.repostOfId }],
+    }),
+    loadQuoteTargets({
+      db,
+      viewerId: session.user.id,
+      env,
+      quoteRows: [{ id: result.post.id, quoteOfId: result.post.quoteOfId }],
+    }),
+    loadPolls(db, session.user.id, [result.post.id]),
+  ])
   const unfurlCardsMap = await loadUnfurlCards(db, [result.post.id], articleMap)
   const dto = toPostDto(
     result.post,
@@ -345,10 +298,10 @@ postsRoute.post("/", requireHandle(), async (c) => {
     unfurlCardsMap.get(result.post.id),
     repostMap.get(result.post.id),
     quoteMap.get(result.post.id),
-    pollMap.get(result.post.id)
+    pollMap.get(result.post.id),
   )
   await attachReplyParents({ db, viewerId: session.user.id, env, posts: [dto] })
-  c.get("ctx").track("post_created", session.user.id, {
+  c.get('ctx').track('post_created', session.user.id, {
     has_media: !!body.mediaIds?.length,
     has_poll: !!body.poll,
     is_reply: !!body.replyToId,
@@ -358,11 +311,11 @@ postsRoute.post("/", requireHandle(), async (c) => {
 })
 
 // Repost (creates a posts row with repostOfId set, empty text).
-postsRoute.post("/:id/repost", requireHandle(), async (c) => {
-  const session = c.get("session")!
-  const { db, cache, rateLimit } = c.get("ctx")
-  const id = c.req.param("id")
-  await rateLimit(c, "posts.repost")
+postsRoute.post('/:id/repost', requireHandle(), async (c) => {
+  const session = c.get('session')!
+  const { db, cache, rateLimit } = c.get('ctx')
+  const id = c.req.param('id')
+  await rateLimit(c, 'posts.repost')
 
   const result = await db.transaction(async (tx) => {
     const [target] = await tx
@@ -370,7 +323,7 @@ postsRoute.post("/:id/repost", requireHandle(), async (c) => {
       .from(schema.posts)
       .where(and(eq(schema.posts.id, id), isNull(schema.posts.deletedAt)))
       .limit(1)
-    if (!target) throw new HttpError(404, "not_found")
+    if (!target) throw new HttpError(404, 'not_found')
 
     const [existing] = await tx
       .select({ id: schema.posts.id })
@@ -379,15 +332,15 @@ postsRoute.post("/:id/repost", requireHandle(), async (c) => {
         and(
           eq(schema.posts.authorId, session.user.id),
           eq(schema.posts.repostOfId, target.id),
-          isNull(schema.posts.deletedAt)
-        )
+          isNull(schema.posts.deletedAt),
+        ),
       )
       .limit(1)
     if (existing) return { notified: new Set<string>() }
 
     await tx.insert(schema.posts).values({
       authorId: session.user.id,
-      text: "",
+      text: '',
       repostOfId: target.id,
     })
 
@@ -400,8 +353,8 @@ postsRoute.post("/:id/repost", requireHandle(), async (c) => {
       {
         userId: target.authorId,
         actorId: session.user.id,
-        kind: "repost",
-        entityType: "post",
+        kind: 'repost',
+        entityType: 'post',
         entityId: target.id,
       },
     ])
@@ -409,20 +362,17 @@ postsRoute.post("/:id/repost", requireHandle(), async (c) => {
   })
 
   await Promise.all([
-    cache.del(
-      homeFeedCacheKey(session.user.id),
-      profileFeedCacheKey(session.user.id)
-    ),
+    cache.del(homeFeedCacheKey(session.user.id), profileFeedCacheKey(session.user.id)),
     invalidateUnreadCounts(cache, result.notified),
   ])
-  c.get("ctx").track("post_reposted", session.user.id)
+  c.get('ctx').track('post_reposted', session.user.id)
   return c.json({ ok: true })
 })
 
-postsRoute.delete("/:id/repost", requireHandle(), async (c) => {
-  const session = c.get("session")!
-  const { db } = c.get("ctx")
-  const id = c.req.param("id")
+postsRoute.delete('/:id/repost', requireHandle(), async (c) => {
+  const session = c.get('session')!
+  const { db } = c.get('ctx')
+  const id = c.req.param('id')
 
   await db.transaction(async (tx) => {
     const [existing] = await tx
@@ -432,31 +382,28 @@ postsRoute.delete("/:id/repost", requireHandle(), async (c) => {
         and(
           eq(schema.posts.authorId, session.user.id),
           eq(schema.posts.repostOfId, id),
-          isNull(schema.posts.deletedAt)
-        )
+          isNull(schema.posts.deletedAt),
+        ),
       )
       .limit(1)
     if (!existing) return
-    await tx
-      .update(schema.posts)
-      .set({ deletedAt: new Date() })
-      .where(eq(schema.posts.id, existing.id))
+    await tx.update(schema.posts).set({ deletedAt: new Date() }).where(eq(schema.posts.id, existing.id))
     await tx
       .update(schema.posts)
       .set({ repostCount: sql`GREATEST(${schema.posts.repostCount} - 1, 0)` })
       .where(eq(schema.posts.id, id))
   })
 
-  c.get("ctx").track("post_unreposted", session.user.id)
+  c.get('ctx').track('post_unreposted', session.user.id)
   return c.json({ ok: true })
 })
 
 // Like / unlike.
-postsRoute.post("/:id/like", requireHandle(), async (c) => {
-  const session = c.get("session")!
-  const { db, rateLimit } = c.get("ctx")
-  const id = c.req.param("id")
-  await rateLimit(c, "posts.like")
+postsRoute.post('/:id/like', requireHandle(), async (c) => {
+  const session = c.get('session')!
+  const { db, rateLimit } = c.get('ctx')
+  const id = c.req.param('id')
+  await rateLimit(c, 'posts.like')
 
   const notified = await db.transaction(async (tx) => {
     const inserted = await tx
@@ -483,41 +430,36 @@ postsRoute.post("/:id/like", requireHandle(), async (c) => {
         and(
           eq(schema.notifications.userId, target.authorId),
           eq(schema.notifications.actorId, session.user.id),
-          eq(schema.notifications.kind, "like"),
-          eq(schema.notifications.entityType, "post"),
-          eq(schema.notifications.entityId, id)
-        )
+          eq(schema.notifications.kind, 'like'),
+          eq(schema.notifications.entityType, 'post'),
+          eq(schema.notifications.entityId, id),
+        ),
       )
     return notify(tx, [
       {
         userId: target.authorId,
         actorId: session.user.id,
-        kind: "like",
-        entityType: "post",
+        kind: 'like',
+        entityType: 'post',
         entityId: id,
       },
     ])
   })
 
-  await invalidateUnreadCounts(c.get("ctx").cache, notified)
-  c.get("ctx").track("post_liked", session.user.id)
+  await invalidateUnreadCounts(c.get('ctx').cache, notified)
+  c.get('ctx').track('post_liked', session.user.id)
   return c.json({ ok: true })
 })
 
-postsRoute.delete("/:id/like", requireHandle(), async (c) => {
-  const session = c.get("session")!
-  const { db } = c.get("ctx")
-  const id = c.req.param("id")
+postsRoute.delete('/:id/like', requireHandle(), async (c) => {
+  const session = c.get('session')!
+  const { db } = c.get('ctx')
+  const id = c.req.param('id')
 
   await db.transaction(async (tx) => {
     const deleted = await tx
       .delete(schema.likes)
-      .where(
-        and(
-          eq(schema.likes.userId, session.user.id),
-          eq(schema.likes.postId, id)
-        )
-      )
+      .where(and(eq(schema.likes.userId, session.user.id), eq(schema.likes.postId, id)))
       .returning({ postId: schema.likes.postId })
     if (deleted.length > 0) {
       await tx
@@ -527,16 +469,16 @@ postsRoute.delete("/:id/like", requireHandle(), async (c) => {
     }
   })
 
-  c.get("ctx").track("post_unliked", session.user.id)
+  c.get('ctx').track('post_unliked', session.user.id)
   return c.json({ ok: true })
 })
 
 // Bookmark / unbookmark.
-postsRoute.post("/:id/bookmark", requireHandle(), async (c) => {
-  const session = c.get("session")!
-  const { db, rateLimit } = c.get("ctx")
-  const id = c.req.param("id")
-  await rateLimit(c, "posts.bookmark")
+postsRoute.post('/:id/bookmark', requireHandle(), async (c) => {
+  const session = c.get('session')!
+  const { db, rateLimit } = c.get('ctx')
+  const id = c.req.param('id')
+  await rateLimit(c, 'posts.bookmark')
 
   await db.transaction(async (tx) => {
     const inserted = await tx
@@ -552,61 +494,55 @@ postsRoute.post("/:id/bookmark", requireHandle(), async (c) => {
     }
   })
 
-  c.get("ctx").track("post_bookmarked", session.user.id)
+  c.get('ctx').track('post_bookmarked', session.user.id)
   return c.json({ ok: true })
 })
 
-postsRoute.delete("/:id/bookmark", requireHandle(), async (c) => {
-  const session = c.get("session")!
-  const { db } = c.get("ctx")
-  const id = c.req.param("id")
+postsRoute.delete('/:id/bookmark', requireHandle(), async (c) => {
+  const session = c.get('session')!
+  const { db } = c.get('ctx')
+  const id = c.req.param('id')
 
   await db.transaction(async (tx) => {
     const deleted = await tx
       .delete(schema.bookmarks)
-      .where(
-        and(
-          eq(schema.bookmarks.userId, session.user.id),
-          eq(schema.bookmarks.postId, id)
-        )
-      )
+      .where(and(eq(schema.bookmarks.userId, session.user.id), eq(schema.bookmarks.postId, id)))
       .returning({ postId: schema.bookmarks.postId })
     if (deleted.length > 0) {
       await tx
         .update(schema.posts)
-        .set({
-          bookmarkCount: sql`GREATEST(${schema.posts.bookmarkCount} - 1, 0)`,
-        })
+        .set({ bookmarkCount: sql`GREATEST(${schema.posts.bookmarkCount} - 1, 0)` })
         .where(eq(schema.posts.id, id))
     }
   })
 
-  c.get("ctx").track("post_unbookmarked", session.user.id)
+  c.get('ctx').track('post_unbookmarked', session.user.id)
   return c.json({ ok: true })
 })
 
 // Thread: ancestors + target + immediate replies.
 const THREAD_MAX_ANCESTORS = 30
 
-postsRoute.get("/:id/thread", async (c) => {
-  const { db, rateLimit } = c.get("ctx")
-  await rateLimit(c, "reads.thread")
-  const viewerId = c.get("session")?.user.id
-  const id = c.req.param("id")
+postsRoute.get('/:id/thread', async (c) => {
+  const { db, rateLimit } = c.get('ctx')
+  await rateLimit(c, 'reads.thread')
+  const viewerId = c.get('session')?.user.id
+  const id = c.req.param('id')
 
   const [target] = await db
     .select()
     .from(schema.posts)
     .where(and(eq(schema.posts.id, id), isNull(schema.posts.deletedAt)))
     .limit(1)
-  if (!target) return c.json({ error: "not_found" }, 404)
+  if (!target) return c.json({ error: 'not_found' }, 404)
 
   // Walk ancestors via a single recursive CTE instead of N sequential round-trips. Bounded
   // depth keeps the planner honest for pathological reply chains. The `depth` column orders
   // results child-first; we reverse to render root-first.
   type AncestorIdRow = { id: string; depth: number }
   const ancestorRows: Array<AncestorIdRow> = target.replyToId
-    ? ((await db.execute(sql<{ id: string; depth: number }>`
+    ? ((
+        await db.execute(sql<{ id: string; depth: number }>`
           WITH RECURSIVE ancestors(id, reply_to_id, depth) AS (
             SELECT id, reply_to_id, 0
               FROM posts
@@ -618,7 +554,8 @@ postsRoute.get("/:id/thread", async (c) => {
               WHERE p.deleted_at IS NULL AND a.depth < ${THREAD_MAX_ANCESTORS - 1}
           )
           SELECT id, depth FROM ancestors ORDER BY depth DESC
-        `)) as unknown as Array<AncestorIdRow>)
+        `)
+      ) as unknown as Array<AncestorIdRow>)
     : []
   const ancestorIds = ancestorRows.map((r) => r.id)
 
@@ -627,12 +564,7 @@ postsRoute.get("/:id/thread", async (c) => {
         .select({ post: schema.posts, author: schema.users })
         .from(schema.posts)
         .innerJoin(schema.users, eq(schema.users.id, schema.posts.authorId))
-        .where(
-          and(
-            inArray(schema.posts.id, ancestorIds),
-            isNull(schema.posts.deletedAt)
-          )
-        )
+        .where(and(inArray(schema.posts.id, ancestorIds), isNull(schema.posts.deletedAt)))
     : []
 
   const [targetWithAuthor] = await db
@@ -646,9 +578,7 @@ postsRoute.get("/:id/thread", async (c) => {
     .select({ post: schema.posts, author: schema.users })
     .from(schema.posts)
     .innerJoin(schema.users, eq(schema.users.id, schema.posts.authorId))
-    .where(
-      and(eq(schema.posts.replyToId, target.id), isNull(schema.posts.deletedAt))
-    )
+    .where(and(eq(schema.posts.replyToId, target.id), isNull(schema.posts.deletedAt)))
     .orderBy(asc(schema.posts.createdAt))
     .limit(100)
 
@@ -667,44 +597,33 @@ postsRoute.get("/:id/thread", async (c) => {
       .where(
         and(
           inArray(schema.posts.replyToId, replyIds),
-          isNull(schema.posts.deletedAt)
-        )
+          isNull(schema.posts.deletedAt),
+        ),
       )
       .groupBy(schema.posts.replyToId)
     for (const r of rows) if (r.id) descendantCounts.set(r.id, r.n)
   }
 
-  const allIds = [
-    ...ancestorPostRows.map((r) => r.post.id),
-    target.id,
-    ...replies.map((r) => r.post.id),
-  ]
-  const env = c.get("ctx").mediaEnv
+  const allIds = [...ancestorPostRows.map((r) => r.post.id), target.id, ...replies.map((r) => r.post.id)]
+  const env = c.get('ctx').mediaEnv
   const allRepostRows = [
-    ...ancestorPostRows.map((r) => ({
-      id: r.post.id,
-      repostOfId: r.post.repostOfId,
-    })),
+    ...ancestorPostRows.map((r) => ({ id: r.post.id, repostOfId: r.post.repostOfId })),
     { id: target.id, repostOfId: target.repostOfId },
     ...replies.map((r) => ({ id: r.post.id, repostOfId: r.post.repostOfId })),
   ]
   const allQuoteRows = [
-    ...ancestorPostRows.map((r) => ({
-      id: r.post.id,
-      quoteOfId: r.post.quoteOfId,
-    })),
+    ...ancestorPostRows.map((r) => ({ id: r.post.id, quoteOfId: r.post.quoteOfId })),
     { id: target.id, quoteOfId: target.quoteOfId },
     ...replies.map((r) => ({ id: r.post.id, quoteOfId: r.post.quoteOfId })),
   ]
-  const [flags, mediaMap, articleMap, repostMap, quoteMap, pollMap] =
-    await Promise.all([
-      loadViewerFlags(db, viewerId, allIds),
-      loadPostMedia(db, allIds),
-      loadArticleCards(db, allIds),
-      loadRepostTargets({ db, viewerId, env, repostRows: allRepostRows }),
-      loadQuoteTargets({ db, viewerId, env, quoteRows: allQuoteRows }),
-      loadPolls(db, viewerId, allIds),
-    ])
+  const [flags, mediaMap, articleMap, repostMap, quoteMap, pollMap] = await Promise.all([
+    loadViewerFlags(db, viewerId, allIds),
+    loadPostMedia(db, allIds),
+    loadArticleCards(db, allIds),
+    loadRepostTargets({ db, viewerId, env, repostRows: allRepostRows }),
+    loadQuoteTargets({ db, viewerId, env, quoteRows: allQuoteRows }),
+    loadPolls(db, viewerId, allIds),
+  ])
   const unfurlCardsMap = await loadUnfurlCards(db, allIds, articleMap)
 
   const byId = new Map(ancestorPostRows.map((r) => [r.post.id, r]))
@@ -721,8 +640,8 @@ postsRoute.get("/:id/thread", async (c) => {
         unfurlCardsMap.get(r.post.id),
         repostMap.get(r.post.id),
         quoteMap.get(r.post.id),
-        pollMap.get(r.post.id)
-      )
+        pollMap.get(r.post.id),
+      ),
     ),
     post: targetWithAuthor
       ? toPostDto(
@@ -734,7 +653,7 @@ postsRoute.get("/:id/thread", async (c) => {
           unfurlCardsMap.get(target.id),
           repostMap.get(target.id),
           quoteMap.get(target.id),
-          pollMap.get(target.id)
+          pollMap.get(target.id),
         )
       : null,
     replies: replies.map((r) => ({
@@ -747,7 +666,7 @@ postsRoute.get("/:id/thread", async (c) => {
         unfurlCardsMap.get(r.post.id),
         repostMap.get(r.post.id),
         quoteMap.get(r.post.id),
-        pollMap.get(r.post.id)
+        pollMap.get(r.post.id),
       ),
       descendantReplyCount: descendantCounts.get(r.post.id) ?? 0,
     })),
@@ -755,11 +674,11 @@ postsRoute.get("/:id/thread", async (c) => {
 })
 
 // Fetch a single post.
-postsRoute.get("/:id", async (c) => {
-  const { db, mediaEnv, rateLimit } = c.get("ctx")
-  await rateLimit(c, "reads.thread")
-  const viewerId = c.get("session")?.user.id
-  const id = c.req.param("id")
+postsRoute.get('/:id', async (c) => {
+  const { db, mediaEnv, rateLimit } = c.get('ctx')
+  await rateLimit(c, 'reads.thread')
+  const viewerId = c.get('session')?.user.id
+  const id = c.req.param('id')
   const rows = await db
     .select({ post: schema.posts, author: schema.users })
     .from(schema.posts)
@@ -767,26 +686,25 @@ postsRoute.get("/:id", async (c) => {
     .where(and(eq(schema.posts.id, id), isNull(schema.posts.deletedAt)))
     .limit(1)
   const row = rows[0]
-  if (!row) return c.json({ error: "not_found" }, 404)
-  const [flags, mediaMap, articleMap, repostMap, quoteMap, pollMap] =
-    await Promise.all([
-      loadViewerFlags(db, viewerId, [row.post.id]),
-      loadPostMedia(db, [row.post.id]),
-      loadArticleCards(db, [row.post.id]),
-      loadRepostTargets({
-        db,
-        viewerId,
-        env: mediaEnv,
-        repostRows: [{ id: row.post.id, repostOfId: row.post.repostOfId }],
-      }),
-      loadQuoteTargets({
-        db,
-        viewerId,
-        env: mediaEnv,
-        quoteRows: [{ id: row.post.id, quoteOfId: row.post.quoteOfId }],
-      }),
-      loadPolls(db, viewerId, [row.post.id]),
-    ])
+  if (!row) return c.json({ error: 'not_found' }, 404)
+  const [flags, mediaMap, articleMap, repostMap, quoteMap, pollMap] = await Promise.all([
+    loadViewerFlags(db, viewerId, [row.post.id]),
+    loadPostMedia(db, [row.post.id]),
+    loadArticleCards(db, [row.post.id]),
+    loadRepostTargets({
+      db,
+      viewerId,
+      env: mediaEnv,
+      repostRows: [{ id: row.post.id, repostOfId: row.post.repostOfId }],
+    }),
+    loadQuoteTargets({
+      db,
+      viewerId,
+      env: mediaEnv,
+      quoteRows: [{ id: row.post.id, quoteOfId: row.post.quoteOfId }],
+    }),
+    loadPolls(db, viewerId, [row.post.id]),
+  ])
   const unfurlCardsMap = await loadUnfurlCards(db, [row.post.id], articleMap)
   return c.json({
     post: toPostDto(
@@ -798,29 +716,25 @@ postsRoute.get("/:id", async (c) => {
       unfurlCardsMap.get(row.post.id),
       repostMap.get(row.post.id),
       quoteMap.get(row.post.id),
-      pollMap.get(row.post.id)
+      pollMap.get(row.post.id),
     ),
   })
 })
 
 // Edit (within 5 min of creation).
-postsRoute.patch("/:id", requireHandle(), async (c) => {
-  const session = c.get("session")!
-  const { db, rateLimit } = c.get("ctx")
-  await rateLimit(c, "posts.edit")
-  const id = c.req.param("id")
+postsRoute.patch('/:id', requireHandle(), async (c) => {
+  const session = c.get('session')!
+  const { db, rateLimit } = c.get('ctx')
+  await rateLimit(c, 'posts.edit')
+  const id = c.req.param('id')
   const body = editPostSchema.parse(await c.req.json())
 
   const result = await db.transaction(async (tx) => {
-    const [post] = await tx
-      .select()
-      .from(schema.posts)
-      .where(eq(schema.posts.id, id))
-      .limit(1)
-    if (!post || post.deletedAt) throw new HttpError(404, "not_found")
-    if (post.authorId !== session.user.id) throw new HttpError(403, "forbidden")
+    const [post] = await tx.select().from(schema.posts).where(eq(schema.posts.id, id)).limit(1)
+    if (!post || post.deletedAt) throw new HttpError(404, 'not_found')
+    if (post.authorId !== session.user.id) throw new HttpError(403, 'forbidden')
     const ageMs = Date.now() - post.createdAt.getTime()
-    if (ageMs > EDIT_WINDOW_MS) throw new HttpError(409, "edit_window_expired")
+    if (ageMs > EDIT_WINDOW_MS) throw new HttpError(409, 'edit_window_expired')
     if (post.text === body.text) return { post, unchanged: true as const }
 
     await tx.insert(schema.postEdits).values({
@@ -844,41 +758,34 @@ postsRoute.patch("/:id", requireHandle(), async (c) => {
   })
 
   if (!result.unchanged) {
-    await runInlineUnfurls(db, c.get("ctx").boss, result.unfurlJobs, {
-      youtubeApiKey: c.get("ctx").env.YOUTUBE_API_KEY,
-      fxtwitterApiBaseUrl: c.get("ctx").env.FXTWITTER_API_BASE_URL,
+    await runInlineUnfurls(db, c.get('ctx').boss, result.unfurlJobs, {
+      youtubeApiKey: c.get('ctx').env.YOUTUBE_API_KEY,
+      fxtwitterApiBaseUrl: c.get('ctx').env.FXTWITTER_API_BASE_URL,
     })
   }
 
-  const [author] = await db
-    .select()
-    .from(schema.users)
-    .where(eq(schema.users.id, result.post.authorId))
-    .limit(1)
-  const env = c.get("ctx").mediaEnv
-  const [flags, mediaMap, articleMap, repostMap, quoteMap, pollMap] =
-    await Promise.all([
-      loadViewerFlags(db, session.user.id, [result.post.id]),
-      loadPostMedia(db, [result.post.id]),
-      loadArticleCards(db, [result.post.id]),
-      loadRepostTargets({
-        db,
-        viewerId: session.user.id,
-        env,
-        repostRows: [
-          { id: result.post.id, repostOfId: result.post.repostOfId },
-        ],
-      }),
-      loadQuoteTargets({
-        db,
-        viewerId: session.user.id,
-        env,
-        quoteRows: [{ id: result.post.id, quoteOfId: result.post.quoteOfId }],
-      }),
-      loadPolls(db, session.user.id, [result.post.id]),
-    ])
+  const [author] = await db.select().from(schema.users).where(eq(schema.users.id, result.post.authorId)).limit(1)
+  const env = c.get('ctx').mediaEnv
+  const [flags, mediaMap, articleMap, repostMap, quoteMap, pollMap] = await Promise.all([
+    loadViewerFlags(db, session.user.id, [result.post.id]),
+    loadPostMedia(db, [result.post.id]),
+    loadArticleCards(db, [result.post.id]),
+    loadRepostTargets({
+      db,
+      viewerId: session.user.id,
+      env,
+      repostRows: [{ id: result.post.id, repostOfId: result.post.repostOfId }],
+    }),
+    loadQuoteTargets({
+      db,
+      viewerId: session.user.id,
+      env,
+      quoteRows: [{ id: result.post.id, quoteOfId: result.post.quoteOfId }],
+    }),
+    loadPolls(db, session.user.id, [result.post.id]),
+  ])
   const unfurlCardsMap = await loadUnfurlCards(db, [result.post.id], articleMap)
-  c.get("ctx").track("post_edited", session.user.id)
+  c.get('ctx').track('post_edited', session.user.id)
   return c.json({
     post: toPostDto(
       result.post,
@@ -889,7 +796,7 @@ postsRoute.patch("/:id", requireHandle(), async (c) => {
       unfurlCardsMap.get(result.post.id),
       repostMap.get(result.post.id),
       quoteMap.get(result.post.id),
-      pollMap.get(result.post.id)
+      pollMap.get(result.post.id),
     ),
   })
 })
@@ -897,70 +804,59 @@ postsRoute.patch("/:id", requireHandle(), async (c) => {
 // Soft delete (author only). Decrements parent counters.
 // Pin a post to the author's profile. Atomic clear-then-set in a tx so only one pinned post
 // per author exists at a time. Reposts/replies/quotes can't be pinned — only originals.
-postsRoute.post("/:id/pin", requireHandle(), async (c) => {
-  const session = c.get("session")!
-  const { db, rateLimit } = c.get("ctx")
-  await rateLimit(c, "posts.pin")
-  const id = c.req.param("id")
+postsRoute.post('/:id/pin', requireHandle(), async (c) => {
+  const session = c.get('session')!
+  const { db, rateLimit } = c.get('ctx')
+  await rateLimit(c, 'posts.pin')
+  const id = c.req.param('id')
   const me = session.user.id
 
-  const [post] = await db
-    .select()
-    .from(schema.posts)
-    .where(eq(schema.posts.id, id))
-    .limit(1)
-  if (!post || post.deletedAt) return c.json({ error: "not_found" }, 404)
-  if (post.authorId !== me) return c.json({ error: "forbidden" }, 403)
+  const [post] = await db.select().from(schema.posts).where(eq(schema.posts.id, id)).limit(1)
+  if (!post || post.deletedAt) return c.json({ error: 'not_found' }, 404)
+  if (post.authorId !== me) return c.json({ error: 'forbidden' }, 403)
   if (post.replyToId || post.repostOfId || post.quoteOfId) {
-    return c.json({ error: "pin_originals_only" }, 400)
+    return c.json({ error: 'pin_originals_only' }, 400)
   }
 
   await db.transaction(async (tx) => {
     await tx
       .update(schema.posts)
       .set({ pinnedAt: null })
-      .where(
-        and(
-          eq(schema.posts.authorId, me),
-          sql`${schema.posts.pinnedAt} IS NOT NULL`
-        )
-      )
+      .where(and(eq(schema.posts.authorId, me), sql`${schema.posts.pinnedAt} IS NOT NULL`))
     await tx
       .update(schema.posts)
       .set({ pinnedAt: new Date() })
       .where(eq(schema.posts.id, id))
   })
-  c.get("ctx").track("post_pinned", session.user.id)
+  c.get('ctx').track('post_pinned', session.user.id)
   return c.json({ ok: true })
 })
 
-postsRoute.delete("/:id/pin", requireHandle(), async (c) => {
-  const session = c.get("session")!
-  const { db, rateLimit } = c.get("ctx")
-  await rateLimit(c, "posts.pin")
-  const id = c.req.param("id")
+postsRoute.delete('/:id/pin', requireHandle(), async (c) => {
+  const session = c.get('session')!
+  const { db, rateLimit } = c.get('ctx')
+  await rateLimit(c, 'posts.pin')
+  const id = c.req.param('id')
   await db
     .update(schema.posts)
     .set({ pinnedAt: null })
-    .where(
-      and(eq(schema.posts.id, id), eq(schema.posts.authorId, session.user.id))
-    )
-  c.get("ctx").track("post_unpinned", session.user.id)
+    .where(and(eq(schema.posts.id, id), eq(schema.posts.authorId, session.user.id)))
+  c.get('ctx').track('post_unpinned', session.user.id)
   return c.json({ ok: true })
 })
 
 // Read the prior versions of a post — newest first. We expose this to anyone
 // who can already see the post (i.e. it isn't deleted) so the "edited" badge
 // can link to a "View edit history" sheet, mirroring X's UX.
-postsRoute.get("/:id/edits", async (c) => {
-  const { db } = c.get("ctx")
-  const id = c.req.param("id")
+postsRoute.get('/:id/edits', async (c) => {
+  const { db } = c.get('ctx')
+  const id = c.req.param('id')
   const [post] = await db
     .select({ id: schema.posts.id, deletedAt: schema.posts.deletedAt })
     .from(schema.posts)
     .where(eq(schema.posts.id, id))
     .limit(1)
-  if (!post || post.deletedAt) return c.json({ error: "not_found" }, 404)
+  if (!post || post.deletedAt) return c.json({ error: 'not_found' }, 404)
   const edits = await db
     .select({
       id: schema.postEdits.id,
@@ -980,24 +876,17 @@ postsRoute.get("/:id/edits", async (c) => {
   })
 })
 
-postsRoute.delete("/:id", requireHandle(), async (c) => {
-  const session = c.get("session")!
-  const { db, cache } = c.get("ctx")
-  const id = c.req.param("id")
+postsRoute.delete('/:id', requireHandle(), async (c) => {
+  const session = c.get('session')!
+  const { db, cache } = c.get('ctx')
+  const id = c.req.param('id')
 
   await db.transaction(async (tx) => {
-    const [post] = await tx
-      .select()
-      .from(schema.posts)
-      .where(eq(schema.posts.id, id))
-      .limit(1)
-    if (!post || post.deletedAt) throw new HttpError(404, "not_found")
-    if (post.authorId !== session.user.id) throw new HttpError(403, "forbidden")
+    const [post] = await tx.select().from(schema.posts).where(eq(schema.posts.id, id)).limit(1)
+    if (!post || post.deletedAt) throw new HttpError(404, 'not_found')
+    if (post.authorId !== session.user.id) throw new HttpError(403, 'forbidden')
 
-    await tx
-      .update(schema.posts)
-      .set({ deletedAt: new Date() })
-      .where(eq(schema.posts.id, post.id))
+    await tx.update(schema.posts).set({ deletedAt: new Date() }).where(eq(schema.posts.id, post.id))
 
     if (post.replyToId) {
       await tx
@@ -1020,17 +909,17 @@ postsRoute.delete("/:id", requireHandle(), async (c) => {
   })
 
   await cache.del(homeFeedCacheKey(session.user.id))
-  c.get("ctx").track("post_deleted", session.user.id)
+  c.get('ctx').track('post_deleted', session.user.id)
   return c.json({ ok: true })
 })
 
 // Global public timeline.
-postsRoute.get("/", async (c) => {
-  const { db, mediaEnv, rateLimit } = c.get("ctx")
-  await rateLimit(c, "reads.feed")
-  const viewerId = c.get("session")?.user.id
-  const limit = Math.min(Number(c.req.query("limit") ?? 40), 100)
-  const cursor = parseCursor(c.req.query("cursor"))
+postsRoute.get('/', async (c) => {
+  const { db, mediaEnv, rateLimit } = c.get('ctx')
+  await rateLimit(c, 'reads.feed')
+  const viewerId = c.get('session')?.user.id
+  const limit = Math.min(Number(c.req.query('limit') ?? 40), 100)
+  const cursor = parseCursor(c.req.query('cursor'))
 
   const rows = await db
     .select({ post: schema.posts, author: schema.users })
@@ -1039,39 +928,32 @@ postsRoute.get("/", async (c) => {
     .where(
       and(
         isNull(schema.posts.deletedAt),
-        eq(schema.posts.visibility, "public"),
-        cursor ? lt(schema.posts.createdAt, cursor) : undefined
-      )
+        eq(schema.posts.visibility, 'public'),
+        cursor ? lt(schema.posts.createdAt, cursor) : undefined,
+      ),
     )
     .orderBy(desc(schema.posts.createdAt))
     .limit(limit)
 
   const ids = rows.map((r) => r.post.id)
-  const [flags, mediaMap, articleMap, repostMap, quoteMap, pollMap] =
-    await Promise.all([
-      loadViewerFlags(db, viewerId, ids),
-      loadPostMedia(db, ids),
-      loadArticleCards(db, ids),
-      loadRepostTargets({
-        db,
-        viewerId,
-        env: mediaEnv,
-        repostRows: rows.map((r) => ({
-          id: r.post.id,
-          repostOfId: r.post.repostOfId,
-        })),
-      }),
-      loadQuoteTargets({
-        db,
-        viewerId,
-        env: mediaEnv,
-        quoteRows: rows.map((r) => ({
-          id: r.post.id,
-          quoteOfId: r.post.quoteOfId,
-        })),
-      }),
-      loadPolls(db, viewerId, ids),
-    ])
+  const [flags, mediaMap, articleMap, repostMap, quoteMap, pollMap] = await Promise.all([
+    loadViewerFlags(db, viewerId, ids),
+    loadPostMedia(db, ids),
+    loadArticleCards(db, ids),
+    loadRepostTargets({
+      db,
+      viewerId,
+      env: mediaEnv,
+      repostRows: rows.map((r) => ({ id: r.post.id, repostOfId: r.post.repostOfId })),
+    }),
+    loadQuoteTargets({
+      db,
+      viewerId,
+      env: mediaEnv,
+      quoteRows: rows.map((r) => ({ id: r.post.id, quoteOfId: r.post.quoteOfId })),
+    }),
+    loadPolls(db, viewerId, ids),
+  ])
   const unfurlCardsMap = await loadUnfurlCards(db, ids, articleMap)
   const posts = rows.map((r) =>
     toPostDto(
@@ -1083,17 +965,15 @@ postsRoute.get("/", async (c) => {
       unfurlCardsMap.get(r.post.id),
       repostMap.get(r.post.id),
       quoteMap.get(r.post.id),
-      pollMap.get(r.post.id)
-    )
+      pollMap.get(r.post.id),
+    ),
   )
   await attachReplyParents({ db, viewerId, env: mediaEnv, posts })
   await attachFeedChainPreviews({ db, viewerId, env: mediaEnv, posts })
   linkSamePageReplies(posts)
   const filtered = filterRedundantChainPosts(posts)
   const hasMore = rows.length === limit
-  const nextCursor = hasMore
-    ? rows[rows.length - 1]!.post.createdAt.toISOString()
-    : null
+  const nextCursor = hasMore ? rows[rows.length - 1]!.post.createdAt.toISOString() : null
   return c.json({ posts: filtered, nextCursor })
 })
 
@@ -1102,87 +982,80 @@ postsRoute.get("/", async (c) => {
 // reply's author still sees it on their own profile and direct links still
 // resolve, but the thread route collapses it behind a "Show hidden replies"
 // affordance — same UX as X.
-postsRoute.post("/:id/hide", requireHandle(), async (c) => {
-  const session = c.get("session")!
-  const { db } = c.get("ctx")
-  const id = c.req.param("id")
+postsRoute.post('/:id/hide', requireHandle(), async (c) => {
+  const session = c.get('session')!
+  const { db } = c.get('ctx')
+  const id = c.req.param('id')
   const [post] = await db
     .select()
     .from(schema.posts)
     .where(and(eq(schema.posts.id, id), isNull(schema.posts.deletedAt)))
     .limit(1)
-  if (!post) return c.json({ error: "not_found" }, 404)
-  if (!post.replyToId) return c.json({ error: "cannot_hide_root" }, 400)
+  if (!post) return c.json({ error: 'not_found' }, 404)
+  if (!post.replyToId) return c.json({ error: 'cannot_hide_root' }, 400)
   const rootId = post.rootId ?? post.replyToId
   const [root] = await db
     .select({ authorId: schema.posts.authorId })
     .from(schema.posts)
     .where(eq(schema.posts.id, rootId))
     .limit(1)
-  if (!root) return c.json({ error: "not_found" }, 404)
+  if (!root) return c.json({ error: 'not_found' }, 404)
   const me = session.user.id
   const [meRow] = await db
     .select({ role: schema.users.role })
     .from(schema.users)
     .where(eq(schema.users.id, me))
     .limit(1)
-  const isMod = meRow?.role === "admin" || meRow?.role === "owner"
+  const isMod = meRow?.role === 'admin' || meRow?.role === 'owner'
   if (root.authorId !== me && !isMod) {
-    return c.json({ error: "forbidden" }, 403)
+    return c.json({ error: 'forbidden' }, 403)
   }
   await db
     .update(schema.posts)
     .set({ hiddenAt: new Date() })
     .where(eq(schema.posts.id, post.id))
-  c.get("ctx").track("post_hidden", session.user.id)
+  c.get('ctx').track('post_hidden', session.user.id)
   return c.json({ ok: true })
 })
 
-postsRoute.delete("/:id/hide", requireHandle(), async (c) => {
-  const session = c.get("session")!
-  const { db } = c.get("ctx")
-  const id = c.req.param("id")
+postsRoute.delete('/:id/hide', requireHandle(), async (c) => {
+  const session = c.get('session')!
+  const { db } = c.get('ctx')
+  const id = c.req.param('id')
   const [post] = await db
-    .select({
-      id: schema.posts.id,
-      rootId: schema.posts.rootId,
-      replyToId: schema.posts.replyToId,
-    })
+    .select({ id: schema.posts.id, rootId: schema.posts.rootId, replyToId: schema.posts.replyToId })
     .from(schema.posts)
     .where(eq(schema.posts.id, id))
     .limit(1)
-  if (!post) return c.json({ error: "not_found" }, 404)
+  if (!post) return c.json({ error: 'not_found' }, 404)
   const rootId = post.rootId ?? post.replyToId
-  if (!rootId) return c.json({ error: "cannot_hide_root" }, 400)
+  if (!rootId) return c.json({ error: 'cannot_hide_root' }, 400)
   const [root] = await db
     .select({ authorId: schema.posts.authorId })
     .from(schema.posts)
     .where(eq(schema.posts.id, rootId))
     .limit(1)
-  if (!root) return c.json({ error: "not_found" }, 404)
+  if (!root) return c.json({ error: 'not_found' }, 404)
   const me = session.user.id
   const [meRow] = await db
     .select({ role: schema.users.role })
     .from(schema.users)
     .where(eq(schema.users.id, me))
     .limit(1)
-  const isMod = meRow?.role === "admin" || meRow?.role === "owner"
+  const isMod = meRow?.role === 'admin' || meRow?.role === 'owner'
   if (root.authorId !== me && !isMod) {
-    return c.json({ error: "forbidden" }, 403)
+    return c.json({ error: 'forbidden' }, 403)
   }
   await db
     .update(schema.posts)
     .set({ hiddenAt: null })
     .where(eq(schema.posts.id, post.id))
-  c.get("ctx").track("post_unhidden", session.user.id)
+  c.get('ctx').track('post_unhidden', session.user.id)
   return c.json({ ok: true })
 })
 
 class HttpError extends Error {
-  constructor(
-    public status: number,
-    public code: string
-  ) {
+  constructor(public status: number, public code: string) {
     super(code)
   }
 }
@@ -1190,8 +1063,7 @@ class HttpError extends Error {
 postsRoute.onError((err, c) => {
   const rl = handleRateLimitError(err, c)
   if (rl) return rl
-  if (err instanceof HttpError)
-    return c.json({ error: err.code }, err.status as never)
+  if (err instanceof HttpError) return c.json({ error: err.code }, err.status as never)
   console.error(err)
-  return c.json({ error: "internal_error", message: err.message }, 500)
+  return c.json({ error: 'internal_error', message: err.message }, 500)
 })

--- a/apps/api/src/routes/posts.ts
+++ b/apps/api/src/routes/posts.ts
@@ -11,7 +11,7 @@ import { loadPostMedia } from '../lib/post-media.ts'
 import { loadArticleCards } from '../lib/article-cards.ts'
 import { loadRepostTargets } from '../lib/repost-targets.ts'
 import { loadQuoteTargets } from '../lib/quote-targets.ts'
-import { attachFeedChainPreviews, filterChainIntermediates } from '../lib/feed-chain-preview.ts'
+import { attachFeedChainPreviews, linkSamePageReplies, filterChainIntermediates } from '../lib/feed-chain-preview.ts'
 import { attachReplyParents } from '../lib/reply-parents.ts'
 import { loadPolls } from '../lib/polls.ts'
 import { linkHashtags } from '../lib/hashtags.ts'
@@ -970,6 +970,7 @@ postsRoute.get('/', async (c) => {
   )
   await attachReplyParents({ db, viewerId, env: mediaEnv, posts })
   await attachFeedChainPreviews({ db, viewerId, env: mediaEnv, posts })
+  linkSamePageReplies(posts)
   const filtered = filterChainIntermediates(posts)
   const hasMore = rows.length === limit
   const nextCursor = hasMore ? rows[rows.length - 1]!.post.createdAt.toISOString() : null

--- a/apps/api/src/routes/posts.ts
+++ b/apps/api/src/routes/posts.ts
@@ -11,7 +11,7 @@ import { loadPostMedia } from '../lib/post-media.ts'
 import { loadArticleCards } from '../lib/article-cards.ts'
 import { loadRepostTargets } from '../lib/repost-targets.ts'
 import { loadQuoteTargets } from '../lib/quote-targets.ts'
-import { attachFeedChainPreviews } from '../lib/feed-chain-preview.ts'
+import { attachFeedChainPreviews, filterChainIntermediates } from '../lib/feed-chain-preview.ts'
 import { attachReplyParents } from '../lib/reply-parents.ts'
 import { loadPolls } from '../lib/polls.ts'
 import { linkHashtags } from '../lib/hashtags.ts'
@@ -970,8 +970,10 @@ postsRoute.get('/', async (c) => {
   )
   await attachReplyParents({ db, viewerId, env: mediaEnv, posts })
   await attachFeedChainPreviews({ db, viewerId, env: mediaEnv, posts })
-  const nextCursor = posts.length === limit ? posts[posts.length - 1]!.createdAt : null
-  return c.json({ posts, nextCursor })
+  const filtered = filterChainIntermediates(posts)
+  const hasMore = rows.length === limit
+  const nextCursor = hasMore ? rows[rows.length - 1]!.post.createdAt.toISOString() : null
+  return c.json({ posts: filtered, nextCursor })
 })
 
 // Hide a reply from the conversation view. Allowed for the author of the

--- a/apps/web/src/components/feed-chain-preview.tsx
+++ b/apps/web/src/components/feed-chain-preview.tsx
@@ -20,26 +20,29 @@ export function FeedChainPreview({ post }: { post: Post }) {
     navigate({ to: "/$handle/p/$id", params: { handle, id: leafId } })
   }
 
-  const replyWord = omittedCount === 1 ? "reply" : "replies"
-
   return (
     <div className="flex flex-col">
       <FeedPostCard post={root} threadLine="bottom" />
-      <button
-        type="button"
-        onClick={(e) => {
-          e.stopPropagation()
-          openLeaf()
-        }}
-        className="text-muted-foreground flex items-center gap-3 px-4 py-1.5 text-left text-xs hover:text-primary"
-      >
-        <div className="-my-1.5 flex w-10 shrink-0 items-stretch justify-center self-stretch">
-          <span className="w-px bg-[var(--border-color-neutral)]" aria-hidden />
-        </div>
-        <span className="underline-offset-2 hover:underline">
-          {omittedCount} more {replyWord}
-        </span>
-      </button>
+      {omittedCount > 0 && (
+        <button
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation()
+            openLeaf()
+          }}
+          className="text-muted-foreground flex items-center gap-3 px-4 py-1.5 text-left text-xs hover:text-primary"
+        >
+          <div className="-my-1.5 flex w-10 shrink-0 items-stretch justify-center self-stretch">
+            <span
+              className="w-px bg-[var(--border-color-neutral)]"
+              aria-hidden
+            />
+          </div>
+          <span className="underline-offset-2 hover:underline">
+            {omittedCount} more {omittedCount === 1 ? "reply" : "replies"}
+          </span>
+        </button>
+      )}
       <FeedPostCard post={post} threadLine="top" />
     </div>
   )

--- a/apps/web/src/components/feed-chain-preview.tsx
+++ b/apps/web/src/components/feed-chain-preview.tsx
@@ -31,12 +31,11 @@ export function FeedChainPreview({ post }: { post: Post }) {
           e.stopPropagation()
           openLeaf()
         }}
-        className="text-muted-foreground flex items-center gap-3 py-1.5 pr-4 pl-[68px] text-left text-xs hover:text-primary"
+        className="text-muted-foreground flex items-center gap-3 px-4 py-1.5 text-left text-xs hover:text-primary"
       >
-        <span
-          className="h-8 w-px shrink-0 bg-[var(--border-color-neutral)]"
-          aria-hidden
-        />
+        <div className="-my-1.5 flex w-10 shrink-0 items-stretch justify-center self-stretch">
+          <span className="w-px bg-[var(--border-color-neutral)]" aria-hidden />
+        </div>
         <span className="underline-offset-2 hover:underline">
           {omittedCount} more {replyWord}
         </span>

--- a/apps/web/src/components/feed.tsx
+++ b/apps/web/src/components/feed.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react"
 import { useInfiniteQuery, useQueryClient } from "@tanstack/react-query"
+import { useElementScrollRestoration } from "@tanstack/react-router"
 import { useVirtualizer, useWindowVirtualizer } from "@tanstack/react-virtual"
 import { Skeleton } from "@workspace/ui/components/skeleton"
 import { PageEmpty, PageError } from "./page-surface"
@@ -267,6 +268,9 @@ function WindowFeedList({
   const wrapperRef = useRef<HTMLDivElement>(null)
   const sentinelRef = useRef<HTMLDivElement>(null)
   const [scrollMargin, setScrollMargin] = useState(0)
+  const scrollEntry = useElementScrollRestoration({
+    getElement: () => window,
+  })
 
   useIsoLayoutEffect(() => {
     const node = wrapperRef.current
@@ -280,6 +284,7 @@ function WindowFeedList({
   const virtualizer = useWindowVirtualizer({
     count: posts.length,
     estimateSize: (i) => estimatePostHeight(posts[i]),
+    initialOffset: scrollEntry?.scrollY,
     overscan: 6,
     scrollMargin,
     getItemKey: (i) => posts[i].id,
@@ -346,11 +351,15 @@ function ContainerFeedList({
 }: FeedListProps & { scrollEl: HTMLElement }) {
   const wrapperRef = useRef<HTMLDivElement>(null)
   const sentinelRef = useRef<HTMLDivElement>(null)
+  const scrollEntry = useElementScrollRestoration({
+    getElement: () => scrollEl,
+  })
 
   const virtualizer = useVirtualizer({
     count: posts.length,
     getScrollElement: () => scrollEl,
     estimateSize: (i) => estimatePostHeight(posts[i]),
+    initialOffset: scrollEntry?.scrollY,
     overscan: 6,
     getItemKey: (i) => posts[i].id,
   })

--- a/apps/web/src/routes/$handle.p.$id.tsx
+++ b/apps/web/src/routes/$handle.p.$id.tsx
@@ -1,4 +1,10 @@
-import { Link, createFileRoute, useNavigate } from "@tanstack/react-router"
+import {
+  Link,
+  createFileRoute,
+  useCanGoBack,
+  useNavigate,
+  useRouter,
+} from "@tanstack/react-router"
 import { useCallback, useEffect, useRef } from "react"
 import { useQuery, useQueryClient } from "@tanstack/react-query"
 import { ArrowLeftIcon } from "@heroicons/react/24/solid"
@@ -103,6 +109,8 @@ export const Route = createFileRoute("/$handle/p/$id")({
 function ThreadView() {
   const { handle, id } = Route.useParams()
   const navigate = useNavigate()
+  const router = useRouter()
+  const canGoBack = useCanGoBack()
   const queryClient = useQueryClient()
   const focalRef = useRef<HTMLDivElement>(null)
   const didScrollRef = useRef(false)
@@ -195,7 +203,13 @@ function ThreadView() {
           variant="transparent"
           size="sm"
           iconLeft={<ArrowLeftIcon className="size-4" />}
-          onClick={() => navigate({ to: "/" })}
+          onClick={() => {
+            if (canGoBack) {
+              router.history.back()
+            } else {
+              navigate({ to: "/" })
+            }
+          }}
           aria-label="Back"
         />
         <span className="text-sm font-semibold text-primary">Post</span>


### PR DESCRIPTION
## Summary

- Render related feed replies as linked chain previews, including direct parent -> child pairs, and hide redundant standalone/intermediate cards once they are represented in a chain.
- Keep feed pagination stable after chain filtering, and preserve repost rows as distinct feed rows.
- Restore feed scroll position when returning from a post, and make the post-view back button use browser history so the active tab is preserved.

## Test plan

- [x] `bun run typecheck` passes
- [x] `bun run lint` passes with the existing `HeatmapSvg` warning
- [x] `bun run format:check` passes
- [x] `bun run build` passes
- [ ] Manually exercised the affected flow in the browser
- [ ] No new console errors / network errors

## Notes

Network feed is unchanged; these chain-preview changes apply to Following and All.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Smarter feed post grouping that links same-page replies and removes redundant items for a cleaner chain view.

* **Improvements**
  * Pagination metadata (hasMore/nextCursor) is now derived from fetched rows for more accurate paging.
  * Feed scroll position is restored for both window and container feeds.
  * Thread back button uses browser history when available.
  * "More replies" button only appears when replies are actually omitted; wording and button layout refined.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->