### PR TITLE
Fix For You announcement on mobile

### DIFF
--- a/apps/web/src/components/app-shell.tsx
+++ b/apps/web/src/components/app-shell.tsx
@@ -24,8 +24,8 @@ export function AppShell({ children }: { children: ReactNode }) {
   const { data: session } = authClient.useSession()
   const authed = Boolean(session)
   const pathname = useRouterState({ select: (s) => s.location.pathname })
-  const isAdminShell = pathname.startsWith("/admin");
-  const showMobileIslandNav = authed && !isAdminShell;
+  const isAdminShell = pathname.startsWith("/admin")
+  const showMobileIslandNav = authed && !isAdminShell
 
   const sidebarLeftStyle = {
     left: "max(0px, calc((100vw - 1080px) / 2))",

--- a/apps/web/src/components/for-you-announcement.tsx
+++ b/apps/web/src/components/for-you-announcement.tsx
@@ -63,14 +63,14 @@ export function ForYouAnnouncement() {
           <DialogFooter className="flex-row justify-end gap-2">
             <Button
               variant="secondary"
-              className="flex-[4] sm:flex-none"
+              className="flex-[3] sm:flex-none"
               onClick={handleTurnOff}
             >
               Turn off
             </Button>
             <Button
               variant="primary"
-              className="flex-[6] sm:flex-none"
+              className="flex-[7] sm:flex-none"
               onClick={handleDismiss}
             >
               Dismiss

--- a/apps/web/src/components/for-you-announcement.tsx
+++ b/apps/web/src/components/for-you-announcement.tsx
@@ -50,19 +50,29 @@ export function ForYouAnnouncement() {
           alt="Introducing the For You feed"
           className="w-full rounded-t-xl"
         />
-        <div className="flex flex-col gap-4 p-4">
+        <div className="flex flex-col gap-5 p-5 sm:p-4">
           <DialogHeader>
-            <DialogTitle>Say goodbye to the Network tab</DialogTitle>
-            <DialogDescription>
+            <DialogTitle className="text-xl/tight font-semibold sm:text-lg/tight">
+              Say goodbye to the Network tab
+            </DialogTitle>
+            <DialogDescription className="text-base/relaxed sm:text-sm/relaxed">
               We've added a personalized feed to your home timeline. You can
               turn it on or off anytime in Settings &rarr; Experiments.
             </DialogDescription>
           </DialogHeader>
-          <DialogFooter>
-            <Button variant="secondary" size="sm" onClick={handleTurnOff}>
+          <DialogFooter className="flex-row justify-end gap-2">
+            <Button
+              variant="secondary"
+              className="flex-[4] sm:flex-none"
+              onClick={handleTurnOff}
+            >
               Turn off
             </Button>
-            <Button variant="primary" size="sm" onClick={handleDismiss}>
+            <Button
+              variant="primary"
+              className="flex-[6] sm:flex-none"
+              onClick={handleDismiss}
+            >
               Dismiss
             </Button>
           </DialogFooter>

--- a/packages/ui/src/components/tooltip.tsx
+++ b/packages/ui/src/components/tooltip.tsx
@@ -1,7 +1,7 @@
 import { Tooltip as TooltipPrimitive } from "@base-ui/react/tooltip"
 import { createContext, useContext, useMemo } from "react"
 import { cn } from "@workspace/ui/lib/utils"
-import type { ReactNode } from "react"
+import type { ReactElement, ReactNode } from "react"
 
 // ---------------------------------------------------------------------------
 // Animation config
@@ -165,7 +165,7 @@ export interface TooltipProps {
   /** Delay in ms before the tooltip appears */
   delay?: number
   /** The element that triggers the tooltip */
-  children: ReactNode
+  children: ReactElement
 }
 
 function TooltipImpl({
@@ -185,18 +185,15 @@ function TooltipImpl({
         handle={group.handle}
         payload={label}
         delay={delay}
-      >
-        {children}
-      </TooltipPrimitive.Trigger>
+        render={children}
+      />
     )
   }
 
   return (
     <TooltipPrimitive.Provider delay={delay}>
       <TooltipPrimitive.Root>
-        <TooltipPrimitive.Trigger className="outline-none">
-          {children}
-        </TooltipPrimitive.Trigger>
+        <TooltipPrimitive.Trigger className="outline-none" render={children} />
         <TooltipPrimitive.Portal>
           <TooltipPrimitive.Positioner
             side={side}


### PR DESCRIPTION
## Summary
- Make the For You announcement read better on mobile with larger copy and a full-width 30/70 action row.
- Compose tooltip triggers into their child button so the compose toolbar no longer renders nested buttons during hydration.

## Test plan
- `bun run typecheck --filter=@workspace/ui --filter=web`
- `bun run typecheck --filter=web`
- `bun run lint --filter=@workspace/ui --filter=web`
- `bunx prettier --check \"apps/web/src/components/for-you-announcement.tsx\"`
- `bunx prettier --check \"packages/ui/src/components/tooltip.tsx\"`
- `bun run build`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Refined the announcement dialog's layout with improved spacing, padding, and responsive typography.
  * Enhanced button styling in the announcement dialog for better visual hierarchy.

* **Refactor**
  * Standardized tooltip trigger rendering for more consistent behavior across usages.
  * Tightened the tooltip component's public API for stricter child element expectations.

* **Behavior**
  * Mobile island navigation is now hidden on admin routes for clearer admin layouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->