### PR TITLE
feat(web): mobile island nav, shell layout, GitHub block tweaks

### DIFF
--- a/apps/web/src/components/app-mobile-island-nav.tsx
+++ b/apps/web/src/components/app-mobile-island-nav.tsx
@@ -1,0 +1,165 @@
+import { motion } from "motion/react"
+import { Link } from "@tanstack/react-router"
+import {
+  BellIcon,
+  EnvelopeIcon,
+  HomeIcon,
+  MagnifyingGlassIcon,
+  UserIcon,
+} from "@heroicons/react/24/outline"
+import {
+  BellIcon as BellIconSolid,
+  EnvelopeIcon as EnvelopeIconSolid,
+  HomeIcon as HomeIconSolid,
+  MagnifyingGlassIcon as MagnifyingGlassIconSolid,
+  PencilSquareIcon,
+  UserIcon as UserIconSolid,
+} from "@heroicons/react/24/solid"
+import {
+  useUnreadDms,
+  useUnreadNotifications,
+} from "../hooks/use-app-nav-badges"
+import { useMe } from "../lib/me"
+import { useCompose } from "./compose-provider"
+import type { ComponentType } from "react"
+
+interface MobileNavItem {
+  to: string
+  label: string
+  icon: ComponentType<{ className?: string }>
+  iconActive: ComponentType<{ className?: string }>
+  end?: boolean
+  badge?: number
+}
+
+function formatBadge(count: number): string {
+  return count > 99 ? "99+" : String(count)
+}
+
+export function AppMobileIslandNav() {
+  const { me } = useMe()
+  const { open: openCompose } = useCompose()
+  const unreadNotifications = useUnreadNotifications(!!me)
+  const unreadDms = useUnreadDms(!!me)
+
+  if (!me) return null
+
+  const items: Array<MobileNavItem> = [
+    {
+      to: "/",
+      label: "Home",
+      icon: HomeIcon,
+      iconActive: HomeIconSolid,
+      end: true,
+    },
+    {
+      to: "/search",
+      label: "Search",
+      icon: MagnifyingGlassIcon,
+      iconActive: MagnifyingGlassIconSolid,
+    },
+    {
+      to: "/notifications",
+      label: "Notifications",
+      icon: BellIcon,
+      iconActive: BellIconSolid,
+      badge: unreadNotifications,
+    },
+    {
+      to: "/inbox",
+      label: "Messages",
+      icon: EnvelopeIcon,
+      iconActive: EnvelopeIconSolid,
+      badge: unreadDms,
+    },
+    {
+      to: `/${me.handle}`,
+      label: "Profile",
+      icon: UserIcon,
+      iconActive: UserIconSolid,
+    },
+  ]
+
+  return (
+    <div className="fixed inset-x-0 bottom-4 z-50 px-3 md:hidden">
+      <div className="mx-auto flex w-full max-w-[400px] flex-col gap-2">
+        <div className="grid w-full grid-cols-5">
+          <div className="col-span-4" aria-hidden={true} />
+          <div className="flex justify-center">
+            <button
+              type="button"
+              onClick={() => openCompose()}
+              className="relative flex size-12 shrink-0 items-center justify-center rounded-full bg-subtle text-primary shadow-lg backdrop-blur-[7px]"
+              aria-label="Compose post"
+            >
+              <div
+                aria-hidden={true}
+                className="pointer-events-none absolute inset-0 rounded-full shadow-(--shadow-mobile-island-inset)"
+                style={{
+                  maskImage:
+                    "linear-gradient(15deg, rgba(0,0,0,0) 0%, rgba(0,0,0,1) 50%, rgba(0,0,0,0) 100%)",
+                }}
+              />
+              <PencilSquareIcon className="relative z-10 size-6" />
+            </button>
+          </div>
+        </div>
+        <nav className="relative flex w-full items-center justify-between rounded-full bg-subtle p-0.5 py-1 shadow-lg backdrop-blur-[7px]">
+          <div
+            aria-hidden={true}
+            className="pointer-events-none absolute inset-0 rounded-full shadow-(--shadow-mobile-island-inset)"
+            style={{
+              maskImage:
+                "linear-gradient(15deg, rgba(0,0,0,0) 0%, rgba(0,0,0,1) 50%, rgba(0,0,0,0) 100%)",
+            }}
+          />
+
+          {items.map((item) => (
+            <Link
+              key={item.to}
+              to={item.to}
+              activeOptions={{ exact: item.end, includeSearch: false }}
+              className="flex min-w-0 flex-1"
+            >
+              {({ isActive }) => {
+                const Icon = isActive ? item.iconActive : item.icon
+                const badgeText =
+                  typeof item.badge === "number" && item.badge > 0
+                    ? formatBadge(item.badge)
+                    : null
+                return (
+                  <span className="relative mx-0.5 flex w-full flex-col items-center justify-center gap-0.5 rounded-full py-1.5 text-primary">
+                    {isActive ? (
+                      <motion.div
+                        layoutId="app-mobile-island-nav-active"
+                        transition={{
+                          type: "spring",
+                          stiffness: 600,
+                          damping: 40,
+                        }}
+                        className="pointer-events-none absolute inset-0 rounded-full bg-neutral-400/30"
+                      />
+                    ) : null}
+                    <span className="relative z-10 flex w-full flex-col items-center justify-center gap-0.5 pt-px">
+                      <span className="relative">
+                        <Icon className="size-5" />
+                        {badgeText !== null && (
+                          <span className="absolute -top-1 -right-1.5 min-w-[14px] rounded-full bg-danger px-1 text-center text-[7px] leading-[14px] font-semibold text-danger-on">
+                            {badgeText}
+                          </span>
+                        )}
+                      </span>
+                      <span className="max-w-full truncate px-1 text-[9px]">
+                        {item.label}
+                      </span>
+                    </span>
+                  </span>
+                )
+              }}
+            </Link>
+          ))}
+        </nav>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/components/app-mobile-island-nav.tsx
+++ b/apps/web/src/components/app-mobile-island-nav.tsx
@@ -73,7 +73,7 @@ export function AppMobileIslandNav() {
       badge: unreadDms,
     },
     {
-      to: `/${me.handle}`,
+      to: me.handle ? `/${me.handle}` : "/",
       label: "Profile",
       icon: UserIcon,
       iconActive: UserIconSolid,

--- a/apps/web/src/components/app-shell.tsx
+++ b/apps/web/src/components/app-shell.tsx
@@ -24,7 +24,8 @@ export function AppShell({ children }: { children: ReactNode }) {
   const { data: session } = authClient.useSession()
   const authed = Boolean(session)
   const pathname = useRouterState({ select: (s) => s.location.pathname })
-  const isAdminShell = pathname.startsWith("/admin")
+  const isAdminShell = pathname.startsWith("/admin");
+  const showMobileIslandNav = authed && !isAdminShell;
 
   const sidebarLeftStyle = {
     left: "max(0px, calc((100vw - 1080px) / 2))",
@@ -56,7 +57,13 @@ export function AppShell({ children }: { children: ReactNode }) {
                     : "hidden w-[68px] shrink-0 md:block xl:w-[240px]"
                 }
               />
-              <main className="flex min-h-svh min-w-0 flex-1 flex-col pb-32 md:pb-0">
+              <main
+                className={
+                  showMobileIslandNav
+                    ? "flex min-h-svh min-w-0 flex-1 flex-col pb-32 md:pb-0"
+                    : "flex min-h-svh min-w-0 flex-1 flex-col"
+                }
+              >
                 {children}
               </main>
               <div
@@ -67,7 +74,7 @@ export function AppShell({ children }: { children: ReactNode }) {
                 }
               />
             </div>
-            {authed && !isAdminShell ? <AppMobileIslandNav /> : null}
+            {showMobileIslandNav ? <AppMobileIslandNav /> : null}
           </YouTubePlayerProvider>
         </LightboxProvider>
       </SettingsProvider>

--- a/apps/web/src/components/app-shell.tsx
+++ b/apps/web/src/components/app-shell.tsx
@@ -12,6 +12,7 @@ import { Button } from "@workspace/ui/components/button"
 import { authClient } from "../lib/auth"
 import { api } from "../lib/api"
 import { qk } from "../lib/query-keys"
+import { AppMobileIslandNav } from "./app-mobile-island-nav"
 import { AppSidebar } from "./app-sidebar"
 import { LightboxProvider } from "./lightbox-provider"
 import { YouTubePlayerProvider } from "./youtube-player-dialog"
@@ -39,8 +40,8 @@ export function AppShell({ children }: { children: ReactNode }) {
             <div
               className={
                 isAdminShell
-                  ? "fixed top-0 z-40 h-svh w-[68px]"
-                  : "fixed top-0 z-40 h-svh w-[68px] xl:w-[240px]"
+                  ? "fixed top-0 z-40 hidden h-svh w-[68px] md:block"
+                  : "fixed top-0 z-40 hidden h-svh w-[68px] md:block xl:w-[240px]"
               }
               style={sidebarLeftStyle}
             >
@@ -51,11 +52,13 @@ export function AppShell({ children }: { children: ReactNode }) {
               <div
                 className={
                   isAdminShell
-                    ? "w-[68px] shrink-0"
-                    : "w-[68px] shrink-0 xl:w-[240px]"
+                    ? "hidden w-[68px] shrink-0 md:block"
+                    : "hidden w-[68px] shrink-0 md:block xl:w-[240px]"
                 }
               />
-              <main className="flex min-h-svh flex-1 flex-col">{children}</main>
+              <main className="flex min-h-svh min-w-0 flex-1 flex-col pb-32 md:pb-0">
+                {children}
+              </main>
               <div
                 className={
                   isAdminShell
@@ -64,6 +67,7 @@ export function AppShell({ children }: { children: ReactNode }) {
                 }
               />
             </div>
+            {authed && !isAdminShell ? <AppMobileIslandNav /> : null}
           </YouTubePlayerProvider>
         </LightboxProvider>
       </SettingsProvider>

--- a/apps/web/src/components/github-block/github-contributions-heatmap.tsx
+++ b/apps/web/src/components/github-block/github-contributions-heatmap.tsx
@@ -389,15 +389,15 @@ export function GithubContributionsHeatmap({
 
   return (
     <>
-      <div className={cn("flex flex-col", className)}>
-        <div className="relative">
+      <div className={cn("flex w-full max-w-full min-w-0 flex-col", className)}>
+        <div className="relative w-full max-w-full min-w-0 overflow-hidden">
           <div
             ref={scrollRef}
             onScroll={updateScrollMasks}
-            className="overflow-x-auto [&::-webkit-scrollbar]:hidden"
+            className="w-full max-w-full min-w-0 overflow-x-auto overscroll-x-contain [&::-webkit-scrollbar]:hidden"
             style={{ scrollbarWidth: "none", msOverflowStyle: "none" }}
           >
-            <div className="inline-block min-w-0">
+            <div className="w-max">
               <div
                 className="relative mb-1 h-3.5"
                 style={{ marginLeft: gridInset, width }}

--- a/apps/web/src/components/github-block/github-profile-section.tsx
+++ b/apps/web/src/components/github-block/github-profile-section.tsx
@@ -11,8 +11,8 @@ export function GithubProfileSection({
   profile: ConnectedGithubProfile
 }) {
   return (
-    <section className="min-w-0 px-4 pt-2 pb-5 w-full">
-      <div className="min-w-0 space-y-1 rounded-2xl bg-subtle p-1 w-full">
+    <section className="w-full min-w-0 px-4 pt-2 pb-5">
+      <div className="w-full min-w-0 space-y-1 rounded-2xl bg-subtle p-1">
         <div className="flex flex-wrap items-center gap-2 px-2 pt-1.5">
           <h2 className="text-foreground inline-flex items-center gap-1.5 text-sm font-semibold">
             <GitHubMark />
@@ -29,11 +29,11 @@ export function GithubProfileSection({
           </a>
         </div>
 
-        <div className="w-full min-w-0 overflow-hidden max-w-full rounded-lg bg-base-1 px-2 pt-0.5 pb-2">
+        <div className="w-full max-w-full min-w-0 overflow-hidden rounded-lg bg-base-1 px-2 pt-0.5 pb-2">
           <GithubContributionsHeatmap
             data={profile.contributions}
             stale={profile.stale}
-            className="mt-3 max-w-full w-full min-w-0"
+            className="mt-3 w-full max-w-full min-w-0"
           />
         </div>
       </div>

--- a/apps/web/src/components/github-block/github-profile-section.tsx
+++ b/apps/web/src/components/github-block/github-profile-section.tsx
@@ -11,8 +11,8 @@ export function GithubProfileSection({
   profile: ConnectedGithubProfile
 }) {
   return (
-    <section className="px-4 pt-2 pb-5">
-      <div className="space-y-1 rounded-2xl bg-subtle p-1">
+    <section className="min-w-0 px-4 pt-2 pb-5 w-full">
+      <div className="min-w-0 space-y-1 rounded-2xl bg-subtle p-1 w-full">
         <div className="flex flex-wrap items-center gap-2 px-2 pt-1.5">
           <h2 className="text-foreground inline-flex items-center gap-1.5 text-sm font-semibold">
             <GitHubMark />
@@ -29,11 +29,11 @@ export function GithubProfileSection({
           </a>
         </div>
 
-        <div className="rounded-lg bg-base-1 px-2 pt-0.5 pb-2">
+        <div className="w-full min-w-0 overflow-hidden max-w-full rounded-lg bg-base-1 px-2 pt-0.5 pb-2">
           <GithubContributionsHeatmap
             data={profile.contributions}
             stale={profile.stale}
-            className="mt-3"
+            className="mt-3 max-w-full w-full min-w-0"
           />
         </div>
       </div>

--- a/apps/web/src/routes/$handle.index.tsx
+++ b/apps/web/src/routes/$handle.index.tsx
@@ -61,7 +61,7 @@ export const Route = createFileRoute("/$handle/")({
     const name = user.displayName || `@${user.handle}`
     const description = clipDescription(
       user.bio ||
-      `@${user.handle} on ${APP_NAME} — ${user.counts.followers} followers, ${user.counts.posts} posts.`
+        `@${user.handle} on ${APP_NAME} — ${user.counts.followers} followers, ${user.counts.posts} posts.`
     )
     return {
       meta: buildSeoMeta({

--- a/apps/web/src/routes/$handle.index.tsx
+++ b/apps/web/src/routes/$handle.index.tsx
@@ -61,7 +61,7 @@ export const Route = createFileRoute("/$handle/")({
     const name = user.displayName || `@${user.handle}`
     const description = clipDescription(
       user.bio ||
-        `@${user.handle} on ${APP_NAME} — ${user.counts.followers} followers, ${user.counts.posts} posts.`
+      `@${user.handle} on ${APP_NAME} — ${user.counts.followers} followers, ${user.counts.posts} posts.`
     )
     return {
       meta: buildSeoMeta({
@@ -141,7 +141,7 @@ function Profile() {
     .toUpperCase()
 
   return (
-    <section className="relative">
+    <section className="relative w-full">
       <ImageLightbox
         images={user.bannerUrl ? [{ src: user.bannerUrl }] : []}
         title={`${displayName}'s banner`}

--- a/packages/ui/src/styles/theme.css
+++ b/packages/ui/src/styles/theme.css
@@ -65,6 +65,8 @@
   --shadow-gh-tooltip:
     0 0.5px 0 oklch(1 0 0 / 100%) inset, 0 -0.5px 0 oklch(1 0 0 / 100%) inset,
     0 0 25px oklch(1 0 0 / 100%) inset;
+  /* Mobile island nav / compose: inset hairline (shared light + dark) */
+  --shadow-mobile-island-inset: 0 0 1px 0.5px oklch(1 0 0 / 0.67) inset;
 
   /* ── Like color ── */
   --text-color-like: var(--color-red-9);


### PR DESCRIPTION
## Summary

Frosted glass nav for mobile. Fix github heat map overflow fixed
<img width="422" height="869" alt="image" src="https://github.com/user-attachments/assets/caac203c-28f0-4642-b677-aa6674a1068f" />


## Test plan

<!-- How you verified it works. Delete what doesn't apply. -->

- [ ] `bun run typecheck` passes
- [x] Manually exercised the affected flow in the browser
- [x] No new console errors / network errors

## Notes

<!-- Anything reviewers should pay attention to: migrations, env-var changes, breaking changes, follow-ups. Delete if none. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mobile bottom navigation for signed-in users with Home, Search, Notifications, Messages, Profile and a centered Compose button (opens composer)
  * Active item shows an animated highlight; labels truncate for compact display

* **Bug Fixes**
  * Layout and overflow fixes for GitHub contributions heatmap and profile sections
  * Mobile layout adjusts main content padding when bottom nav is present

* **Style**
  * New inset shadow token for mobile island navigation visuals

<!-- end of auto-generated comment: release notes by coderabbit.ai -->