### PR TITLE
Fix profile images breaking after 15 minutes

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -193,9 +193,9 @@ app.route(
 )
 
 // Signing proxy: takes a stored object key on the path, mints a short-lived signed URL, and
-// 302s the browser to it. We cache the redirect for a few minutes so repeated `<img>` paints
-// don't thrash signing. The signed URL itself stays valid past the cache so refreshes hit the
-// same underlying object cheaply.
+// 302s the browser to it. The CDN edge caches the redirect briefly (s-maxage) so repeated
+// paints don't thrash signing; browsers are told no-store to avoid disk-caching a redirect
+// whose signed URL expires long before the browser would evict it.
 app.get('/api/m/*', async (c) => {
   // Recover the object key by stripping every leading occurrence of the route prefix. Belt
   // and suspenders for any path-doubling that happens upstream (proxies, custom domains).
@@ -221,14 +221,12 @@ app.get('/api/m/*', async (c) => {
     key,
     expiresInSeconds: ctx.env.MEDIA_SIGNED_URL_TTL_SEC,
   })
-  // Keep redirect caches comfortably shorter than the signed URL they point at. If an
-  // intermediary or browser reuses the 302 after the S3 signature expires, image loads fail
-  // with 403 until the cached redirect is bypassed.
-  const cacheSeconds = Math.max(0, Math.min(300, ctx.env.MEDIA_SIGNED_URL_TTL_SEC - 60))
-  c.header(
-    'Cache-Control',
-    `public, max-age=${cacheSeconds}, s-maxage=${cacheSeconds}, must-revalidate`,
-  )
+  // Cloudflare's default Browser Cache TTL (4 h) overrides any lower max-age, so the
+  // browser would disk-cache this 302 far past the signed URL's 15-min lifetime → 403.
+  // `no-store` is respected even when CF overrides max-age, preventing browser caching.
+  // `s-maxage` still lets the CDN edge cache the redirect for a few minutes.
+  const edgeSeconds = Math.max(0, Math.min(300, ctx.env.MEDIA_SIGNED_URL_TTL_SEC - 60))
+  c.header('Cache-Control', `no-store, s-maxage=${edgeSeconds}`)
   return c.redirect(signed, 302)
 })
 app.route('/api/articles', articlesRoute)


### PR DESCRIPTION
## Summary

- Profile pics and other media load fine initially, then start 403-ing after ~15 minutes. The pattern: browser serves a cached 302 redirect from `/api/m/*` whose signed Tigris URL has already expired, so the storage layer rejects it.
- Root cause: Cloudflare's default Browser Cache TTL is 4 hours and it silently overrides any lower `max-age` we set. Our previous fix (#131) correctly lowered `max-age` to 300s, but Cloudflare rewrote it back to 14400s before the browser saw it. The `s-maxage=300` we added did reach the CDN edge, but `max-age` — the one the browser actually uses — was still 4 hours.
- Fix: switch the redirect's `Cache-Control` to `no-store` (which Cloudflare respects unconditionally) so the browser never disk-caches the 302. The CDN edge still caches it briefly via `s-maxage`.

## Test plan

- [x] `bun run typecheck` passes
- [x] `bun run lint` passes
- [x] `bun run format:check` passes
- [x] `bun run build` passes
- [ ] Manually verify images stay loaded after 15+ minutes with cache enabled
- [ ] No new console errors / network errors

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized caching behavior for media redirects to balance browser cache efficiency with content delivery network performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->