### PR TITLE
Fix feed query defaults

### DIFF
--- a/packages/validators/src/feed.ts
+++ b/packages/validators/src/feed.ts
@@ -17,16 +17,16 @@ const feedLimitSchema = z.preprocess((value) => {
 }, z.number().int().min(1).max(FEED_MAX_LIMIT))
 
 export const feedQuerySchema = z.object({
-  limit: feedLimitSchema,
+  limit: feedLimitSchema.optional().default(FEED_DEFAULT_LIMIT),
   cursor: z.string().optional(),
 })
 
 export const forYouFeedQuerySchema = z.object({
-  limit: feedLimitSchema,
+  limit: feedLimitSchema.optional().default(FEED_DEFAULT_LIMIT),
   cursor: z.preprocess(
     (value) => (typeof value === "string" ? value : null),
     z.string().nullable()
-  ),
+  ).optional().default(null),
 })
 
 export type FeedQuery = z.infer<typeof feedQuerySchema>


### PR DESCRIPTION
## Summary
- Fix feed query validators so missing `limit` and For You `cursor` params use defaults instead of throwing.

## Test plan
- `bun run --cwd packages/validators typecheck`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Feed pagination parameters are now optional with automatic defaults. When pagination parameters are not provided, the system applies sensible defaults, streamlining feed requests and improving API usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->