### PR TITLE
Fix replies showing unchained when parent is off-page

### DIFF
--- a/apps/api/src/lib/feed-chain-preview.ts
+++ b/apps/api/src/lib/feed-chain-preview.ts
@@ -162,9 +162,15 @@ export function linkSamePageReplies(posts: Array<PostDto>): void {
     if (p.chainPreview) continue
     if (!p.replyToId) continue
     const parent = byId.get(p.replyToId)
-    if (!parent) continue
-    p.chainPreview = { root: parent, omittedCount: 0 }
-    delete p.replyParent
+    if (parent) {
+      p.chainPreview = { root: parent, omittedCount: 0 }
+      delete p.replyParent
+      continue
+    }
+    if (p.replyParent) {
+      p.chainPreview = { root: p.replyParent, omittedCount: 0 }
+      delete p.replyParent
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

Replies to older posts were showing up as standalone/orphan posts in the Home and All feeds instead of being chained to their parent.

The issue: when a depth-1 reply's parent post is too old to land on the same page of results, `linkSamePageReplies` couldn't find it and just gave up — even though the parent data was already loaded and sitting right there on the post (`replyParent`). The For You feed already handled this case, but the other feeds didn't.

The fix adds a simple fallback: if the parent isn't on the current page, use the already-loaded parent data to build the chain. No extra DB queries, just using data we already have.

## Test plan

- [ ] Open the All feed — replies to older posts should now show chained to their parent
- [ ] Open the Home (Following) feed — same behavior
- [ ] Verify deep replies (depth 2+) and same-page replies still chain correctly
- [ ] Verify the For You feed is unaffected (uses a separate code path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reply chain preview display to show previews in more scenarios, including fallback cases where in-page parent references are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->