### PR TITLE
Fix notifications actor hover card and profile navigation

### DIFF
--- a/apps/web/src/components/profile-hover-card.tsx
+++ b/apps/web/src/components/profile-hover-card.tsx
@@ -3,7 +3,7 @@ import { useQuery } from "@tanstack/react-query"
 import { Avatar } from "@workspace/ui/components/avatar"
 import { Button } from "@workspace/ui/components/button"
 import { PreviewCard } from "@workspace/ui/components/preview-card"
-import { api } from "../lib/api"
+import { api, type PublicProfile } from "../lib/api"
 import { qk } from "../lib/query-keys"
 import { useMe } from "../lib/me"
 import { VerifiedBadge } from "./verified-badge"
@@ -15,12 +15,20 @@ interface ProfileHoverCardProps {
 }
 
 export function ProfileHoverCard({ handle, children }: ProfileHoverCardProps) {
+  const doc = typeof document !== "undefined" ? document : undefined
+
   return (
     <PreviewCard.Root>
       <PreviewCard.Trigger render={<div className="inline" />}>
         {children}
       </PreviewCard.Trigger>
-      <PreviewCard.Content side="bottom" align="start" sideOffset={8}>
+      <PreviewCard.Content
+        side="bottom"
+        align="start"
+        sideOffset={8}
+        collisionBoundary={doc?.documentElement}
+        positionMethod="fixed"
+      >
         <ProfileCardInner handle={handle} />
       </PreviewCard.Content>
     </PreviewCard.Root>
@@ -29,14 +37,11 @@ export function ProfileHoverCard({ handle, children }: ProfileHoverCardProps) {
 
 function ProfileCardInner({ handle }: { handle: string }) {
   const { me } = useMe()
-  const { data, isPending } = useQuery({
+  const { data: profile, error, isPending } = useQuery({
     queryKey: qk.user(handle),
-    queryFn: () => api.user(handle),
+    queryFn: async (): Promise<PublicProfile> => (await api.user(handle)).user,
     staleTime: 60_000,
   })
-
-  const profile = data?.user
-  const isSelf = me?.id === profile?.id
 
   if (isPending) {
     return (
@@ -46,15 +51,22 @@ function ProfileCardInner({ handle }: { handle: string }) {
     )
   }
 
-  if (!profile) return null
+  if (error || !profile) {
+    return (
+      <div className="p-4 text-sm text-secondary">Could not load this profile.</div>
+    )
+  }
 
+  const isSelf = me?.id === profile.id
   const initial = (profile.displayName ?? profile.handle ?? "?")
     .slice(0, 1)
     .toUpperCase()
+  const viewer = profile.viewer
+  const hasFollowState = typeof viewer?.following === "boolean"
+  const isFollowing = viewer?.following === true
 
   return (
     <div className="flex flex-col gap-3 p-4">
-      {/* Header: avatar + follow button */}
       <div className="flex items-start justify-between">
         <Link to="/$handle" params={{ handle }}>
           <Avatar
@@ -64,12 +76,21 @@ function ProfileCardInner({ handle }: { handle: string }) {
             className="ring-1 ring-neutral"
           />
         </Link>
-        {!isSelf && profile.viewer && (
-          <FollowButton handle={handle} following={profile.viewer.following} />
+        {!isSelf && hasFollowState && (
+          <Button
+            size="sm"
+            variant={isFollowing ? "outline" : "primary"}
+            onClick={async (e) => {
+              e.preventDefault()
+              e.stopPropagation()
+              if (isFollowing) await api.unfollow(handle)
+              else await api.follow(handle)
+            }}
+          >
+            {isFollowing ? "Following" : "Follow"}
+          </Button>
         )}
       </div>
-
-      {/* Name + handle */}
       <div className="min-w-0">
         <Link
           to="/$handle"
@@ -83,15 +104,11 @@ function ProfileCardInner({ handle }: { handle: string }) {
         </Link>
         <span className="text-xs text-tertiary">@{handle}</span>
       </div>
-
-      {/* Bio */}
       {profile.bio && (
         <p className="line-clamp-3 text-sm leading-relaxed text-primary">
           {profile.bio}
         </p>
       )}
-
-      {/* Counts */}
       <div className="flex gap-3 text-xs">
         <Link
           to="/$handle/following"
@@ -115,32 +132,6 @@ function ProfileCardInner({ handle }: { handle: string }) {
         </Link>
       </div>
     </div>
-  )
-}
-
-function FollowButton({
-  handle,
-  following,
-}: {
-  handle: string
-  following: boolean
-}) {
-  return (
-    <Button
-      size="sm"
-      variant={following ? "outline" : "primary"}
-      onClick={async (e) => {
-        e.preventDefault()
-        e.stopPropagation()
-        if (following) {
-          await api.unfollow(handle)
-        } else {
-          await api.follow(handle)
-        }
-      }}
-    >
-      {following ? "Following" : "Follow"}
-    </Button>
   )
 }
 

--- a/apps/web/src/components/profile-hover-card.tsx
+++ b/apps/web/src/components/profile-hover-card.tsx
@@ -1,13 +1,14 @@
 import { Link } from "@tanstack/react-router"
-import { useQuery } from "@tanstack/react-query"
+import { useQuery, useQueryClient } from "@tanstack/react-query"
 import { Avatar } from "@workspace/ui/components/avatar"
 import { Button } from "@workspace/ui/components/button"
 import { PreviewCard } from "@workspace/ui/components/preview-card"
+import { toast } from "sonner"
 import { api, type PublicProfile } from "../lib/api"
 import { qk } from "../lib/query-keys"
 import { useMe } from "../lib/me"
 import { VerifiedBadge } from "./verified-badge"
-import type { ReactNode } from "react"
+import { useState, type ReactNode } from "react"
 
 interface ProfileHoverCardProps {
   handle: string
@@ -37,6 +38,8 @@ export function ProfileHoverCard({ handle, children }: ProfileHoverCardProps) {
 
 function ProfileCardInner({ handle }: { handle: string }) {
   const { me } = useMe()
+  const queryClient = useQueryClient()
+  const [isFollowPending, setIsFollowPending] = useState(false)
   const { data: profile, error, isPending } = useQuery({
     queryKey: qk.user(handle),
     queryFn: async (): Promise<PublicProfile> => (await api.user(handle)).user,
@@ -80,11 +83,46 @@ function ProfileCardInner({ handle }: { handle: string }) {
           <Button
             size="sm"
             variant={isFollowing ? "outline" : "primary"}
+            disabled={isFollowPending}
             onClick={async (e) => {
               e.preventDefault()
               e.stopPropagation()
-              if (isFollowing) await api.unfollow(handle)
-              else await api.follow(handle)
+              if (isFollowPending) return
+              setIsFollowPending(true)
+              const shouldFollow = !isFollowing
+              try {
+                if (isFollowing) await api.unfollow(handle)
+                else await api.follow(handle)
+                queryClient.setQueryData<PublicProfile | undefined>(
+                  qk.user(handle),
+                  (current) => {
+                    if (!current) return current
+                    return {
+                      ...current,
+                      viewer: current.viewer
+                        ? { ...current.viewer, following: shouldFollow }
+                        : current.viewer,
+                      counts: {
+                        ...current.counts,
+                        followers: Math.max(
+                          0,
+                          current.counts.followers + (shouldFollow ? 1 : -1)
+                        ),
+                      },
+                    }
+                  }
+                )
+                await queryClient.invalidateQueries({ queryKey: qk.user(handle) })
+              } catch (caught) {
+                console.error("Failed to update follow status", caught)
+                toast.error(
+                  shouldFollow
+                    ? "Could not follow this user. Please try again."
+                    : "Could not unfollow this user. Please try again."
+                )
+              } finally {
+                setIsFollowPending(false)
+              }
             }}
           >
             {isFollowing ? "Following" : "Follow"}

--- a/apps/web/src/routes/notifications.tsx
+++ b/apps/web/src/routes/notifications.tsx
@@ -925,11 +925,17 @@ function NotificationRow({ item }: { item: NotificationItem }) {
 
   const containerClass = `block border-b border-neutral px-4 py-3.5 transition-colors hover:bg-base-2/20 ${!item.readAt ? "bg-subtle" : ""}`
 
-  function openActorProfile(e: React.MouseEvent | React.KeyboardEvent) {
-    if (!actorHandle) return
-    e.preventDefault()
-    e.stopPropagation()
-    navigate({ to: "/$handle", params: { handle: actorHandle } })
+  function openRowDestination(e: React.MouseEvent | React.KeyboardEvent) {
+    if (!destination) return
+    if ("target" in e && (e.target as HTMLElement).closest("a")) return
+    navigate({ to: destination })
+  }
+
+  function handleRowKeyDown(e: React.KeyboardEvent) {
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault()
+      openRowDestination(e)
+    }
   }
 
   const content = (
@@ -938,20 +944,15 @@ function NotificationRow({ item }: { item: NotificationItem }) {
         <Icon className={`size-5.5 ${iconClass}`} />
       </div>
       {actorHandle ? (
-        <ProfileHoverCard handle={actorHandle}>
-          <button
-            type="button"
-            onClick={openActorProfile}
-            className="shrink-0 rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
-            aria-label={`Open @${actorHandle} profile`}
-          >
+        <Link to="/$handle" params={{ handle: actorHandle }} className="shrink-0">
+          <ProfileHoverCard handle={actorHandle}>
             <Avatar
               initial={actorInitial}
               src={item.actor?.avatarUrl}
               className="size-10"
             />
-          </button>
-        </ProfileHoverCard>
+          </ProfileHoverCard>
+        </Link>
       ) : (
         <Avatar
           initial={actorInitial}
@@ -962,12 +963,8 @@ function NotificationRow({ item }: { item: NotificationItem }) {
       <div className="min-w-0 flex-1 text-sm">
         <p>
           {actorHandle ? (
-            <ProfileHoverCard handle={actorHandle}>
-              <button
-                type="button"
-                onClick={openActorProfile}
-                className="inline-flex cursor-pointer items-center rounded-sm align-middle focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
-              >
+            <Link to="/$handle" params={{ handle: actorHandle }} className="inline-block">
+              <ProfileHoverCard handle={actorHandle}>
                 <span className="inline-flex items-center gap-1 align-middle font-semibold text-primary">
                   {actorDisplayName || actorHandle || "someone"}
                   {item.actor?.isVerified && (
@@ -975,8 +972,8 @@ function NotificationRow({ item }: { item: NotificationItem }) {
                   )}
                 </span>
                 <span className="text-tertiary"> @{actorHandle}</span>
-              </button>
-            </ProfileHoverCard>
+              </ProfileHoverCard>
+            </Link>
           ) : (
             <span className="inline-flex items-center gap-1 align-middle font-semibold text-primary">
               {actorDisplayName || actorHandle || "someone"}
@@ -1001,9 +998,15 @@ function NotificationRow({ item }: { item: NotificationItem }) {
 
   if (destination) {
     return (
-      <Link to={destination} className={containerClass}>
+      <div
+        role="link"
+        tabIndex={0}
+        onClick={openRowDestination}
+        onKeyDown={handleRowKeyDown}
+        className={`focus-visible:ring-primary cursor-pointer focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-inset ${containerClass}`}
+      >
         {content}
-      </Link>
+      </div>
     )
   }
 

--- a/apps/web/src/routes/notifications.tsx
+++ b/apps/web/src/routes/notifications.tsx
@@ -662,79 +662,106 @@ function ReplyRow({ item }: { item: NotificationItem }) {
 
   return (
     <div
-      role="button"
-      tabIndex={0}
-      onClick={openPost}
-      onKeyDown={handleKeyDown}
-      className={`focus-visible:ring-primary cursor-pointer border-b border-neutral px-4 py-3.5 transition-colors hover:bg-base-2/20 focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-inset ${!item.readAt ? "bg-subtle" : ""}`}
+      className={`border-b border-neutral px-4 py-3.5 transition-colors hover:bg-base-2/20 ${!item.readAt ? "bg-subtle" : ""}`}
     >
       <div className="flex items-start gap-3">
-        <Avatar
-          initial={actorInitial}
-          src={actor?.avatarUrl}
-          className="size-10 shrink-0"
-        />
+        {actorHandle ? (
+          <Link to="/$handle" params={{ handle: actorHandle }} className="shrink-0">
+            <ProfileHoverCard handle={actorHandle}>
+              <Avatar
+                initial={actorInitial}
+                src={actor?.avatarUrl}
+                className="size-10"
+              />
+            </ProfileHoverCard>
+          </Link>
+        ) : (
+          <Avatar
+            initial={actorInitial}
+            src={actor?.avatarUrl}
+            className="size-10 shrink-0"
+          />
+        )}
         <div className="min-w-0 flex-1 text-sm">
           <div className="flex items-center gap-1.5">
-            <span className="inline-flex items-center gap-1 font-semibold text-primary">
-              {actorDisplayName || actorHandle || "someone"}
-              {actor?.isVerified && (
-                <VerifiedBadge size={14} role={actor.role} />
-              )}
-            </span>
-            {actorHandle && (
-              <span className="text-tertiary">@{actorHandle}</span>
+            {actorHandle ? (
+              <Link to="/$handle" params={{ handle: actorHandle }} className="inline-block">
+                <ProfileHoverCard handle={actorHandle}>
+                  <span className="inline-flex items-center gap-1 font-semibold text-primary">
+                    {actorDisplayName || actorHandle || "someone"}
+                    {actor?.isVerified && (
+                      <VerifiedBadge size={14} role={actor.role} />
+                    )}
+                  </span>
+                  <span className="text-tertiary"> @{actorHandle}</span>
+                </ProfileHoverCard>
+              </Link>
+            ) : (
+              <span className="inline-flex items-center gap-1 font-semibold text-primary">
+                {actorDisplayName || actorHandle || "someone"}
+                {actor?.isVerified && (
+                  <VerifiedBadge size={14} role={actor.role} />
+                )}
+              </span>
             )}
             <span className="text-xs text-tertiary">
               · {formatShortTime(item.createdAt)}
             </span>
           </div>
-          {replyToHandles.length > 0 && (
-            <p className="mt-0.5 text-secondary">
-              Replying to{" "}
-              {replyToHandles.slice(0, 2).map((handle, i) => (
-                <span key={handle}>
-                  {i > 0 && ", "}
-                  <span className="text-sky-500">@{handle}</span>
-                </span>
-              ))}
-              {replyToHandles.length > 2 && (
-                <span className="text-secondary">
-                  {" "}
-                  and {replyToHandles.length - 2} other
-                  {replyToHandles.length - 2 !== 1 ? "s" : ""}
-                </span>
-              )}
-            </p>
-          )}
-          {replyTarget?.text && (
-            <p className="mt-0.5 leading-relaxed whitespace-pre-wrap text-primary">
-              <RichText text={replyTarget.text} />
-            </p>
-          )}
           <div
-            className="mt-2 flex items-center"
-            onClick={(e) => e.stopPropagation()}
+            role="button"
+            tabIndex={0}
+            onClick={openPost}
+            onKeyDown={handleKeyDown}
+            className="focus-visible:ring-primary mt-1.5 cursor-pointer rounded-md p-1 -m-1 focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-inset"
           >
-            <div className="flex-1">
-              <span className="inline-flex size-7 items-center justify-center rounded-full text-tertiary">
-                <ChatBubbleOutline className="size-4" />
-              </span>
-            </div>
-            <div className="flex-1">
-              <span className="inline-flex size-7 items-center justify-center rounded-full text-tertiary">
-                <ArrowPathOutline className="size-4" />
-              </span>
-            </div>
-            <div className="flex-1">
-              <span className="inline-flex size-7 items-center justify-center rounded-full text-tertiary">
-                <HeartOutline className="size-4" />
-              </span>
-            </div>
-            <div>
-              <span className="inline-flex size-7 items-center justify-center rounded-full text-tertiary">
-                <BookmarkIconOutline className="size-4" />
-              </span>
+            {replyToHandles.length > 0 && (
+              <p className="mt-0.5 text-secondary">
+                Replying to{" "}
+                {replyToHandles.slice(0, 2).map((handle, i) => (
+                  <span key={handle}>
+                    {i > 0 && ", "}
+                    <span className="text-sky-500">@{handle}</span>
+                  </span>
+                ))}
+                {replyToHandles.length > 2 && (
+                  <span className="text-secondary">
+                    {" "}
+                    and {replyToHandles.length - 2} other
+                    {replyToHandles.length - 2 !== 1 ? "s" : ""}
+                  </span>
+                )}
+              </p>
+            )}
+            {replyTarget?.text && (
+              <p className="mt-0.5 leading-relaxed whitespace-pre-wrap text-primary">
+                <RichText text={replyTarget.text} />
+              </p>
+            )}
+            <div
+              className="mt-2 flex items-center"
+              onClick={(e) => e.stopPropagation()}
+            >
+              <div className="flex-1">
+                <span className="inline-flex size-7 items-center justify-center rounded-full text-tertiary">
+                  <ChatBubbleOutline className="size-4" />
+                </span>
+              </div>
+              <div className="flex-1">
+                <span className="inline-flex size-7 items-center justify-center rounded-full text-tertiary">
+                  <ArrowPathOutline className="size-4" />
+                </span>
+              </div>
+              <div className="flex-1">
+                <span className="inline-flex size-7 items-center justify-center rounded-full text-tertiary">
+                  <HeartOutline className="size-4" />
+                </span>
+              </div>
+              <div>
+                <span className="inline-flex size-7 items-center justify-center rounded-full text-tertiary">
+                  <BookmarkIconOutline className="size-4" />
+                </span>
+              </div>
             </div>
           </div>
         </div>
@@ -772,61 +799,88 @@ function MentionRow({ item }: { item: NotificationItem }) {
 
   return (
     <div
-      role="button"
-      tabIndex={0}
-      onClick={openPost}
-      onKeyDown={handleKeyDown}
-      className={`focus-visible:ring-primary cursor-pointer border-b border-neutral px-4 py-3.5 transition-colors hover:bg-base-2/20 focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-inset ${!item.readAt ? "bg-subtle" : ""}`}
+      className={`border-b border-neutral px-4 py-3.5 transition-colors hover:bg-base-2/20 ${!item.readAt ? "bg-subtle" : ""}`}
     >
       <div className="flex items-start gap-3">
-        <Avatar
-          initial={actorInitial}
-          src={actor?.avatarUrl}
-          className="size-10 shrink-0"
-        />
+        {actorHandle ? (
+          <Link to="/$handle" params={{ handle: actorHandle }} className="shrink-0">
+            <ProfileHoverCard handle={actorHandle}>
+              <Avatar
+                initial={actorInitial}
+                src={actor?.avatarUrl}
+                className="size-10"
+              />
+            </ProfileHoverCard>
+          </Link>
+        ) : (
+          <Avatar
+            initial={actorInitial}
+            src={actor?.avatarUrl}
+            className="size-10 shrink-0"
+          />
+        )}
         <div className="min-w-0 flex-1 text-sm">
           <div className="flex items-center gap-1.5">
-            <span className="inline-flex items-center gap-1 font-semibold text-primary">
-              {actorDisplayName || actorHandle || "someone"}
-              {actor?.isVerified && (
-                <VerifiedBadge size={14} role={actor.role} />
-              )}
-            </span>
-            {actorHandle && (
-              <span className="text-tertiary">@{actorHandle}</span>
+            {actorHandle ? (
+              <Link to="/$handle" params={{ handle: actorHandle }} className="inline-block">
+                <ProfileHoverCard handle={actorHandle}>
+                  <span className="inline-flex items-center gap-1 font-semibold text-primary">
+                    {actorDisplayName || actorHandle || "someone"}
+                    {actor?.isVerified && (
+                      <VerifiedBadge size={14} role={actor.role} />
+                    )}
+                  </span>
+                  <span className="text-tertiary"> @{actorHandle}</span>
+                </ProfileHoverCard>
+              </Link>
+            ) : (
+              <span className="inline-flex items-center gap-1 font-semibold text-primary">
+                {actorDisplayName || actorHandle || "someone"}
+                {actor?.isVerified && (
+                  <VerifiedBadge size={14} role={actor.role} />
+                )}
+              </span>
             )}
             <span className="text-xs text-tertiary">
               · {formatShortTime(item.createdAt)}
             </span>
           </div>
-          {mentionTarget?.text && (
-            <p className="mt-0.5 leading-relaxed whitespace-pre-wrap text-primary">
-              <RichText text={mentionTarget.text} />
-            </p>
-          )}
           <div
-            className="mt-2 flex items-center"
-            onClick={(e) => e.stopPropagation()}
+            role="button"
+            tabIndex={0}
+            onClick={openPost}
+            onKeyDown={handleKeyDown}
+            className="focus-visible:ring-primary mt-1.5 cursor-pointer rounded-md p-1 -m-1 focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-inset"
           >
-            <div className="flex-1">
-              <span className="inline-flex size-7 items-center justify-center rounded-full text-tertiary">
-                <ChatBubbleOutline className="size-4" />
-              </span>
-            </div>
-            <div className="flex-1">
-              <span className="inline-flex size-7 items-center justify-center rounded-full text-tertiary">
-                <ArrowPathOutline className="size-4" />
-              </span>
-            </div>
-            <div className="flex-1">
-              <span className="inline-flex size-7 items-center justify-center rounded-full text-tertiary">
-                <HeartOutline className="size-4" />
-              </span>
-            </div>
-            <div>
-              <span className="inline-flex size-7 items-center justify-center rounded-full text-tertiary">
-                <BookmarkIconOutline className="size-4" />
-              </span>
+            {mentionTarget?.text && (
+              <p className="mt-0.5 leading-relaxed whitespace-pre-wrap text-primary">
+                <RichText text={mentionTarget.text} />
+              </p>
+            )}
+            <div
+              className="mt-2 flex items-center"
+              onClick={(e) => e.stopPropagation()}
+            >
+              <div className="flex-1">
+                <span className="inline-flex size-7 items-center justify-center rounded-full text-tertiary">
+                  <ChatBubbleOutline className="size-4" />
+                </span>
+              </div>
+              <div className="flex-1">
+                <span className="inline-flex size-7 items-center justify-center rounded-full text-tertiary">
+                  <ArrowPathOutline className="size-4" />
+                </span>
+              </div>
+              <div className="flex-1">
+                <span className="inline-flex size-7 items-center justify-center rounded-full text-tertiary">
+                  <HeartOutline className="size-4" />
+                </span>
+              </div>
+              <div>
+                <span className="inline-flex size-7 items-center justify-center rounded-full text-tertiary">
+                  <BookmarkIconOutline className="size-4" />
+                </span>
+              </div>
             </div>
           </div>
         </div>

--- a/apps/web/src/routes/notifications.tsx
+++ b/apps/web/src/routes/notifications.tsx
@@ -904,6 +904,7 @@ function formatShortTime(iso: string): string {
 }
 
 function NotificationRow({ item }: { item: NotificationItem }) {
+  const navigate = useNavigate()
   const Icon = iconForKind(item.kind)
   const iconClass = iconClassForKind(item.kind)
   const verb = verbForKind(item.kind)
@@ -924,21 +925,33 @@ function NotificationRow({ item }: { item: NotificationItem }) {
 
   const containerClass = `block border-b border-neutral px-4 py-3.5 transition-colors hover:bg-base-2/20 ${!item.readAt ? "bg-subtle" : ""}`
 
+  function openActorProfile(e: React.MouseEvent | React.KeyboardEvent) {
+    if (!actorHandle) return
+    e.preventDefault()
+    e.stopPropagation()
+    navigate({ to: "/$handle", params: { handle: actorHandle } })
+  }
+
   const content = (
     <div className="flex items-start gap-3">
       <div className="flex size-10 shrink-0 items-center justify-center">
         <Icon className={`size-5.5 ${iconClass}`} />
       </div>
       {actorHandle ? (
-        <Link to="/$handle" params={{ handle: actorHandle }} className="shrink-0">
-          <ProfileHoverCard handle={actorHandle}>
+        <ProfileHoverCard handle={actorHandle}>
+          <button
+            type="button"
+            onClick={openActorProfile}
+            className="shrink-0 rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+            aria-label={`Open @${actorHandle} profile`}
+          >
             <Avatar
               initial={actorInitial}
               src={item.actor?.avatarUrl}
               className="size-10"
             />
-          </ProfileHoverCard>
-        </Link>
+          </button>
+        </ProfileHoverCard>
       ) : (
         <Avatar
           initial={actorInitial}
@@ -949,8 +962,12 @@ function NotificationRow({ item }: { item: NotificationItem }) {
       <div className="min-w-0 flex-1 text-sm">
         <p>
           {actorHandle ? (
-            <Link to="/$handle" params={{ handle: actorHandle }} className="inline-block">
-              <ProfileHoverCard handle={actorHandle}>
+            <ProfileHoverCard handle={actorHandle}>
+              <button
+                type="button"
+                onClick={openActorProfile}
+                className="inline-flex cursor-pointer items-center rounded-sm align-middle focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+              >
                 <span className="inline-flex items-center gap-1 align-middle font-semibold text-primary">
                   {actorDisplayName || actorHandle || "someone"}
                   {item.actor?.isVerified && (
@@ -958,8 +975,8 @@ function NotificationRow({ item }: { item: NotificationItem }) {
                   )}
                 </span>
                 <span className="text-tertiary"> @{actorHandle}</span>
-              </ProfileHoverCard>
-            </Link>
+              </button>
+            </ProfileHoverCard>
           ) : (
             <span className="inline-flex items-center gap-1 align-middle font-semibold text-primary">
               {actorDisplayName || actorHandle || "someone"}

--- a/apps/web/src/routes/notifications.tsx
+++ b/apps/web/src/routes/notifications.tsx
@@ -850,7 +850,6 @@ function formatShortTime(iso: string): string {
 }
 
 function NotificationRow({ item }: { item: NotificationItem }) {
-  const navigate = useNavigate()
   const Icon = iconForKind(item.kind)
   const iconClass = iconClassForKind(item.kind)
   const verb = verbForKind(item.kind)
@@ -871,20 +870,13 @@ function NotificationRow({ item }: { item: NotificationItem }) {
 
   const containerClass = `block border-b border-neutral px-4 py-3.5 transition-colors hover:bg-base-2/20 ${!item.readAt ? "bg-subtle" : ""}`
 
-  function openActorProfile(e: React.MouseEvent) {
-    if (!actorHandle) return
-    e.preventDefault()
-    e.stopPropagation()
-    navigate({ to: "/$handle", params: { handle: actorHandle } })
-  }
-
   const content = (
     <div className="flex items-start gap-3">
       <div className="flex size-10 shrink-0 items-center justify-center">
         <Icon className={`size-5.5 ${iconClass}`} />
       </div>
       {actorHandle ? (
-        <div onClick={openActorProfile} className="shrink-0">
+        <Link to="/$handle" params={{ handle: actorHandle }} className="shrink-0">
           <ProfileHoverCard handle={actorHandle}>
             <Avatar
               initial={actorInitial}
@@ -892,7 +884,7 @@ function NotificationRow({ item }: { item: NotificationItem }) {
               className="size-10"
             />
           </ProfileHoverCard>
-        </div>
+        </Link>
       ) : (
         <Avatar
           initial={actorInitial}
@@ -903,7 +895,7 @@ function NotificationRow({ item }: { item: NotificationItem }) {
       <div className="min-w-0 flex-1 text-sm">
         <p>
           {actorHandle ? (
-            <span onClick={openActorProfile} className="inline-block">
+            <Link to="/$handle" params={{ handle: actorHandle }} className="inline-block">
               <ProfileHoverCard handle={actorHandle}>
                 <span className="inline-flex items-center gap-1 align-middle font-semibold text-primary">
                   {actorDisplayName || actorHandle || "someone"}
@@ -913,7 +905,7 @@ function NotificationRow({ item }: { item: NotificationItem }) {
                 </span>
                 <span className="text-tertiary"> @{actorHandle}</span>
               </ProfileHoverCard>
-            </span>
+            </Link>
           ) : (
             <span className="inline-flex items-center gap-1 align-middle font-semibold text-primary">
               {actorDisplayName || actorHandle || "someone"}

--- a/apps/web/src/routes/notifications.tsx
+++ b/apps/web/src/routes/notifications.tsx
@@ -39,6 +39,7 @@ import { usePageHeader } from "../components/app-page-header"
 import { useCompose } from "../components/compose-provider"
 import { PageEmpty } from "../components/page-surface"
 import { PageFrame } from "../components/page-frame"
+import { ProfileHoverCard } from "../components/profile-hover-card"
 import { VerifiedBadge } from "../components/verified-badge"
 import { RichText } from "../components/rich-text"
 import { useInfiniteScrollSentinel } from "../lib/use-infinite-scroll-sentinel"
@@ -849,6 +850,7 @@ function formatShortTime(iso: string): string {
 }
 
 function NotificationRow({ item }: { item: NotificationItem }) {
+  const navigate = useNavigate()
   const Icon = iconForKind(item.kind)
   const iconClass = iconClassForKind(item.kind)
   const verb = verbForKind(item.kind)
@@ -869,26 +871,56 @@ function NotificationRow({ item }: { item: NotificationItem }) {
 
   const containerClass = `block border-b border-neutral px-4 py-3.5 transition-colors hover:bg-base-2/20 ${!item.readAt ? "bg-subtle" : ""}`
 
+  function openActorProfile(e: React.MouseEvent) {
+    if (!actorHandle) return
+    e.preventDefault()
+    e.stopPropagation()
+    navigate({ to: "/$handle", params: { handle: actorHandle } })
+  }
+
   const content = (
     <div className="flex items-start gap-3">
       <div className="flex size-10 shrink-0 items-center justify-center">
         <Icon className={`size-5.5 ${iconClass}`} />
       </div>
-      <Avatar
-        initial={actorInitial}
-        src={item.actor?.avatarUrl}
-        className="size-10 shrink-0"
-      />
+      {actorHandle ? (
+        <div onClick={openActorProfile} className="shrink-0">
+          <ProfileHoverCard handle={actorHandle}>
+            <Avatar
+              initial={actorInitial}
+              src={item.actor?.avatarUrl}
+              className="size-10"
+            />
+          </ProfileHoverCard>
+        </div>
+      ) : (
+        <Avatar
+          initial={actorInitial}
+          src={item.actor?.avatarUrl}
+          className="size-10 shrink-0"
+        />
+      )}
       <div className="min-w-0 flex-1 text-sm">
         <p>
-          <span className="inline-flex items-center gap-1 align-middle font-semibold text-primary">
-            {actorDisplayName || actorHandle || "someone"}
-            {item.actor?.isVerified && (
-              <VerifiedBadge size={14} role={item.actor.role} />
-            )}
-          </span>
-          {actorHandle && (
-            <span className="text-tertiary"> @{actorHandle}</span>
+          {actorHandle ? (
+            <span onClick={openActorProfile} className="inline-block">
+              <ProfileHoverCard handle={actorHandle}>
+                <span className="inline-flex items-center gap-1 align-middle font-semibold text-primary">
+                  {actorDisplayName || actorHandle || "someone"}
+                  {item.actor?.isVerified && (
+                    <VerifiedBadge size={14} role={item.actor.role} />
+                  )}
+                </span>
+                <span className="text-tertiary"> @{actorHandle}</span>
+              </ProfileHoverCard>
+            </span>
+          ) : (
+            <span className="inline-flex items-center gap-1 align-middle font-semibold text-primary">
+              {actorDisplayName || actorHandle || "someone"}
+              {item.actor?.isVerified && (
+                <VerifiedBadge size={14} role={item.actor.role} />
+              )}
+            </span>
           )}
           <span className="text-secondary"> {verb}</span>
           <span className="ml-1.5 text-xs text-tertiary">

--- a/packages/ui/src/components/preview-card.tsx
+++ b/packages/ui/src/components/preview-card.tsx
@@ -50,12 +50,12 @@ function PreviewCardTrigger({
 // ---------------------------------------------------------------------------
 
 export interface PreviewCardContentProps {
-  /** Side relative to the trigger */
   side?: "top" | "bottom" | "left" | "right"
-  /** Alignment relative to the trigger */
   align?: "start" | "center" | "end"
-  /** Offset from the trigger in px */
   sideOffset?: number
+  /** Wider than default `clipping-ancestors` so popovers aren’t squashed in virtual/scroll layouts. */
+  collisionBoundary?: Element | "clipping-ancestors"
+  positionMethod?: "absolute" | "fixed"
   className?: string
   children: ReactNode
 }
@@ -64,6 +64,8 @@ function PreviewCardContent({
   side = "bottom",
   align = "start",
   sideOffset = 8,
+  collisionBoundary,
+  positionMethod,
   className,
   children,
 }: PreviewCardContentProps) {
@@ -73,6 +75,8 @@ function PreviewCardContent({
         side={side}
         align={align}
         sideOffset={sideOffset}
+        {...(collisionBoundary !== undefined ? { collisionBoundary } : {})}
+        {...(positionMethod !== undefined ? { positionMethod } : {})}
         className="isolate z-50"
       >
         <PreviewCardPrimitive.Popup


### PR DESCRIPTION
### PR Description

## Summary

- Adds `ProfileHoverCard` to notification actor avatar/name so users can preview profiles directly from notifications, matching profile interaction behavior elsewhere.
- Keeps actor avatar/name clickable to open the actor profile page without breaking existing notification row navigation for post-targeted items.
- Improves hover card resilience by adding profile-load fallback UI and preview-card positioning/collision options to avoid clipping in notification layouts.

## Test plan

- [x] `bun run typecheck` passes
- [x] Manually exercised the affected flow in the browser
- [x] No new console errors / network errors

## Notes

- Fixes [#128](https://github.com/twitbruv/twitbruv/issues/128)
- No migrations, env var changes, or breaking API changes.

## Screen Recording:

<table>
  <tr>
    <th>Before</th>
    <th>After</th>
  </tr>
  <tr>
    <td>
      <video src="https://github.com/user-attachments/assets/9d3589aa-0b2e-4214-83e4-68ef18a0b9fa" controls muted playsinline width="360"></video>      
    </td>
    <td>
	<video src="https://github.com/user-attachments/assets/e636f1ff-e0b5-44d3-9f26-9ebe6ff48bda" controls muted playsinline width="360"></video>
    </td>
  </tr>
</table>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Profile hover cards added to notifications for quick preview of actor profiles and inline navigation.

* **Improvements**
  * Reworked follow/unfollow flow with pending-state handling and clearer failure messages.
  * Explicit error shown when profile data is missing or fails to load.
  * Preview cards gain collision-boundary and positioning options for more stable, predictable placement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->