### PR TITLE
Fix likes count rendering in notifications

### DIFF
--- a/apps/web/src/routes/notifications.tsx
+++ b/apps/web/src/routes/notifications.tsx
@@ -726,8 +726,11 @@ function ReplyRow({ item }: { item: NotificationItem }) {
               </span>
             </div>
             <div className="flex-1">
-              <span className="inline-flex size-7 items-center justify-center rounded-full text-tertiary">
+              <span className="inline-flex items-center gap-1 rounded-full text-tertiary">
                 <HeartOutline className="size-4" />
+                {(replyTarget?.counts.likes ?? 0) > 0 && (
+                  <span className="text-xs">{replyTarget?.counts.likes}</span>
+                )}
               </span>
             </div>
             <div>
@@ -818,8 +821,11 @@ function MentionRow({ item }: { item: NotificationItem }) {
               </span>
             </div>
             <div className="flex-1">
-              <span className="inline-flex size-7 items-center justify-center rounded-full text-tertiary">
+              <span className="inline-flex items-center gap-1 rounded-full text-tertiary">
                 <HeartOutline className="size-4" />
+                {(mentionTarget?.counts.likes ?? 0) > 0 && (
+                  <span className="text-xs">{mentionTarget?.counts.likes}</span>
+                )}
               </span>
             </div>
             <div>
@@ -899,6 +905,12 @@ function NotificationRow({ item }: { item: NotificationItem }) {
           <p className="mt-1 line-clamp-1 text-sm text-tertiary">
             {item.target.text}
           </p>
+        )}
+        {item.target && item.kind !== "like" && item.target.counts.likes > 0 && (
+          <div className="mt-1.5 flex items-center gap-1 text-xs text-tertiary">
+            <HeartOutline className="size-3.5" />
+            <span>{item.target.counts.likes}</span>
+          </div>
         )}
       </div>
     </div>


### PR DESCRIPTION
## Summary

- Fixed notification item rendering in `apps/web/src/routes/notifications.tsx` so like metadata is shown only where it adds context, and not duplicated in like notifications.
- Updated `GroupedLikeRow` and `NotificationRow` to avoid showing a redundant likes count on liked-post notifications.
- Updated `ReplyRow`, `MentionRow`, and `NotificationRow` to hide numeric like counts when the value is `0`, keeping the UI cleaner and consistent with expected behavior.

## Test plan

- [x] `bun run typecheck` passes
- [x] Manually exercised the affected flow in the browser
- [x] No new console errors / network errors

## Notes

- No migrations, env-var changes, or API contract changes.
- UI-only change scoped to notifications rendering logic.

Screenshots:
<table>
  <tr>
    <th>Before</th>
    <th>After</th>
  </tr>
  <tr>
    <td>
      <img width="901" height="721" alt="Before notifications UI" src="https://github.com/user-attachments/assets/6495e724-69e0-4d08-ad53-e4afdd3ce025" />
    </td>
    <td>
      <img width="867" height="571" alt="After notifications UI" src="https://github.com/user-attachments/assets/3cff2dcb-8e25-44cc-9f87-dcb9ce6c2527" />
    </td>
  </tr>
</table>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Notification UI now displays likes counts with heart icons in relevant notification sections. Like count badges appear only when likes are present, providing clearer visibility of engagement metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->