### PR TITLE
feat(badges): add contributor tier driven by GitHub connector

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -47,6 +47,12 @@ CONNECTORS_ENCRYPTION_KEY=
 # post cards. Optional — without it, GitHub URLs in posts render without the rich card.
 GITHUB_UNFURL_TOKEN=
 
+# Comma-separated list of `owner/repo` GitHub repositories whose contributors should
+# receive the contributor badge (purple). Evaluated when a user connects GitHub or hits
+# Refresh in Settings → Connections. Unset → contributor checks are skipped and the badge
+# is only granted via admin override.
+# GITHUB_CONTRIBUTOR_REPOS=twitbruv/twitbruv
+
 YOUTUBE_API_KEY=
 
 # Apple Push Notification service (worker). Optional — when unset, apns.send jobs no-op after logging.

--- a/apps/api/src/lib/analytics.ts
+++ b/apps/api/src/lib/analytics.ts
@@ -50,6 +50,8 @@ export type EventName =
   | 'admin_user_unshadowbanned'
   | 'admin_user_verified'
   | 'admin_user_unverified'
+  | 'admin_user_contributor_granted'
+  | 'admin_user_contributor_revoked'
   | 'admin_user_role_set'
   | 'admin_user_handle_set'
   | 'admin_user_deleted'

--- a/apps/api/src/lib/env.ts
+++ b/apps/api/src/lib/env.ts
@@ -77,6 +77,21 @@ const envSchema = z.object({
   // actually work. If unset, posts containing GitHub URLs render fine but without the card.
   GITHUB_UNFURL_TOKEN: z.string().optional(),
 
+  // Comma-separated list of `owner/repo` GitHub repositories whose contributors should
+  // receive the contributor badge. Evaluated when a user connects their GitHub account or
+  // hits Refresh in Settings → Connections. Unset → contributor checks are skipped and the
+  // badge is only granted via admin override.
+  GITHUB_CONTRIBUTOR_REPOS: z
+    .string()
+    .optional()
+    .transform((s) => {
+      if (!s) return [] as string[]
+      return s
+        .split(",")
+        .map((x) => x.trim())
+        .filter((x) => /^[^/\s]+\/[^/\s]+$/.test(x))
+    }),
+
   YOUTUBE_API_KEY: z.string().optional(),
   FXTWITTER_API_BASE_URL: z.string().optional(),
 

--- a/apps/api/src/lib/github-contributors.ts
+++ b/apps/api/src/lib/github-contributors.ts
@@ -1,0 +1,113 @@
+import type { AppContext } from "./context.ts"
+
+const CACHE_TTL_SEC = 10 * 60
+const PER_PAGE = 100
+const MAX_PAGES = 10
+
+interface ContributorEntry {
+  login?: string
+  type?: string
+}
+
+function cacheKey(repo: string): string {
+  return `gh:contributors:${repo.toLowerCase()}`
+}
+
+function buildHeaders(token: string | undefined): Record<string, string> {
+  const headers: Record<string, string> = {
+    accept: "application/vnd.github+json",
+    "user-agent": "twotter-contributor-check",
+    "x-github-api-version": "2022-11-28",
+  }
+  if (token) headers.authorization = `Bearer ${token}`
+  return headers
+}
+
+async function fetchContributorLogins(
+  ctx: AppContext,
+  repo: string,
+): Promise<Set<string> | null> {
+  const headers = buildHeaders(ctx.env.GITHUB_UNFURL_TOKEN)
+  const logins = new Set<string>()
+  for (let page = 1; page <= MAX_PAGES; page++) {
+    const url = `https://api.github.com/repos/${repo}/contributors?per_page=${PER_PAGE}&anon=false&page=${page}`
+    let res: Response
+    try {
+      res = await fetch(url, { headers })
+    } catch (err) {
+      ctx.log.warn(
+        { repo, err: err instanceof Error ? err.message : err },
+        "github_contributors_fetch_failed",
+      )
+      return null
+    }
+    if (res.status === 404) {
+      ctx.log.warn({ repo }, "github_contributors_repo_not_found")
+      return new Set()
+    }
+    if (res.status === 204 || res.status === 202) {
+      return new Set()
+    }
+    if (!res.ok) {
+      ctx.log.warn(
+        { repo, status: res.status },
+        "github_contributors_fetch_non_ok",
+      )
+      return null
+    }
+    let body: unknown
+    try {
+      body = await res.json()
+    } catch {
+      return null
+    }
+    if (!Array.isArray(body)) return null
+    let received = 0
+    for (const entry of body as Array<ContributorEntry>) {
+      received++
+      if (entry?.type === "Bot") continue
+      const login = entry?.login
+      if (typeof login === "string" && login.length > 0) {
+        logins.add(login.toLowerCase())
+      }
+    }
+    if (received < PER_PAGE) break
+  }
+  return logins
+}
+
+async function getContributorLogins(
+  ctx: AppContext,
+  repo: string,
+): Promise<Set<string>> {
+  const key = cacheKey(repo)
+  const cached = await ctx.cache.get<Array<string>>(key)
+  if (cached) return new Set(cached)
+  const fetched = await fetchContributorLogins(ctx, repo)
+  if (!fetched) return new Set()
+  await ctx.cache.set(key, [...fetched], CACHE_TTL_SEC)
+  return fetched
+}
+
+export async function isUserContributor(
+  ctx: AppContext,
+  login: string | null | undefined,
+): Promise<boolean> {
+  if (!login) return false
+  const repos = ctx.env.GITHUB_CONTRIBUTOR_REPOS
+  if (!repos || repos.length === 0) return false
+  const target = login.toLowerCase()
+  for (const repo of repos) {
+    const logins = await getContributorLogins(ctx, repo)
+    if (logins.has(target)) return true
+  }
+  return false
+}
+
+export function contributorReposConfigured(ctx: AppContext): boolean {
+  return (ctx.env.GITHUB_CONTRIBUTOR_REPOS ?? []).length > 0
+}
+
+export function configuredContributorRepos(ctx: AppContext): Array<string> {
+  return ctx.env.GITHUB_CONTRIBUTOR_REPOS ?? []
+}

--- a/apps/api/src/lib/post-dto.ts
+++ b/apps/api/src/lib/post-dto.ts
@@ -59,6 +59,7 @@ export interface PostDto {
     avatarUrl: string | null
     isVerified: boolean
     isBot: boolean
+    isContributor: boolean
     role: "user" | "admin" | "owner"
   }
   counts: {
@@ -154,6 +155,7 @@ export function toPostDto(
       avatarUrl: env ? assetUrl(env, author.avatarUrl) : author.avatarUrl,
       isVerified: author.isVerified,
       isBot: author.isBot,
+      isContributor: author.isContributor,
       role: author.role,
     },
     counts: {

--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -317,6 +317,8 @@ adminRoute.get('/users', async (c) => {
     banExpires: u.banExpires?.toISOString() ?? null,
     shadowBannedAt: u.shadowBannedAt?.toISOString() ?? null,
     isVerified: u.isVerified,
+    isContributor: u.isContributor,
+    contributorCheckedAt: u.contributorCheckedAt?.toISOString() ?? null,
     deletedAt: u.deletedAt?.toISOString() ?? null,
     createdAt: u.createdAt.toISOString(),
     postsCount: postsCountByUser.get(u.id) ?? 0,
@@ -413,6 +415,8 @@ adminRoute.get('/users/:id', async (c) => {
       banExpires: user.banExpires?.toISOString() ?? null,
       shadowBannedAt: user.shadowBannedAt?.toISOString() ?? null,
       isVerified: user.isVerified,
+      isContributor: user.isContributor,
+      contributorCheckedAt: user.contributorCheckedAt?.toISOString() ?? null,
       deletedAt: user.deletedAt?.toISOString() ?? null,
       createdAt: user.createdAt.toISOString(),
       postsCount: postsCountAgg[0]?.c ?? 0,
@@ -917,6 +921,56 @@ adminRoute.post('/users/:id/unverify', async (c) => {
   return c.json({ ok: true })
 })
 
+// Grant the contributor badge manually. Useful for non-code contributors (designers, docs,
+// translations) who won't appear in the GitHub /contributors list, and for testing without
+// a real GitHub connection. Sets contributorCheckedAt to "now" so the audit trail reflects
+// when the override happened.
+adminRoute.post('/users/:id/contributor', async (c) => {
+  const session = c.get('session')!
+  const { db } = c.get('ctx')
+  const id = c.req.param('id')
+  const body = verifySchema.parse(await c.req.json().catch(() => ({})))
+
+  await db.transaction(async (tx) => {
+    await tx
+      .update(schema.users)
+      .set({ isContributor: true, contributorCheckedAt: new Date() })
+      .where(eq(schema.users.id, id))
+    await tx.insert(schema.moderationActions).values({
+      moderatorId: session.user.id,
+      subjectType: 'user',
+      subjectId: id,
+      action: 'warn',
+      privateNote: `contributor_grant${body.reason ? `: ${body.reason}` : ''}`,
+    })
+  })
+  c.get('ctx').track('admin_user_contributor_granted', session.user.id)
+  return c.json({ ok: true })
+})
+
+adminRoute.delete('/users/:id/contributor', async (c) => {
+  const session = c.get('session')!
+  const { db } = c.get('ctx')
+  const id = c.req.param('id')
+  const body = verifySchema.parse(await c.req.json().catch(() => ({})))
+
+  await db.transaction(async (tx) => {
+    await tx
+      .update(schema.users)
+      .set({ isContributor: false, contributorCheckedAt: new Date() })
+      .where(eq(schema.users.id, id))
+    await tx.insert(schema.moderationActions).values({
+      moderatorId: session.user.id,
+      subjectType: 'user',
+      subjectId: id,
+      action: 'warn',
+      privateNote: `contributor_revoke${body.reason ? `: ${body.reason}` : ''}`,
+    })
+  })
+  c.get('ctx').track('admin_user_contributor_revoked', session.user.id)
+  return c.json({ ok: true })
+})
+
 // Owner-only: forcibly reassign a user's handle. Useful for reclaiming squatted handles or
 // resolving impersonation reports. The handle is freed atomically — if the new handle is
 // taken or reserved we 4xx without touching the row.
@@ -1156,6 +1210,7 @@ adminRoute.get('/posts', async (c) => {
             displayName: r.author.displayName,
             avatarUrl: assetUrl(mediaEnv, r.author.avatarUrl),
             isVerified: r.author.isVerified,
+            isContributor: r.author.isContributor,
             role: r.author.role as Role,
           }
         : null,

--- a/apps/api/src/routes/articles.ts
+++ b/apps/api/src/routes/articles.ts
@@ -60,6 +60,7 @@ function toArticleDto(
       displayName: author.displayName,
       avatarUrl: assetUrl(env, author.avatarUrl),
       isVerified: author.isVerified,
+      isContributor: author.isContributor,
       role: author.role,
     },
   }

--- a/apps/api/src/routes/connectors/github.ts
+++ b/apps/api/src/routes/connectors/github.ts
@@ -8,6 +8,7 @@ import { requireHandle } from '../../middleware/session.ts'
 import { connectorsEnabled, decryptToken, encryptToken } from '../../lib/connector-crypto.ts'
 import { exchangeCode, revokeGrant } from '../../lib/github-client.ts'
 import { bustCache, getGithubSnapshot } from '../../lib/github-snapshot.ts'
+import { isUserContributor } from '../../lib/github-contributors.ts'
 
 export const githubConnectorRoute = new Hono<HonoEnv>()
 
@@ -182,8 +183,32 @@ githubConnectorRoute.get('/callback', async (c) => {
   await bustCache(ctx, session.user.id)
   await getGithubSnapshot(ctx, session.user.id, { forceRefresh: true }).catch(() => {})
 
+  await syncContributorStatus(ctx, session.user.id, viewerLogin)
+
   return settled({ settings_tab: 'connections', connected: 'github' })
 })
+
+async function syncContributorStatus(
+  ctx: import('../../lib/context.ts').AppContext,
+  userId: string,
+  login: string | null | undefined,
+): Promise<void> {
+  try {
+    const isContributor = await isUserContributor(ctx, login)
+    await ctx.db
+      .update(schema.users)
+      .set({
+        isContributor,
+        contributorCheckedAt: new Date(),
+      })
+      .where(eq(schema.users.id, userId))
+  } catch (err) {
+    ctx.log.warn(
+      { err: err instanceof Error ? err.message : err, userId },
+      'github_contributor_sync_failed',
+    )
+  }
+}
 
 // What the settings page reads to render the current connection state.
 githubConnectorRoute.get('/me', requireHandle(), async (c) => {
@@ -209,7 +234,22 @@ githubConnectorRoute.get('/me', requireHandle(), async (c) => {
       ),
     )
     .limit(1)
-  if (!row) return c.json({ connected: false, configured: true })
+  const [userRow] = await ctx.db
+    .select({
+      isContributor: schema.users.isContributor,
+      contributorCheckedAt: schema.users.contributorCheckedAt,
+    })
+    .from(schema.users)
+    .where(eq(schema.users.id, session.user.id))
+    .limit(1)
+  const contributor = {
+    isContributor: userRow?.isContributor ?? false,
+    contributorCheckedAt:
+      userRow?.contributorCheckedAt?.toISOString() ?? null,
+    repos: ctx.env.GITHUB_CONTRIBUTOR_REPOS ?? [],
+  }
+  if (!row)
+    return c.json({ connected: false, configured: true, contributor })
 
   const meta = (row.metadata ?? {}) as {
     refreshedAt?: string
@@ -226,6 +266,7 @@ githubConnectorRoute.get('/me', requireHandle(), async (c) => {
     refreshedAt: meta.refreshedAt ?? null,
     lastFailureAt: meta.failedAt ?? null,
     lastFailureReason: meta.failureReason ?? null,
+    contributor,
   })
 })
 
@@ -256,6 +297,7 @@ githubConnectorRoute.post('/refresh', requireHandle(), async (c) => {
   await bustCache(ctx, session.user.id)
   const { snapshot } = await getGithubSnapshot(ctx, session.user.id, { forceRefresh: true })
   if (!snapshot) return c.json({ error: 'refresh_failed' }, 502)
+  await syncContributorStatus(ctx, session.user.id, snapshot.login)
   return c.json({ ok: true, refreshedAt: snapshot.refreshedAt, stale: snapshot.stale ?? false })
 })
 
@@ -302,6 +344,10 @@ githubConnectorRoute.delete('/', requireHandle(), async (c) => {
       ),
     )
   await ctx.db.delete(schema.oauthConnections).where(eq(schema.oauthConnections.id, row.id))
+  await ctx.db
+    .update(schema.users)
+    .set({ isContributor: false, contributorCheckedAt: null })
+    .where(eq(schema.users.id, session.user.id))
   await bustCache(ctx, session.user.id)
   return c.json({ ok: true })
 })

--- a/apps/api/src/routes/dms.ts
+++ b/apps/api/src/routes/dms.ts
@@ -219,6 +219,7 @@ dmsRoute.get('/', async (c) => {
       displayName: u.displayName,
       avatarUrl: assetUrl(mediaEnv, u.avatarUrl),
       isVerified: u.isVerified,
+      isContributor: u.isContributor,
       role: u.role,
     }))
     const latest = latestByConv.get(r.conv.id)
@@ -736,6 +737,7 @@ dmsRoute.get('/:id', async (c) => {
         displayName: r.user.displayName,
         avatarUrl: assetUrl(mediaEnv, r.user.avatarUrl),
         isVerified: r.user.isVerified,
+        isContributor: r.user.isContributor,
         role: r.user.role,
         chatRole: r.member.role,
         lastReadMessageId: r.member.lastReadMessageId,
@@ -815,6 +817,7 @@ dmsRoute.get('/:id/messages', async (c) => {
       displayName: r.sender.displayName,
       avatarUrl: assetUrl(mediaEnv, r.sender.avatarUrl),
       isVerified: r.sender.isVerified,
+      isContributor: r.sender.isContributor,
       role: r.sender.role,
     },
   }))

--- a/apps/api/src/routes/invites.ts
+++ b/apps/api/src/routes/invites.ts
@@ -47,6 +47,7 @@ invitesRoute.get('/:token', async (c) => {
           displayName: r.user.displayName,
           avatarUrl: assetUrl(mediaEnv, r.user.avatarUrl),
           isVerified: r.user.isVerified,
+          isContributor: r.user.isContributor,
           role: r.user.role,
         })),
       },

--- a/apps/api/src/routes/lists.ts
+++ b/apps/api/src/routes/lists.ts
@@ -277,6 +277,7 @@ listsRoute.get('/:id/members', async (c) => {
       displayName: r.user.displayName,
       avatarUrl: assetUrl(mediaEnv, r.user.avatarUrl),
       isVerified: r.user.isVerified,
+      isContributor: r.user.isContributor,
       role: r.user.role,
       addedAt: r.addedAt.toISOString(),
     })),

--- a/apps/api/src/routes/me.ts
+++ b/apps/api/src/routes/me.ts
@@ -181,6 +181,7 @@ meRoute.get('/blocks', async (c) => {
     displayName: r.user.displayName,
     avatarUrl: assetUrl(mediaEnv, r.user.avatarUrl),
     isVerified: r.user.isVerified,
+    isContributor: r.user.isContributor,
     role: r.user.role,
     blockedAt: r.block.createdAt.toISOString(),
   }))
@@ -216,6 +217,7 @@ meRoute.get('/mutes', async (c) => {
     displayName: r.user.displayName,
     avatarUrl: assetUrl(mediaEnv, r.user.avatarUrl),
     isVerified: r.user.isVerified,
+    isContributor: r.user.isContributor,
     role: r.user.role,
     mutedAt: r.mute.createdAt.toISOString(),
     scope: r.mute.scope,
@@ -341,6 +343,7 @@ function toSelfDto(
     birthday: u.birthday,
     isVerified: u.isVerified,
     isBot: u.isBot,
+    isContributor: u.isContributor,
     role: u.role,
     locale: u.locale,
     timezone: u.timezone,

--- a/apps/api/src/routes/notifications.ts
+++ b/apps/api/src/routes/notifications.ts
@@ -136,6 +136,7 @@ notificationsRoute.get('/', async (c) => {
           displayName: r.actor.displayName,
           avatarUrl: assetUrl(mediaEnv, r.actor.avatarUrl),
           isVerified: r.actor.isVerified,
+          isContributor: r.actor.isContributor,
           role: r.actor.role,
         }
       : null,

--- a/apps/api/src/routes/search.ts
+++ b/apps/api/src/routes/search.ts
@@ -158,6 +158,8 @@ searchRoute.get('/', async (c) => {
           bannerUrl: schema.users.bannerUrl,
           isVerified: schema.users.isVerified,
           isBot: schema.users.isBot,
+          isContributor: schema.users.isContributor,
+          role: schema.users.role,
           createdAt: schema.users.createdAt,
         })
         .from(schema.users)

--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -189,6 +189,7 @@ usersRoute.get('/:handle', async (c) => {
       bannerUrl: assetUrl(mediaEnv, user.bannerUrl),
       isVerified: user.isVerified,
       isBot: user.isBot,
+      isContributor: user.isContributor,
       role: user.role,
       createdAt: user.createdAt,
       counts: {
@@ -463,6 +464,7 @@ usersRoute.get('/:handle/articles/:slug', async (c) => {
         displayName: user.displayName,
         avatarUrl: assetUrl(mediaEnv, user.avatarUrl),
         isVerified: user.isVerified,
+        isContributor: user.isContributor,
         role: user.role,
       },
     },
@@ -680,6 +682,7 @@ function publicUser(
     bannerUrl: assetUrl(env, u.bannerUrl),
     isVerified: u.isVerified,
     isBot: u.isBot,
+    isContributor: u.isContributor,
     role: u.role,
     createdAt: u.createdAt,
   }

--- a/apps/web/src/components/admin/posts.tsx
+++ b/apps/web/src/components/admin/posts.tsx
@@ -45,7 +45,7 @@ import { qk } from "../../lib/query-keys"
 import { useInfiniteScrollSentinel } from "../../lib/use-infinite-scroll-sentinel"
 import { PageError, PageLoading } from "../page-surface"
 import { PageFrame } from "../page-frame"
-import { VerifiedBadge } from "../verified-badge"
+import { VerifiedBadge, resolveBadgeTier } from "../verified-badge"
 import type { AdminPostFilters } from "../../lib/query-keys"
 import type { ColumnDef } from "@tanstack/react-table"
 import type { AdminPost, AdminPostSort, AdminPostType } from "../../lib/api"
@@ -242,9 +242,12 @@ export default function AdminPosts() {
                     <span className="truncate">
                       {a.displayName ?? a.handle}
                     </span>
-                    {a.isVerified && (
-                      <VerifiedBadge className="size-3" role={a.role} />
-                    )}
+                    {(() => {
+                      const tier = resolveBadgeTier(a)
+                      return tier ? (
+                        <VerifiedBadge className="size-3" role={tier} />
+                      ) : null
+                    })()}
                   </Link>
                 ) : (
                   <span className="text-xs font-semibold">

--- a/apps/web/src/components/admin/users.tsx
+++ b/apps/web/src/components/admin/users.tsx
@@ -49,7 +49,7 @@ import { useInfiniteScrollSentinel } from "../../lib/use-infinite-scroll-sentine
 import { useMe } from "../../lib/me"
 import { PageError, PageLoading } from "../page-surface"
 import { PageFrame } from "../page-frame"
-import { VerifiedBadge } from "../verified-badge"
+import { VerifiedBadge, resolveBadgeTier } from "../verified-badge"
 import type { ColumnDef } from "@tanstack/react-table"
 import type { AdminUser } from "../../lib/api"
 
@@ -60,6 +60,7 @@ type ActionDialogState =
   | { kind: "ban"; user: AdminUser }
   | { kind: "shadow"; user: AdminUser }
   | { kind: "verify"; user: AdminUser }
+  | { kind: "contributor"; user: AdminUser }
   | { kind: "handle"; user: AdminUser }
   | { kind: "delete"; user: AdminUser }
   | null
@@ -166,16 +167,22 @@ export default function AdminUsers() {
                     onClick={(e) => e.stopPropagation()}
                   >
                     {u.displayName ?? u.handle}
-                    {u.isVerified && (
-                      <VerifiedBadge className="size-3.5" role={u.role} />
-                    )}
+                    {(() => {
+                      const tier = resolveBadgeTier(u)
+                      return tier ? (
+                        <VerifiedBadge className="size-3.5" role={tier} />
+                      ) : null
+                    })()}
                   </Link>
                 ) : (
                   <span className="flex items-center gap-1 text-sm font-semibold">
                     {u.displayName ?? u.email}
-                    {u.isVerified && (
-                      <VerifiedBadge className="size-3.5" role={u.role} />
-                    )}
+                    {(() => {
+                      const tier = resolveBadgeTier(u)
+                      return tier ? (
+                        <VerifiedBadge className="size-3.5" role={tier} />
+                      ) : null
+                    })()}
                   </span>
                 )}
                 {u.handle && (
@@ -400,6 +407,15 @@ export default function AdminUsers() {
                       onClick={() => setDialog({ kind: "verify", user: u })}
                     >
                       {u.isVerified ? "Revoke verified" : "Mark verified"}
+                    </DropdownMenu.Item>
+                    <DropdownMenu.Item
+                      onClick={() =>
+                        setDialog({ kind: "contributor", user: u })
+                      }
+                    >
+                      {u.isContributor
+                        ? "Revoke contributor"
+                        : "Mark contributor"}
                     </DropdownMenu.Item>
                   </DropdownMenu.Group>
                   {isOwner && (
@@ -662,6 +678,21 @@ function ActionDialog({
           ? api.adminUnverify(u.id, reason.trim() || undefined)
           : api.adminVerify(u.id, reason.trim() || undefined),
     },
+    contributor: {
+      title: u.isContributor
+        ? `Revoke contributor badge from ${subject}`
+        : `Grant contributor badge to ${subject}`,
+      description: u.isContributor
+        ? "The contributor badge will be removed. The user can re-acquire it by refreshing their GitHub connection if they're listed as a contributor."
+        : "The user will be marked as a contributor regardless of their GitHub connection state.",
+      submitLabel: u.isContributor ? "Revoke" : "Grant",
+      submitVariant: "outline" as const,
+      showDuration: false,
+      run: () =>
+        u.isContributor
+          ? api.adminRevokeContributor(u.id, reason.trim() || undefined)
+          : api.adminGrantContributor(u.id, reason.trim() || undefined),
+    },
     handle: {
       title: `Change handle for ${subject}`,
       description:
@@ -884,9 +915,12 @@ function UserDetailSheet({
                 <div className="min-w-0 flex-1">
                   <div className="flex items-center gap-1 text-sm font-semibold">
                     {u.displayName ?? u.handle ?? u.email}
-                    {u.isVerified && (
-                      <VerifiedBadge className="size-3.5" role={u.role} />
-                    )}
+                    {(() => {
+                      const tier = resolveBadgeTier(u)
+                      return tier ? (
+                        <VerifiedBadge className="size-3.5" role={tier} />
+                      ) : null
+                    })()}
                   </div>
                   {u.handle && (
                     <Link
@@ -930,6 +964,16 @@ function UserDetailSheet({
                   <dd className="tracking-wider uppercase">{u.role}</dd>
                   <dt className="text-tertiary">Verified</dt>
                   <dd>{u.isVerified ? "yes" : "no"}</dd>
+                  <dt className="text-tertiary">Contributor</dt>
+                  <dd>
+                    {u.isContributor ? "yes" : "no"}
+                    {u.contributorCheckedAt && (
+                      <span className="ml-1 text-tertiary">
+                        (checked{" "}
+                        {new Date(u.contributorCheckedAt).toLocaleString()})
+                      </span>
+                    )}
+                  </dd>
                   <dt className="text-tertiary">Banned</dt>
                   <dd className={u.banned ? "text-destructive" : ""}>
                     {u.banned

--- a/apps/web/src/components/feed-post-card.tsx
+++ b/apps/web/src/components/feed-post-card.tsx
@@ -199,6 +199,7 @@ export function FeedPostCard({
             displayName: q.author.displayName,
             avatarUrl: q.author.avatarUrl,
             isVerified: q.author.isVerified,
+            isContributor: q.author.isContributor,
             role: q.author.role,
           },
           text: q.text,
@@ -221,6 +222,7 @@ export function FeedPostCard({
           displayName: post.author.displayName ?? authorHandle,
           avatarUrl: post.author.avatarUrl,
           isVerified: post.author.isVerified,
+          isContributor: post.author.isContributor,
           role: post.author.role,
         }}
         text={post.text}

--- a/apps/web/src/components/post-card.tsx
+++ b/apps/web/src/components/post-card.tsx
@@ -34,7 +34,7 @@ import { ImageLightbox } from "./image-lightbox"
 import { Compose } from "./compose"
 import { PollBlock } from "./poll-block"
 import { PostMenu } from "./post-menu"
-import { VerifiedBadge } from "./verified-badge"
+import { VerifiedBadge, resolveBadgeTier } from "./verified-badge"
 import type {
   ArticleUnfurlCard,
   Post,
@@ -173,9 +173,10 @@ export function QuoteEmbed({ post }: { post: Post }) {
           <div className="flex items-center gap-2 text-xs">
             <span className="flex items-center gap-1 font-semibold text-primary">
               {post.author.displayName || `@${handle ?? "unknown"}`}
-              {post.author.isVerified && (
-                <VerifiedBadge size={13} role={post.author.role} />
-              )}
+              {(() => {
+                const tier = resolveBadgeTier(post.author)
+                return tier ? <VerifiedBadge size={13} role={tier} /> : null
+              })()}
             </span>
             {handle && <span className="text-tertiary">@{handle}</span>}
             <span className="text-tertiary">·</span>
@@ -467,9 +468,10 @@ export function PostCard({
               Reposted by{" "}
               {outerPost.author.displayName || `@${outerPost.author.handle}`}
             </span>
-            {outerPost.author.isVerified && (
-              <VerifiedBadge size={12} role={outerPost.author.role} />
-            )}
+            {(() => {
+              const tier = resolveBadgeTier(outerPost.author)
+              return tier ? <VerifiedBadge size={12} role={tier} /> : null
+            })()}
           </span>
         </Link>
       )}
@@ -508,16 +510,18 @@ export function PostCard({
                 className="flex items-center gap-1 font-semibold text-primary hover:underline"
               >
                 {post.author.displayName || `@${authorHandle}`}
-                {post.author.isVerified && (
-                  <VerifiedBadge size={15} role={post.author.role} />
-                )}
+                {(() => {
+                  const tier = resolveBadgeTier(post.author)
+                  return tier ? <VerifiedBadge size={15} role={tier} /> : null
+                })()}
               </Link>
             ) : (
               <span className="flex items-center gap-1 font-semibold text-primary">
                 {post.author.displayName ?? "unknown"}
-                {post.author.isVerified && (
-                  <VerifiedBadge size={15} role={post.author.role} />
-                )}
+                {(() => {
+                  const tier = resolveBadgeTier(post.author)
+                  return tier ? <VerifiedBadge size={15} role={tier} /> : null
+                })()}
               </span>
             )}
             {authorHandle && (

--- a/apps/web/src/components/profile-hover-card.tsx
+++ b/apps/web/src/components/profile-hover-card.tsx
@@ -6,7 +6,7 @@ import { PreviewCard } from "@workspace/ui/components/preview-card"
 import { api } from "../lib/api"
 import { qk } from "../lib/query-keys"
 import { useMe } from "../lib/me"
-import { VerifiedBadge } from "./verified-badge"
+import { VerifiedBadge, resolveBadgeTier } from "./verified-badge"
 import type { ReactNode } from "react"
 
 interface ProfileHoverCardProps {
@@ -77,9 +77,10 @@ function ProfileCardInner({ handle }: { handle: string }) {
           className="flex items-center gap-1 text-sm font-semibold text-primary hover:underline"
         >
           {profile.displayName || `@${handle}`}
-          {profile.isVerified && (
-            <VerifiedBadge size={14} role={profile.role} />
-          )}
+          {(() => {
+            const tier = resolveBadgeTier(profile)
+            return tier ? <VerifiedBadge size={14} role={tier} /> : null
+          })()}
         </Link>
         <span className="text-xs text-tertiary">@{handle}</span>
       </div>

--- a/apps/web/src/components/settings/sections.tsx
+++ b/apps/web/src/components/settings/sections.tsx
@@ -1187,7 +1187,8 @@ function ContributorStatus({
     <div className="mt-3 flex items-center gap-2 rounded-xl border border-neutral px-3 py-2 text-xs">
       <VerifiedBadge
         size={14}
-        role={contributor.isContributor ? "contributor" : "user"}
+        role={contributor.isContributor ? "contributor" : undefined}
+        aria-hidden={!contributor.isContributor}
         className={contributor.isContributor ? "" : "opacity-30"}
       />
       <div className="flex min-w-0 flex-1 flex-col">

--- a/apps/web/src/components/settings/sections.tsx
+++ b/apps/web/src/components/settings/sections.tsx
@@ -24,7 +24,7 @@ import { ApiError, api } from "../../lib/api"
 import { ClaimHandle } from "../claim-handle"
 import { AvatarUpload } from "../avatar-upload"
 import { BannerUpload } from "../banner-upload"
-import { VerifiedBadge } from "../verified-badge"
+import { VerifiedBadge, resolveBadgeTier } from "../verified-badge"
 import { PageLoading } from "../page-surface"
 import {
   SettingsSection,
@@ -780,14 +780,20 @@ function PrivacyList<
                   <span className="truncate">
                     {u.displayName ?? `@${u.handle}`}
                   </span>
-                  {u.isVerified && <VerifiedBadge size={13} role={u.role} />}
+                  {(() => {
+                    const tier = resolveBadgeTier(u)
+                    return tier ? <VerifiedBadge size={13} role={tier} /> : null
+                  })()}
                 </Link>
               ) : (
                 <span className="flex items-center gap-1 text-sm font-medium">
                   <span className="truncate">
                     {u.displayName ?? "Unknown user"}
                   </span>
-                  {u.isVerified && <VerifiedBadge size={13} role={u.role} />}
+                  {(() => {
+                    const tier = resolveBadgeTier(u)
+                    return tier ? <VerifiedBadge size={13} role={tier} /> : null
+                  })()}
                 </span>
               )}
               <p className="text-muted-foreground truncate text-xs">
@@ -1155,9 +1161,57 @@ export function ConnectionsSection({
             Show on my profile
           </label>
         ) : null}
+        {state?.connected === true && state.contributor.repos.length > 0 ? (
+          <ContributorStatus contributor={state.contributor} />
+        ) : null}
         {status ? <p className="mt-2 text-xs text-tertiary">{status}</p> : null}
       </div>
     </section>
+  )
+}
+
+function ContributorStatus({
+  contributor,
+}: {
+  contributor: {
+    isContributor: boolean
+    contributorCheckedAt: string | null
+    repos: Array<string>
+  }
+}) {
+  const repoLabel =
+    contributor.repos.length === 1
+      ? contributor.repos[0]
+      : `any of ${contributor.repos.length} repos`
+  return (
+    <div className="mt-3 flex items-center gap-2 rounded-xl border border-neutral px-3 py-2 text-xs">
+      <VerifiedBadge
+        size={14}
+        role={contributor.isContributor ? "contributor" : "user"}
+        className={contributor.isContributor ? "" : "opacity-30"}
+      />
+      <div className="flex min-w-0 flex-1 flex-col">
+        <span className="text-primary">
+          {contributor.isContributor
+            ? `Recognized as a contributor to ${repoLabel}.`
+            : `Not detected as a contributor to ${repoLabel} yet.`}
+        </span>
+        {contributor.contributorCheckedAt ? (
+          <span className="text-tertiary [font-variant-numeric:tabular-nums]">
+            Checked{" "}
+            {new Date(contributor.contributorCheckedAt).toLocaleString(
+              undefined,
+              {
+                month: "short",
+                day: "numeric",
+                hour: "numeric",
+                minute: "2-digit",
+              }
+            )}
+          </span>
+        ) : null}
+      </div>
+    </div>
   )
 }
 

--- a/apps/web/src/components/user-list.tsx
+++ b/apps/web/src/components/user-list.tsx
@@ -6,7 +6,7 @@ import { UsersIcon } from "@heroicons/react/24/solid"
 import { Avatar } from "@workspace/ui/components/avatar"
 import { useInfiniteScrollSentinel } from "../lib/use-infinite-scroll-sentinel"
 import { PageEmpty, PageError, PageLoadingList } from "./page-surface"
-import { VerifiedBadge } from "./verified-badge"
+import { VerifiedBadge, resolveBadgeTier } from "./verified-badge"
 import type { InfiniteData } from "@tanstack/react-query"
 import type { PublicUser, UserListPage } from "../lib/api"
 
@@ -150,7 +150,12 @@ export function UserList({
                     <span className="truncate">
                       {u.displayName || `@${u.handle}`}
                     </span>
-                    {u.isVerified && <VerifiedBadge size={14} role={u.role} />}
+                    {(() => {
+                      const tier = resolveBadgeTier(u)
+                      return tier ? (
+                        <VerifiedBadge size={14} role={tier} />
+                      ) : null
+                    })()}
                   </div>
                   <div className="truncate text-xs text-tertiary">
                     @{u.handle}

--- a/apps/web/src/components/verified-badge.tsx
+++ b/apps/web/src/components/verified-badge.tsx
@@ -1,4 +1,6 @@
 export {
   VerifiedBadge,
+  resolveBadgeTier,
   type VerifiedBadgeRole,
+  type BadgeTierInput,
 } from "@workspace/ui/components/verified-badge"

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -497,6 +497,16 @@ export const api = {
       method: "POST",
       body: JSON.stringify(reason ? { reason } : {}),
     }),
+  adminGrantContributor: (id: string, reason?: string) =>
+    request<{ ok: true }>(`/api/admin/users/${id}/contributor`, {
+      method: "POST",
+      body: JSON.stringify(reason ? { reason } : {}),
+    }),
+  adminRevokeContributor: (id: string, reason?: string) =>
+    request<{ ok: true }>(`/api/admin/users/${id}/contributor`, {
+      method: "DELETE",
+      body: JSON.stringify(reason ? { reason } : {}),
+    }),
   adminReports: (status?: ReportStatus, cursor?: string) => {
     const params = new URLSearchParams()
     if (status) params.set("status", status)
@@ -697,6 +707,7 @@ export interface Post {
     avatarUrl: string | null
     isVerified: boolean
     isBot: boolean
+    isContributor: boolean
     role: "user" | "admin" | "owner"
   }
   counts: {
@@ -802,6 +813,7 @@ export interface UserListMember {
   displayName: string | null
   avatarUrl: string | null
   isVerified: boolean
+  isContributor: boolean
   role: "user" | "admin" | "owner"
   addedAt: string
 }
@@ -862,6 +874,7 @@ export interface PublicUser {
   bannerUrl: string | null
   isVerified: boolean
   isBot: boolean
+  isContributor: boolean
   role: "user" | "admin" | "owner"
   createdAt: string
 }
@@ -892,6 +905,7 @@ export interface BlockedUser {
   displayName: string | null
   avatarUrl: string | null
   isVerified: boolean
+  isContributor: boolean
   role: "user" | "admin" | "owner"
   blockedAt: string
 }
@@ -916,6 +930,7 @@ export interface MutedUser {
   displayName: string | null
   avatarUrl: string | null
   isVerified: boolean
+  isContributor: boolean
   role: "user" | "admin" | "owner"
   mutedAt: string
   scope: "feed" | "notifications" | "both"
@@ -939,6 +954,7 @@ export interface SelfUser {
   birthday: string | null
   isVerified: boolean
   isBot: boolean
+  isContributor: boolean
   role: "user" | "admin" | "owner"
   locale: string
   timezone: string | null
@@ -978,6 +994,7 @@ export interface NotificationItem {
     displayName: string | null
     avatarUrl: string | null
     isVerified: boolean
+    isContributor: boolean
     role: "user" | "admin" | "owner"
   } | null
   /** Hydrated for kinds whose entity is a post (like / repost / reply / mention / quote /
@@ -1032,6 +1049,7 @@ export interface ArticleDto {
     displayName: string | null
     avatarUrl: string | null
     isVerified: boolean
+    isContributor: boolean
     role: "user" | "admin" | "owner"
   }
 }
@@ -1042,6 +1060,7 @@ export interface DmMember {
   displayName: string | null
   avatarUrl: string | null
   isVerified: boolean
+  isContributor: boolean
   role: "user" | "admin" | "owner"
 }
 
@@ -1102,6 +1121,7 @@ export interface InvitePreview {
       displayName: string | null
       avatarUrl: string | null
       isVerified: boolean
+      isContributor: boolean
       role: "user" | "admin" | "owner"
     }>
   }
@@ -1210,6 +1230,7 @@ export interface AdminPost {
     displayName: string | null
     avatarUrl: string | null
     isVerified: boolean
+    isContributor: boolean
     role: "user" | "admin" | "owner"
   } | null
   text: string
@@ -1241,6 +1262,8 @@ export interface AdminUser {
   banExpires: string | null
   shadowBannedAt: string | null
   isVerified: boolean
+  isContributor: boolean
+  contributorCheckedAt: string | null
   deletedAt: string | null
   createdAt: string
   postsCount: number
@@ -1409,8 +1432,18 @@ export interface GithubPinnedRepo {
   primaryLanguage: { name: string; color: string | null } | null
 }
 
+export interface GithubConnectorContributor {
+  isContributor: boolean
+  contributorCheckedAt: string | null
+  repos: Array<string>
+}
+
 export type GithubConnectorMe =
-  | { connected: false; configured: boolean }
+  | {
+      connected: false
+      configured: boolean
+      contributor?: GithubConnectorContributor
+    }
   | {
       connected: true
       configured: true
@@ -1421,6 +1454,7 @@ export type GithubConnectorMe =
       refreshedAt: string | null
       lastFailureAt: string | null
       lastFailureReason: string | null
+      contributor: GithubConnectorContributor
     }
 
 export type GithubProfilePayload =

--- a/apps/web/src/routes/$handle.a.$slug.tsx
+++ b/apps/web/src/routes/$handle.a.$slug.tsx
@@ -5,7 +5,7 @@ import { ApiError, api } from "../lib/api"
 import { qk } from "../lib/query-keys"
 import { Editor } from "../components/editor/editor"
 import { PageFrame } from "../components/page-frame"
-import { VerifiedBadge } from "../components/verified-badge"
+import { VerifiedBadge, resolveBadgeTier } from "../components/verified-badge"
 import { authClient } from "../lib/auth"
 import { APP_NAME } from "../lib/env"
 import { buildSeoMeta, canonicalLink, clipDescription } from "../lib/seo"
@@ -163,9 +163,10 @@ function ArticleView() {
               className="text-foreground flex items-center gap-1 font-medium hover:underline"
             >
               {article.author.displayName || `@${article.author.handle}`}
-              {article.author.isVerified && (
-                <VerifiedBadge size={14} role={article.author.role} />
-              )}
+              {(() => {
+                const tier = resolveBadgeTier(article.author)
+                return tier ? <VerifiedBadge size={14} role={tier} /> : null
+              })()}
             </Link>
           )}
           <span>·</span>

--- a/apps/web/src/routes/$handle.index.tsx
+++ b/apps/web/src/routes/$handle.index.tsx
@@ -12,7 +12,7 @@ import { ImageLightbox } from "../components/image-lightbox"
 import { RichText } from "../components/rich-text"
 import { GithubBlock } from "../components/github-block"
 import { MetaPill } from "../components/meta-pill"
-import { VerifiedBadge } from "../components/verified-badge"
+import { VerifiedBadge, resolveBadgeTier } from "../components/verified-badge"
 import {
   NotFoundPanel,
   PageEmpty,
@@ -195,7 +195,10 @@ function Profile() {
           <div className="mt-1">
             <h1 className="flex items-center gap-1.5 text-2xl font-bold tracking-tight">
               {displayName}
-              {user.isVerified && <VerifiedBadge size={22} role={user.role} />}
+              {(() => {
+                const tier = resolveBadgeTier(user)
+                return tier ? <VerifiedBadge size={22} role={tier} /> : null
+              })()}
             </h1>
             <p className="text-sm text-secondary">@{user.handle}</p>
           </div>

--- a/apps/web/src/routes/inbox.$conversationId.tsx
+++ b/apps/web/src/routes/inbox.$conversationId.tsx
@@ -30,7 +30,7 @@ import { ImageLightbox } from "../components/image-lightbox"
 import { PageEmpty, PageError } from "../components/page-surface"
 import { PageFrame } from "../components/page-frame"
 import { RichText } from "../components/rich-text"
-import { VerifiedBadge } from "../components/verified-badge"
+import { VerifiedBadge, resolveBadgeTier } from "../components/verified-badge"
 import { subscribeToDmStream } from "../lib/dm-stream"
 import {
   MAX_UPLOAD_BYTES,
@@ -1244,7 +1244,10 @@ function ThreadAppHeaderTitle({
         <span className="truncate font-semibold text-primary">
           {p?.displayName || (p?.handle ? `@${p.handle}` : "Conversation")}
         </span>
-        {p?.isVerified && <VerifiedBadge size={14} role={p.role} />}
+        {(() => {
+          const tier = p ? resolveBadgeTier(p) : null
+          return tier ? <VerifiedBadge size={14} role={tier} /> : null
+        })()}
         {p?.handle && (
           <>
             <span className="shrink-0 text-tertiary" aria-hidden>
@@ -1421,9 +1424,12 @@ function GroupSettingsDialog({
                         {m.displayName ||
                           (m.handle ? `@${m.handle}` : m.id.slice(0, 8))}
                       </span>
-                      {m.isVerified && (
-                        <VerifiedBadge size={13} role={m.role} />
-                      )}
+                      {(() => {
+                        const tier = resolveBadgeTier(m)
+                        return tier ? (
+                          <VerifiedBadge size={13} role={tier} />
+                        ) : null
+                      })()}
                       {m.chatRole === "admin" && (
                         <span className="rounded-full bg-base-2 px-1.5 py-0.5 text-[10px] font-medium text-tertiary">
                           admin
@@ -1487,9 +1493,12 @@ function GroupSettingsDialog({
                               {u.displayName ||
                                 (u.handle ? `@${u.handle}` : u.id.slice(0, 8))}
                             </span>
-                            {u.isVerified && (
-                              <VerifiedBadge size={13} role={u.role} />
-                            )}
+                            {(() => {
+                              const tier = resolveBadgeTier(u)
+                              return tier ? (
+                                <VerifiedBadge size={13} role={tier} />
+                              ) : null
+                            })()}
                           </div>
                           {u.handle && (
                             <div className="truncate text-xs text-tertiary">

--- a/apps/web/src/routes/inbox.index.tsx
+++ b/apps/web/src/routes/inbox.index.tsx
@@ -13,7 +13,7 @@ import { SegmentedControl } from "@workspace/ui/components/segmented-control"
 import { api } from "../lib/api"
 import { PageEmpty, PageError } from "../components/page-surface"
 import { PageFrame } from "../components/page-frame"
-import { VerifiedBadge } from "../components/verified-badge"
+import { VerifiedBadge, resolveBadgeTier } from "../components/verified-badge"
 import { subscribeToDmStream } from "../lib/dm-stream"
 import { qk } from "../lib/query-keys"
 import type { DmConversation, DmMember } from "../lib/api"
@@ -193,9 +193,12 @@ function ConversationRow({ conversation }: { conversation: DmConversation }) {
           <div className="flex items-baseline justify-between gap-2">
             <span className="flex min-w-0 items-center gap-1 text-sm font-semibold text-primary">
               <span className="truncate">{title}</span>
-              {peer?.isVerified && (
-                <VerifiedBadge className="size-3.5" role={peer.role} />
-              )}
+              {(() => {
+                const tier = peer ? resolveBadgeTier(peer) : null
+                return tier ? (
+                  <VerifiedBadge className="size-3.5" role={tier} />
+                ) : null
+              })()}
             </span>
             {ts && (
               <time className="shrink-0 text-xs text-tertiary tabular-nums">

--- a/apps/web/src/routes/inbox.new.tsx
+++ b/apps/web/src/routes/inbox.new.tsx
@@ -10,7 +10,7 @@ import { api } from "../lib/api"
 import { qk } from "../lib/query-keys"
 import { PageError } from "../components/page-surface"
 import { PageFrame } from "../components/page-frame"
-import { VerifiedBadge } from "../components/verified-badge"
+import { VerifiedBadge, resolveBadgeTier } from "../components/verified-badge"
 import type { PublicUser } from "../lib/api"
 
 export const Route = createFileRoute("/inbox/new")({
@@ -118,9 +118,12 @@ function NewConversation() {
                     {u.displayName ||
                       (u.handle ? `@${u.handle}` : u.id.slice(0, 8))}
                   </span>
-                  {u.isVerified && (
-                    <VerifiedBadge className="size-3" role={u.role} />
-                  )}
+                  {(() => {
+                    const tier = resolveBadgeTier(u)
+                    return tier ? (
+                      <VerifiedBadge className="size-3" role={tier} />
+                    ) : null
+                  })()}
                 </span>
                 <button
                   type="button"
@@ -214,9 +217,12 @@ function NewConversation() {
                         {u.displayName ||
                           (u.handle ? `@${u.handle}` : u.id.slice(0, 8))}
                       </span>
-                      {u.isVerified && (
-                        <VerifiedBadge size={14} role={u.role} />
-                      )}
+                      {(() => {
+                        const tier = resolveBadgeTier(u)
+                        return tier ? (
+                          <VerifiedBadge size={14} role={tier} />
+                        ) : null
+                      })()}
                     </div>
                     {u.handle && (
                       <div className="truncate text-xs text-tertiary">

--- a/apps/web/src/routes/invite.$token.tsx
+++ b/apps/web/src/routes/invite.$token.tsx
@@ -6,7 +6,7 @@ import { Avatar } from "@workspace/ui/components/avatar"
 import { ApiError, api } from "../lib/api"
 import { authClient } from "../lib/auth"
 import { PageFrame } from "../components/page-frame"
-import { VerifiedBadge } from "../components/verified-badge"
+import { VerifiedBadge, resolveBadgeTier } from "../components/verified-badge"
 import { qk } from "../lib/query-keys"
 import { PageLoading } from "@/components/page-surface"
 
@@ -120,9 +120,10 @@ function InvitePage() {
           </div>
           <h1 className="flex items-center justify-center gap-1.5 text-lg font-semibold">
             {title}
-            {soloPeer?.isVerified && (
-              <VerifiedBadge size={16} role={soloPeer.role} />
-            )}
+            {(() => {
+              const tier = soloPeer ? resolveBadgeTier(soloPeer) : null
+              return tier ? <VerifiedBadge size={16} role={tier} /> : null
+            })()}
           </h1>
           <p className="text-muted-foreground mt-1 text-xs">
             {conv.kind === "group" ? "Group conversation" : "Conversation"} ·{" "}

--- a/apps/web/src/routes/notifications.tsx
+++ b/apps/web/src/routes/notifications.tsx
@@ -33,7 +33,7 @@ import { usePageHeader } from "../components/app-page-header"
 import { useCompose } from "../components/compose-provider"
 import { PageEmpty } from "../components/page-surface"
 import { PageFrame } from "../components/page-frame"
-import { VerifiedBadge } from "../components/verified-badge"
+import { VerifiedBadge, resolveBadgeTier } from "../components/verified-badge"
 import { RichText } from "../components/rich-text"
 import { PostEngagementBar } from "../components/post-engagement-bar"
 import { useInfiniteScrollSentinel } from "../lib/use-infinite-scroll-sentinel"
@@ -733,16 +733,18 @@ function ReplyRow({ item }: { item: NotificationItem }) {
                 onClick={(e) => e.stopPropagation()}
               >
                 {actorDisplayName || actorHandle}
-                {actor?.isVerified && (
-                  <VerifiedBadge size={14} role={actor.role} />
-                )}
+                {(() => {
+                  const tier = actor ? resolveBadgeTier(actor) : null
+                  return tier ? <VerifiedBadge size={14} role={tier} /> : null
+                })()}
               </Link>
             ) : (
               <span className="inline-flex items-center gap-1 font-semibold text-primary">
                 {actorDisplayName || "someone"}
-                {actor?.isVerified && (
-                  <VerifiedBadge size={14} role={actor.role} />
-                )}
+                {(() => {
+                  const tier = actor ? resolveBadgeTier(actor) : null
+                  return tier ? <VerifiedBadge size={14} role={tier} /> : null
+                })()}
               </span>
             )}
             {actorHandle && (
@@ -855,16 +857,18 @@ function MentionRow({ item }: { item: NotificationItem }) {
                 onClick={(e) => e.stopPropagation()}
               >
                 {actorDisplayName || actorHandle}
-                {actor?.isVerified && (
-                  <VerifiedBadge size={14} role={actor.role} />
-                )}
+                {(() => {
+                  const tier = actor ? resolveBadgeTier(actor) : null
+                  return tier ? <VerifiedBadge size={14} role={tier} /> : null
+                })()}
               </Link>
             ) : (
               <span className="inline-flex items-center gap-1 font-semibold text-primary">
                 {actorDisplayName || "someone"}
-                {actor?.isVerified && (
-                  <VerifiedBadge size={14} role={actor.role} />
-                )}
+                {(() => {
+                  const tier = actor ? resolveBadgeTier(actor) : null
+                  return tier ? <VerifiedBadge size={14} role={tier} /> : null
+                })()}
               </span>
             )}
             {actorHandle && (
@@ -982,16 +986,18 @@ function NotificationRow({ item }: { item: NotificationItem }) {
                 onClick={(e) => e.stopPropagation()}
               >
                 {actorDisplayName || actorHandle}
-                {item.actor?.isVerified && (
-                  <VerifiedBadge size={14} role={item.actor.role} />
-                )}
+                {(() => {
+                  const tier = item.actor ? resolveBadgeTier(item.actor) : null
+                  return tier ? <VerifiedBadge size={14} role={tier} /> : null
+                })()}
               </Link>
             ) : (
               <span className="inline-flex items-center gap-1 align-middle font-semibold text-primary">
                 {actorDisplayName || "someone"}
-                {item.actor?.isVerified && (
-                  <VerifiedBadge size={14} role={item.actor.role} />
-                )}
+                {(() => {
+                  const tier = item.actor ? resolveBadgeTier(item.actor) : null
+                  return tier ? <VerifiedBadge size={14} role={tier} /> : null
+                })()}
               </span>
             )}
             {actorHandle && (

--- a/apps/web/src/routes/og.post.$id.tsx
+++ b/apps/web/src/routes/og.post.$id.tsx
@@ -15,7 +15,15 @@ import {
   loadOgImage,
   truncate,
 } from "../lib/og-image"
+import { resolveBadgeTier } from "../components/verified-badge"
 import type { Post } from "../lib/api"
+
+const BADGE_GRADIENT: Record<string, string> = {
+  user: "linear-gradient(135deg, #60a5fa 0%, #a78bfa 100%)",
+  contributor: "linear-gradient(135deg, #d946ef 0%, #a855f7 100%)",
+  admin: "linear-gradient(135deg, #34d399 0%, #10b981 100%)",
+  owner: "linear-gradient(135deg, #fde047 0%, #f59e0b 100%)",
+}
 
 function PostCard({
   post,
@@ -75,25 +83,28 @@ function PostCard({
             }}
           >
             {display}
-            {post.author.isVerified && (
-              <div
-                style={{
-                  display: "flex",
-                  alignItems: "center",
-                  justifyContent: "center",
-                  width: 26,
-                  height: 26,
-                  borderRadius: 999,
-                  background:
-                    "linear-gradient(135deg, #60a5fa 0%, #a78bfa 100%)",
-                  fontSize: 18,
-                  fontWeight: 800,
-                  color: "#0a0a0a",
-                }}
-              >
-                ✓
-              </div>
-            )}
+            {(() => {
+              const tier = resolveBadgeTier(post.author)
+              if (!tier) return null
+              return (
+                <div
+                  style={{
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "center",
+                    width: 26,
+                    height: 26,
+                    borderRadius: 999,
+                    background: BADGE_GRADIENT[tier],
+                    fontSize: 18,
+                    fontWeight: 800,
+                    color: "#0a0a0a",
+                  }}
+                >
+                  ✓
+                </div>
+              )
+            })()}
           </div>
           <div style={{ fontSize: 22, color: "rgba(255,255,255,0.6)" }}>
             @{handle}

--- a/apps/web/src/routes/og.user.$handle.tsx
+++ b/apps/web/src/routes/og.user.$handle.tsx
@@ -15,7 +15,15 @@ import {
   loadOgImage,
   truncate,
 } from "../lib/og-image"
+import { resolveBadgeTier } from "../components/verified-badge"
 import type { PublicProfile } from "../lib/api"
+
+const BADGE_GRADIENT: Record<string, string> = {
+  user: "linear-gradient(135deg, #60a5fa 0%, #a78bfa 100%)",
+  contributor: "linear-gradient(135deg, #d946ef 0%, #a855f7 100%)",
+  admin: "linear-gradient(135deg, #34d399 0%, #10b981 100%)",
+  owner: "linear-gradient(135deg, #fde047 0%, #f59e0b 100%)",
+}
 
 function ProfileCard({
   user,
@@ -63,25 +71,28 @@ function ProfileCard({
             }}
           >
             {truncate(display, 30)}
-            {user.isVerified && (
-              <div
-                style={{
-                  display: "flex",
-                  alignItems: "center",
-                  justifyContent: "center",
-                  width: 40,
-                  height: 40,
-                  borderRadius: 999,
-                  background:
-                    "linear-gradient(135deg, #60a5fa 0%, #a78bfa 100%)",
-                  fontSize: 28,
-                  fontWeight: 800,
-                  color: "#0a0a0a",
-                }}
-              >
-                ✓
-              </div>
-            )}
+            {(() => {
+              const tier = resolveBadgeTier(user)
+              if (!tier) return null
+              return (
+                <div
+                  style={{
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "center",
+                    width: 40,
+                    height: 40,
+                    borderRadius: 999,
+                    background: BADGE_GRADIENT[tier],
+                    fontSize: 28,
+                    fontWeight: 800,
+                    color: "#0a0a0a",
+                  }}
+                >
+                  ✓
+                </div>
+              )
+            })()}
           </div>
           <div style={{ fontSize: 30, color: "rgba(255,255,255,0.6)" }}>
             @{user.handle}

--- a/apps/web/src/routes/search.tsx
+++ b/apps/web/src/routes/search.tsx
@@ -24,7 +24,7 @@ import { usePageHeader } from "../components/app-page-header"
 import { PageEmpty, PageLoading } from "../components/page-surface"
 import { PageFrame } from "../components/page-frame"
 import { PostCard } from "../components/post-card"
-import { VerifiedBadge } from "../components/verified-badge"
+import { VerifiedBadge, resolveBadgeTier } from "../components/verified-badge"
 import { ApiError, api } from "../lib/api"
 import { qk } from "../lib/query-keys"
 import { useMe } from "../lib/me"
@@ -314,9 +314,12 @@ function SearchInner({ initialQuery }: { initialQuery: string }) {
                         <span className="truncate">
                           {u.displayName || `@${u.handle}`}
                         </span>
-                        {u.isVerified && (
-                          <VerifiedBadge size={14} role={u.role} />
-                        )}
+                        {(() => {
+                          const tier = resolveBadgeTier(u)
+                          return tier ? (
+                            <VerifiedBadge size={14} role={tier} />
+                          ) : null
+                        })()}
                       </div>
                       <div className="text-xs text-tertiary">@{u.handle}</div>
                       {u.bio && (
@@ -352,9 +355,12 @@ function SearchInner({ initialQuery }: { initialQuery: string }) {
                       <span className="truncate">
                         {u.displayName || `@${u.handle}`}
                       </span>
-                      {u.isVerified && (
-                        <VerifiedBadge size={14} role={u.role} />
-                      )}
+                      {(() => {
+                        const tier = resolveBadgeTier(u)
+                        return tier ? (
+                          <VerifiedBadge size={14} role={tier} />
+                        ) : null
+                      })()}
                     </div>
                     <div className="text-xs text-tertiary">@{u.handle}</div>
                     {u.bio && (

--- a/packages/db/src/schema/auth.ts
+++ b/packages/db/src/schema/auth.ts
@@ -35,6 +35,8 @@ export const users = pgTable(
     birthday: date('birthday'),
     isVerified: boolean('is_verified').notNull().default(false),
     isBot: boolean('is_bot').notNull().default(false),
+    isContributor: boolean('is_contributor').notNull().default(false),
+    contributorCheckedAt: timestamp('contributor_checked_at', { withTimezone: true }),
     role: userRoleEnum('role').notNull().default('user'),
     locale: text('locale').notNull().default('en'),
     timezone: text('timezone'),

--- a/packages/ui/src/components/post-card.tsx
+++ b/packages/ui/src/components/post-card.tsx
@@ -20,8 +20,10 @@ import { DropdownMenu } from "@workspace/ui/components/dropdown-menu"
 import { Hover } from "@workspace/ui/components/hover"
 import { PreviewCard } from "@workspace/ui/components/preview-card"
 import { AnimatedNumber } from "@workspace/ui/components/animated-number"
-import { VerifiedBadge } from "@workspace/ui/components/verified-badge"
-import type { VerifiedBadgeRole } from "@workspace/ui/components/verified-badge"
+import {
+  VerifiedBadge,
+  resolveBadgeTier,
+} from "@workspace/ui/components/verified-badge"
 import type { CSSProperties, ReactNode } from "react"
 
 /** Extra profile data for the author hover card */
@@ -45,7 +47,8 @@ export interface PostQuoteOf {
     displayName: string | null
     avatarUrl: string | null
     isVerified?: boolean
-    role?: VerifiedBadgeRole | null
+    isContributor?: boolean
+    role?: "user" | "admin" | "owner" | null
   }
   text: string
   time: string
@@ -60,7 +63,8 @@ export interface PostCardProps {
     displayName: string
     avatarUrl: string | null
     isVerified?: boolean
-    role?: VerifiedBadgeRole | null
+    isContributor?: boolean
+    role?: "user" | "admin" | "owner" | null
   }
   text: string
   time: string
@@ -311,9 +315,12 @@ export function PostCard({
                     }}
                   >
                     {author.displayName}
-                    {author.isVerified && (
-                      <VerifiedBadge size={15} role={author.role} />
-                    )}
+                    {(() => {
+                      const tier = resolveBadgeTier(author)
+                      return tier ? (
+                        <VerifiedBadge size={15} role={tier} />
+                      ) : null
+                    })()}
                   </PreviewCard.Trigger>
                   <PreviewCard.Content
                     side="bottom"
@@ -345,9 +352,10 @@ export function PostCard({
                   }}
                 >
                   {author.displayName}
-                  {author.isVerified && (
-                    <VerifiedBadge size={15} role={author.role} />
-                  )}
+                  {(() => {
+                    const tier = resolveBadgeTier(author)
+                    return tier ? <VerifiedBadge size={15} role={tier} /> : null
+                  })()}
                 </span>
               )}
               <span className="truncate text-tertiary">@{author.handle}</span>
@@ -652,9 +660,10 @@ function QuoteEmbed({ quote }: { quote: PostQuoteOf }) {
             />
             <span className="flex items-center gap-1 font-semibold text-primary">
               {displayName}
-              {quote.author.isVerified && (
-                <VerifiedBadge size={13} role={quote.author.role} />
-              )}
+              {(() => {
+                const tier = resolveBadgeTier(quote.author)
+                return tier ? <VerifiedBadge size={13} role={tier} /> : null
+              })()}
             </span>
             {handle && <span className="text-tertiary">@{handle}</span>}
             <span className="text-tertiary">&middot;</span>
@@ -759,7 +768,10 @@ function AuthorHoverContent({
           }}
         >
           {author.displayName}
-          {author.isVerified && <VerifiedBadge size={15} role={author.role} />}
+          {(() => {
+            const tier = resolveBadgeTier(author)
+            return tier ? <VerifiedBadge size={15} role={tier} /> : null
+          })()}
         </span>
         <span className="text-xs text-tertiary">@{author.handle}</span>
       </div>

--- a/packages/ui/src/components/verified-badge.tsx
+++ b/packages/ui/src/components/verified-badge.tsx
@@ -1,16 +1,18 @@
 import { CheckBadgeIcon } from "@heroicons/react/16/solid"
 import { cn } from "@workspace/ui/lib/utils"
 
-export type VerifiedBadgeRole = "user" | "admin" | "owner"
+export type VerifiedBadgeRole = "user" | "contributor" | "admin" | "owner"
 
 const roleColorClass: Record<VerifiedBadgeRole, string> = {
   user: "text-badge-user",
+  contributor: "text-badge-contributor",
   admin: "text-badge-admin",
   owner: "text-badge-owner",
 }
 
 const roleAriaLabel: Record<VerifiedBadgeRole, string> = {
   user: "Verified account",
+  contributor: "Contributor",
   admin: "Verified admin account",
   owner: "Verified owner account",
 }
@@ -36,4 +38,22 @@ export function VerifiedBadge({
       style={size !== undefined ? { width: size, height: size } : undefined}
     />
   )
+}
+
+export interface BadgeTierInput {
+  isVerified?: boolean | null
+  isContributor?: boolean | null
+  role?: "user" | "admin" | "owner" | null
+}
+
+export function resolveBadgeTier(
+  user: BadgeTierInput | null | undefined
+): VerifiedBadgeRole | null {
+  if (!user) return null
+  const role = user.role ?? "user"
+  if (role === "owner" && user.isVerified) return "owner"
+  if (role === "admin" && user.isVerified) return "admin"
+  if (user.isContributor) return "contributor"
+  if (user.isVerified) return "user"
+  return null
 }

--- a/packages/ui/src/components/verified-badge.tsx
+++ b/packages/ui/src/components/verified-badge.tsx
@@ -51,8 +51,8 @@ export function resolveBadgeTier(
 ): VerifiedBadgeRole | null {
   if (!user) return null
   const role = user.role ?? "user"
-  if (role === "owner" && user.isVerified) return "owner"
-  if (role === "admin" && user.isVerified) return "admin"
+  if (role === "owner") return "owner"
+  if (role === "admin") return "admin"
   if (user.isContributor) return "contributor"
   if (user.isVerified) return "user"
   return null

--- a/packages/ui/src/styles/theme.css
+++ b/packages/ui/src/styles/theme.css
@@ -76,6 +76,7 @@
   --color-badge-user: oklch(0.685 0.169 237.7);
   --color-badge-admin: oklch(0.696 0.17 162.5);
   --color-badge-owner: oklch(0.837 0.161 86.7);
+  --color-badge-contributor: oklch(0.62 0.27 330);
 
   /* ── Easing ── */
   --ease-out-expo: cubic-bezier(0.16, 1, 0.3, 1);
@@ -221,6 +222,7 @@
   --color-badge-user: oklch(0.65 0.13 237.7);
   --color-badge-admin: oklch(0.66 0.13 162.5);
   --color-badge-owner: oklch(0.78 0.12 86.7);
+  --color-badge-contributor: oklch(0.7 0.24 330);
 
   --border-color-neutral: var(--color-gray-5);
   --border-color-neutral-strong: var(--color-gray-7);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Adds a fourth verified-badge tier — `contributor` — that lights up in vivid fuchsia/magenta whenever a user is recognized as a contributor to one of the configured project repos.
- Contributor status is evaluated against `GITHUB_CONTRIBUTOR_REPOS` (a new comma-separated `owner/repo` env var) when a user finishes the GitHub connector OAuth dance or hits **Refresh** in Settings → Connections, and is cleared when they disconnect GitHub.
- Tier precedence is centralized in a single `resolveBadgeTier()` helper in `@workspace/ui`. Order: `owner` → `admin` → `contributor` → verified `user`. Contributor wins over plain `verified+user`; staff tiers continue to win over contributor.

## Why

A way to recognize folks who've actually shipped code/docs/translations to the project, distinct from generic "verified" users and the staff tiers, with a self-serve flow (just connect GitHub) and an admin override for non-code contributors and testing.

## What changed

**Schema** (`packages/db/src/schema/auth.ts`)
- Adds `users.is_contributor` (boolean, default false) and `users.contributor_checked_at` (nullable timestamp). No migration files generated; sync via `bun run db:push`.

**Server: lookup + connector wiring**
- `apps/api/src/lib/github-contributors.ts`: Redis-cached per-repo contributors lookup (10 min TTL). Uses `GITHUB_UNFURL_TOKEN` if present, falls back to anonymous.
- `apps/api/src/routes/connectors/github.ts`: callback and `POST /refresh` now also evaluate contributor status; `DELETE /` clears the flag. `GET /me` exposes `contributor: { isContributor, contributorCheckedAt, repos }`.
- New env var `GITHUB_CONTRIBUTOR_REPOS` in `apps/api/src/lib/env.ts` and `.env.example`.

**Admin override**
- `POST/DELETE /api/admin/users/:id/contributor` (mirrors `/verify` and `/unverify`) with `moderationActions` audit. New events `admin_user_contributor_granted` / `_revoked`.
- New menu item + dialog + status row in `apps/web/src/components/admin/users.tsx`.

**DTOs** — `isContributor` added to `publicUser()`, `toSelfDto`, `toPostDto.author`, plus the inline shapes in admin/users/me/notifications/invites/lists/dms/articles/search route handlers. Mirrored in client types in `apps/web/src/lib/api.ts` (`PublicUser`, `PublicProfile`, `SelfUser`, `Post.author`, `AdminUser` + new `contributorCheckedAt`, `BlockedUser`, `MutedUser`, `UserListMember`, `DmMember`, `InvitePreview`, `ArticleDto`, `AdminPost`, notification actor).

**UI**
- `packages/ui/src/components/verified-badge.tsx`: extends `VerifiedBadgeRole` with `'contributor'`; exports `resolveBadgeTier(input)`.
- `packages/ui/src/styles/theme.css`: new `--color-badge-contributor` token (fuchsia) for light + dark.
- Every existing `isVerified && <VerifiedBadge role={user.role}/>` callsite in the web app now goes through `resolveBadgeTier` (profile header, hover card, post card, search, lists, notifications, DMs, invites, admin tooling, settings privacy lists, OG images for `/og.user.$handle` and `/og.post.$id`).

**Settings**
- `ConnectionsSection` shows a small status row under the GitHub card after connect/refresh: "Recognized as a contributor to {repo}." or "Not detected as a contributor to {repo} yet." with a last-checked timestamp.

## Test plan

- [x] `bun run typecheck` passes
- [x] `bun run lint` passes (after `lint:fix` for sort-imports)
- [x] `bun run format:check` passes
- [x] `bun run build` passes
- [ ] Manually exercised the affected flow in the browser — pending env setup; the implementation has been type-checked, lint-clean, and built end-to-end. Manual flow:
  1. With `GITHUB_CONTRIBUTOR_REPOS` set, connect GitHub as a known contributor → purple badge appears on profile, hover card, post chrome.
  2. Connect as non-contributor with `isVerified=false` → no badge.
  3. Connect as `isVerified=true` regular user who is also a contributor → purple wins over blue.
  4. As `admin`/`owner` who is also a contributor → admin/owner badge wins.
  5. Disconnect GitHub → contributor flag clears.
  6. Admin grants contributor manually → badge appears with no GitHub connection. Admin revokes → badge disappears.

## Notes

- New env var `GITHUB_CONTRIBUTOR_REPOS` (e.g. `twitbruv/twitbruv`). Unset → contributor checks are skipped and the badge is only granted via admin override.
- New schema columns; sync with `bun run db:push`. No migration files generated.
- Disconnecting GitHub clears `is_contributor` regardless of how it was granted (auto vs admin override). If you'd prefer admin overrides to persist across disconnect, that's a small follow-up.
- Risks called out in the plan still apply: private contributions and squash-attribution are invisible to the public contributors API (admin override is the escape hatch); the per-repo cache TTL means new contributors need to wait ≤10 min and hit Refresh to light up.
- Plan committed in PR #143 (`cursor/contributor-badge-plan-812d`).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-edd9f2d7-0de3-455e-b44e-674672fc812d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-edd9f2d7-0de3-455e-b44e-674672fc812d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Contributor badge system added to recognize users who contribute to configured GitHub repos.
  * Admins can manually grant or revoke contributor badges from user management.
  * Contributor status syncs when users connect GitHub; a "checked" timestamp is shown where applicable.
  * Contributor badges now appear across profiles, posts, DMs, notifications, search, invites, lists, and admin views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->