### PR TITLE
Add verified badges to new PostCard UI

### DIFF
--- a/apps/web/src/components/feed-post-card.tsx
+++ b/apps/web/src/components/feed-post-card.tsx
@@ -198,6 +198,8 @@ export function FeedPostCard({
             handle: q.author.handle,
             displayName: q.author.displayName,
             avatarUrl: q.author.avatarUrl,
+            isVerified: q.author.isVerified,
+            role: q.author.role,
           },
           text: q.text,
           time: relativeTime(q.createdAt),
@@ -218,6 +220,8 @@ export function FeedPostCard({
           handle: authorHandle,
           displayName: post.author.displayName ?? authorHandle,
           avatarUrl: post.author.avatarUrl,
+          isVerified: post.author.isVerified,
+          role: post.author.role,
         }}
         text={post.text}
         time={relativeTime(post.createdAt)}

--- a/apps/web/src/components/verified-badge.tsx
+++ b/apps/web/src/components/verified-badge.tsx
@@ -1,39 +1,4 @@
-import { CheckBadgeIcon } from "@heroicons/react/24/solid"
-import { cn } from "@workspace/ui/lib/utils"
-
-export type VerifiedBadgeRole = "user" | "admin" | "owner"
-
-const roleColorClass: Record<VerifiedBadgeRole, string> = {
-  user: "text-sky-500",
-  admin: "text-emerald-500",
-  owner: "text-amber-400",
-}
-
-const roleAriaLabel: Record<VerifiedBadgeRole, string> = {
-  user: "Verified account",
-  admin: "Verified admin account",
-  owner: "Verified owner account",
-}
-
-export function VerifiedBadge({
-  size,
-  role = "user",
-  className,
-}: {
-  size?: number
-  role?: VerifiedBadgeRole | null
-  className?: string
-}) {
-  const resolvedRole: VerifiedBadgeRole = role ?? "user"
-  return (
-    <CheckBadgeIcon
-      aria-label={roleAriaLabel[resolvedRole]}
-      className={cn(
-        "inline-block shrink-0",
-        roleColorClass[resolvedRole],
-        className
-      )}
-      style={size !== undefined ? { width: size, height: size } : undefined}
-    />
-  )
-}
+export {
+  VerifiedBadge,
+  type VerifiedBadgeRole,
+} from "@workspace/ui/components/verified-badge"

--- a/packages/ui/src/components/post-card.tsx
+++ b/packages/ui/src/components/post-card.tsx
@@ -20,6 +20,8 @@ import { DropdownMenu } from "@workspace/ui/components/dropdown-menu"
 import { Hover } from "@workspace/ui/components/hover"
 import { PreviewCard } from "@workspace/ui/components/preview-card"
 import { AnimatedNumber } from "@workspace/ui/components/animated-number"
+import { VerifiedBadge } from "@workspace/ui/components/verified-badge"
+import type { VerifiedBadgeRole } from "@workspace/ui/components/verified-badge"
 import type { CSSProperties, ReactNode } from "react"
 
 /** Extra profile data for the author hover card */
@@ -42,6 +44,8 @@ export interface PostQuoteOf {
     handle: string | null
     displayName: string | null
     avatarUrl: string | null
+    isVerified?: boolean
+    role?: VerifiedBadgeRole | null
   }
   text: string
   time: string
@@ -55,6 +59,8 @@ export interface PostCardProps {
     handle: string
     displayName: string
     avatarUrl: string | null
+    isVerified?: boolean
+    role?: VerifiedBadgeRole | null
   }
   text: string
   time: string
@@ -296,7 +302,7 @@ export function PostCard({
                   <PreviewCard.Trigger
                     render={<span />}
                     className={cn(
-                      "truncate font-semibold text-primary outline-none",
+                      "flex items-center gap-1 truncate font-semibold text-primary outline-none",
                       onAuthorClick && "cursor-pointer hover:underline"
                     )}
                     onClick={(e) => {
@@ -305,6 +311,9 @@ export function PostCard({
                     }}
                   >
                     {author.displayName}
+                    {author.isVerified && (
+                      <VerifiedBadge size={15} role={author.role} />
+                    )}
                   </PreviewCard.Trigger>
                   <PreviewCard.Content
                     side="bottom"
@@ -327,7 +336,7 @@ export function PostCard({
               ) : (
                 <span
                   className={cn(
-                    "truncate font-semibold text-primary",
+                    "flex items-center gap-1 truncate font-semibold text-primary",
                     onAuthorClick && "cursor-pointer hover:underline"
                   )}
                   onClick={(e) => {
@@ -336,6 +345,9 @@ export function PostCard({
                   }}
                 >
                   {author.displayName}
+                  {author.isVerified && (
+                    <VerifiedBadge size={15} role={author.role} />
+                  )}
                 </span>
               )}
               <span className="truncate text-tertiary">@{author.handle}</span>
@@ -638,7 +650,12 @@ function QuoteEmbed({ quote }: { quote: PostQuoteOf }) {
               src={quote.author.avatarUrl}
               size="xs"
             />
-            <span className="font-semibold text-primary">{displayName}</span>
+            <span className="flex items-center gap-1 font-semibold text-primary">
+              {displayName}
+              {quote.author.isVerified && (
+                <VerifiedBadge size={13} role={quote.author.role} />
+              )}
+            </span>
             {handle && <span className="text-tertiary">@{handle}</span>}
             <span className="text-tertiary">&middot;</span>
             <span className="text-tertiary">{quote.time}</span>
@@ -742,6 +759,7 @@ function AuthorHoverContent({
           }}
         >
           {author.displayName}
+          {author.isVerified && <VerifiedBadge size={15} role={author.role} />}
         </span>
         <span className="text-xs text-tertiary">@{author.handle}</span>
       </div>

--- a/packages/ui/src/components/verified-badge.tsx
+++ b/packages/ui/src/components/verified-badge.tsx
@@ -1,12 +1,12 @@
-import { CheckBadgeIcon } from "@heroicons/react/24/solid"
+import { CheckBadgeIcon } from "@heroicons/react/16/solid"
 import { cn } from "@workspace/ui/lib/utils"
 
 export type VerifiedBadgeRole = "user" | "admin" | "owner"
 
 const roleColorClass: Record<VerifiedBadgeRole, string> = {
-  user: "text-sky-500",
-  admin: "text-emerald-500",
-  owner: "text-amber-400",
+  user: "text-link",
+  admin: "text-success",
+  owner: "text-warn",
 }
 
 const roleAriaLabel: Record<VerifiedBadgeRole, string> = {

--- a/packages/ui/src/components/verified-badge.tsx
+++ b/packages/ui/src/components/verified-badge.tsx
@@ -1,0 +1,39 @@
+import { CheckBadgeIcon } from "@heroicons/react/24/solid"
+import { cn } from "@workspace/ui/lib/utils"
+
+export type VerifiedBadgeRole = "user" | "admin" | "owner"
+
+const roleColorClass: Record<VerifiedBadgeRole, string> = {
+  user: "text-sky-500",
+  admin: "text-emerald-500",
+  owner: "text-amber-400",
+}
+
+const roleAriaLabel: Record<VerifiedBadgeRole, string> = {
+  user: "Verified account",
+  admin: "Verified admin account",
+  owner: "Verified owner account",
+}
+
+export function VerifiedBadge({
+  size,
+  role = "user",
+  className,
+}: {
+  size?: number
+  role?: VerifiedBadgeRole | null
+  className?: string
+}) {
+  const resolvedRole: VerifiedBadgeRole = role ?? "user"
+  return (
+    <CheckBadgeIcon
+      aria-label={roleAriaLabel[resolvedRole]}
+      className={cn(
+        "inline-block shrink-0",
+        roleColorClass[resolvedRole],
+        className
+      )}
+      style={size !== undefined ? { width: size, height: size } : undefined}
+    />
+  )
+}

--- a/packages/ui/src/components/verified-badge.tsx
+++ b/packages/ui/src/components/verified-badge.tsx
@@ -4,9 +4,9 @@ import { cn } from "@workspace/ui/lib/utils"
 export type VerifiedBadgeRole = "user" | "admin" | "owner"
 
 const roleColorClass: Record<VerifiedBadgeRole, string> = {
-  user: "text-link",
-  admin: "text-success",
-  owner: "text-warn",
+  user: "text-badge-user",
+  admin: "text-badge-admin",
+  owner: "text-badge-owner",
 }
 
 const roleAriaLabel: Record<VerifiedBadgeRole, string> = {

--- a/packages/ui/src/styles/theme.css
+++ b/packages/ui/src/styles/theme.css
@@ -72,6 +72,11 @@
   --text-color-like: var(--color-red-9);
   --background-color-like: var(--color-red-9);
 
+  /* ── Verified badge ── */
+  --color-badge-user: oklch(0.685 0.169 237.7);
+  --color-badge-admin: oklch(0.696 0.17 162.5);
+  --color-badge-owner: oklch(0.837 0.161 86.7);
+
   /* ── Easing ── */
   --ease-out-expo: cubic-bezier(0.16, 1, 0.3, 1);
 
@@ -212,6 +217,10 @@
 
   --text-color-like: var(--color-red-9);
   --background-color-like: var(--color-red-9);
+
+  --color-badge-user: oklch(0.65 0.13 237.7);
+  --color-badge-admin: oklch(0.66 0.13 162.5);
+  --color-badge-owner: oklch(0.78 0.12 86.7);
 
   --border-color-neutral: var(--color-gray-5);
   --border-color-neutral-strong: var(--color-gray-7);


### PR DESCRIPTION
## Summary
- The new `PostCard` in `packages/ui` was missing verified badge support — the old one in `apps/web` had it but the new one never got it
- Moved `VerifiedBadge` to `packages/ui` and wired `isVerified`/`role` through the existing `author` prop on `PostCardProps` and `PostQuoteOf`
- Badges now show in feed post headers, author hover cards, and quote embeds

## Verification
- `bun run typecheck` ✅
- `bun run lint` ✅
- `bun run format:check` ✅
- `bun run build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Author verification badges now display on posts with role-specific styling for user, admin, and owner accounts.
  * Verification indicators appear in post headers, quoted posts, and author preview cards for consistent verification display across the app.

* **Style**
  * Added theme colors for verification badges, including dark-mode variants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->