### PR TITLE
Add post linking to For You feed

### DIFF
--- a/apps/api/src/lib/feed-chain-preview.ts
+++ b/apps/api/src/lib/feed-chain-preview.ts
@@ -182,3 +182,70 @@ export function filterRedundantChainPosts(
     return !shownAsChainRoot.has(p.id)
   })
 }
+
+/**
+ * Ranked-feed variant of link + dedup. Walks posts in ranker order so the first
+ * reply to claim a root wins; later replies to the same root are dropped entirely.
+ * This avoids showing the same root post twice and gives the ranker indirect control
+ * over which reply surfaces (the one it ranked highest).
+ *
+ * Handles three reply tiers:
+ *  1. depth >= 2 already processed by attachFeedChainPreviews (chainPreview set)
+ *  2. depth-1 replies whose parent is on the same page (same-page linking)
+ *  3. depth-1 replies whose parent is off-page (promote replyParent to chainPreview)
+ *
+ * After linking, standalone posts that became chain roots are removed.
+ */
+export function linkAndDeduplicateRanked(
+  posts: Array<PostDto>
+): Array<PostDto> {
+  const byId = new Map<string, PostDto>()
+  for (const p of posts) byId.set(p.id, p)
+
+  const usedRoots = new Set<string>()
+  const toRemove = new Set<string>()
+
+  for (const p of posts) {
+    if (p.chainPreview) {
+      const rootId = p.chainPreview.root.id
+      if (usedRoots.has(rootId)) {
+        delete p.chainPreview
+        toRemove.add(p.id)
+      } else {
+        usedRoots.add(rootId)
+      }
+      continue
+    }
+
+    if (!p.replyToId) continue
+
+    const parent = byId.get(p.replyToId)
+    if (parent) {
+      if (usedRoots.has(parent.id)) {
+        toRemove.add(p.id)
+        continue
+      }
+      p.chainPreview = { root: parent, omittedCount: 0 }
+      delete p.replyParent
+      usedRoots.add(parent.id)
+      continue
+    }
+
+    if (p.replyParent) {
+      const parentId = p.replyParent.id
+      if (usedRoots.has(parentId)) {
+        toRemove.add(p.id)
+        continue
+      }
+      p.chainPreview = { root: p.replyParent, omittedCount: 0 }
+      delete p.replyParent
+      usedRoots.add(parentId)
+    }
+  }
+
+  return posts.filter((p) => {
+    if (toRemove.has(p.id)) return false
+    if (usedRoots.has(p.id) && !p.chainPreview) return false
+    return true
+  })
+}

--- a/apps/api/src/routes/feed.ts
+++ b/apps/api/src/routes/feed.ts
@@ -31,6 +31,7 @@ import {
   attachFeedChainPreviews,
   linkSamePageReplies,
   filterRedundantChainPosts,
+  linkAndDeduplicateRanked,
 } from "../lib/feed-chain-preview.ts"
 import { attachReplyParents } from "../lib/reply-parents.ts"
 import { loadPolls } from "../lib/polls.ts"
@@ -504,7 +505,14 @@ feedRoute.get("/for-you", requireHandle(), async (c) => {
       mediaEnv,
       postIds: fallbackIds,
     })
-    const trimmed = fallbackPosts.slice(0, limit)
+    await attachFeedChainPreviews({
+      db,
+      viewerId: me,
+      env: mediaEnv,
+      posts: fallbackPosts,
+    })
+    const linkedFallback = linkAndDeduplicateRanked(fallbackPosts)
+    const trimmed = linkedFallback.slice(0, limit)
     const fallbackResponse: ForYouFeedResponse = {
       posts: trimmed,
       nextCursor: null,
@@ -525,7 +533,14 @@ feedRoute.get("/for-you", requireHandle(), async (c) => {
     mediaEnv,
     postIds: ranker.data.postIds,
   })
-  const trimmed = ordered.slice(0, limit)
+  await attachFeedChainPreviews({
+    db,
+    viewerId: me,
+    env: mediaEnv,
+    posts: ordered,
+  })
+  const linked = linkAndDeduplicateRanked(ordered)
+  const trimmed = linked.slice(0, limit)
   if (
     ranker.data.algoVersion !== algoVersion ||
     ranker.data.variant !== variant


### PR DESCRIPTION
## Summary

- Replies in the For You feed now show the linked chain preview UI (root post → thread line → reply) instead of rendering as disconnected cards. The API was hydrating For You posts but never calling the chain preview logic, so `post.chainPreview` was always empty — even though the web app was already wired up to render it.
- A new `linkAndDeduplicateRanked()` function walks posts in ranker order so the first reply to claim a root wins. Later replies to the same root are dropped entirely, which avoids showing the same root post twice and naturally rotates which reply surfaces across impression cycles.
- Also applies to the fallback (chrono) path when the ranker is unavailable.

## Test plan

- [x] `bun run typecheck` passes
- [x] `bun run lint` passes
- [x] `bun run format:check` passes
- [x] `bun run build` passes
- [ ] Manually exercised the affected flow in the browser

## Notes

No schema changes, no new dependencies, no env vars. The web app already had `chainPreview={true}` for the For You tab and the `FeedChainPreview` component — this just makes the API actually populate the data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of duplicate posts in ranked feeds with enhanced deduplication logic.
  * Optimized post organization to better associate and link reply chains with their root posts.
  * Refined feed result processing to deduplicate and organize posts before applying result limits, ensuring higher-quality feed content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->