### PR TITLE
Fix empty posts in feed caused by repost-of-a-repost

### DIFF
--- a/apps/api/src/routes/posts.ts
+++ b/apps/api/src/routes/posts.ts
@@ -341,13 +341,31 @@ postsRoute.post('/:id/repost', requireHandle(), async (c) => {
       .limit(1)
     if (!target) throw new HttpError(404, 'not_found')
 
+    // If the target is itself a repost, resolve to the original content post
+    // so we never create a repost-of-a-repost chain.
+    let original = target
+    if (target.repostOfId) {
+      const [resolved] = await tx
+        .select()
+        .from(schema.posts)
+        .where(
+          and(
+            eq(schema.posts.id, target.repostOfId),
+            isNull(schema.posts.deletedAt),
+          ),
+        )
+        .limit(1)
+      if (!resolved) throw new HttpError(404, 'not_found')
+      original = resolved
+    }
+
     const [existing] = await tx
       .select({ id: schema.posts.id })
       .from(schema.posts)
       .where(
         and(
           eq(schema.posts.authorId, session.user.id),
-          eq(schema.posts.repostOfId, target.id),
+          eq(schema.posts.repostOfId, original.id),
           isNull(schema.posts.deletedAt),
         ),
       )
@@ -357,13 +375,13 @@ postsRoute.post('/:id/repost', requireHandle(), async (c) => {
     await tx.insert(schema.posts).values({
       authorId: session.user.id,
       text: '',
-      repostOfId: target.id,
+      repostOfId: original.id,
     })
 
     await tx
       .update(schema.posts)
       .set({ repostCount: sql`${schema.posts.repostCount} + 1` })
-      .where(eq(schema.posts.id, target.id))
+      .where(eq(schema.posts.id, original.id))
 
     const [actor] = await tx
       .select({ displayName: schema.users.displayName, handle: schema.users.handle })
@@ -373,21 +391,21 @@ postsRoute.post('/:id/repost', requireHandle(), async (c) => {
     const [targetAuthor] = await tx
       .select({ handle: schema.users.handle })
       .from(schema.users)
-      .where(eq(schema.users.id, target.authorId))
+      .where(eq(schema.users.id, original.authorId))
       .limit(1)
     const actorLabel = actor?.displayName?.trim() || actor?.handle || 'Someone'
 
     const { recipients: notifyRecipients, pushJobs } = await notify(tx, [
       {
-        userId: target.authorId,
+        userId: original.authorId,
         actorId: session.user.id,
         kind: 'repost',
         entityType: 'post',
-        entityId: target.id,
+        entityId: original.id,
         push: {
           title: actorLabel,
           body: 'Reposted your post',
-          deepLink: postPermalink(webUrl, targetAuthor?.handle, target.id),
+          deepLink: postPermalink(webUrl, targetAuthor?.handle, original.id),
         },
       },
     ])

--- a/apps/api/src/routes/posts.ts
+++ b/apps/api/src/routes/posts.ts
@@ -341,16 +341,19 @@ postsRoute.post('/:id/repost', requireHandle(), async (c) => {
       .limit(1)
     if (!target) throw new HttpError(404, 'not_found')
 
-    // If the target is itself a repost, resolve to the original content post
+    // Transitively resolve through repost chains to the original content post
     // so we never create a repost-of-a-repost chain.
     let original = target
-    if (target.repostOfId) {
+    const visited = new Set<string>([target.id])
+    while (original.repostOfId) {
+      if (visited.has(original.repostOfId)) break
+      visited.add(original.repostOfId)
       const [resolved] = await tx
         .select()
         .from(schema.posts)
         .where(
           and(
-            eq(schema.posts.id, target.repostOfId),
+            eq(schema.posts.id, original.repostOfId),
             isNull(schema.posts.deletedAt),
           ),
         )


### PR DESCRIPTION
## Summary

Reposting a post that was itself a repost created a chain (repost → repost → original) that the feed couldn't fully resolve. The inner repost has no text, so it showed up as an empty card in both the All and For You tabs.

The repost endpoint now resolves through to the original content post when the target is a repost, so the pointer always lands on real content. Duplicate checks, repost counts, and notifications all go to the right place too.

## Test plan

- [x] `bun run typecheck` passes
- [x] `bun run lint` passes
- [x] `bun run format:check` passes
- [x] `bun run build` passes

## Notes

Existing repost-of-a-repost rows in the database (e.g. cydex's repost of Ahmet's repost) will still show as empty until they're manually cleaned up or `loadRepostTargets` is hardened to resolve chains defensively. This PR prevents new ones from being created.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reposts of reposts now consistently resolve to the original (non-repost) post.
  * "Already reposted" detection correctly checks against the original post, preventing duplicate reposts.
  * Notifications and deep links for reposted content now point to the original post and its author.
  * Actor label computation is more tolerant of missing actor information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->