### PR TITLE
Prevent challenging yourself to a chess game

### DIFF
--- a/apps/api/src/routes/chess.ts
+++ b/apps/api/src/routes/chess.ts
@@ -136,6 +136,10 @@ chessRoute.post('/', async (c) => {
   const { db } = c.get('ctx')
   const body = createChessGameSchema.parse(await c.req.json())
 
+  if (body.opponentId === session.user.id) {
+    return c.json({ error: 'self_challenge' }, 400)
+  }
+
   // Validate opponent and create the game in one transaction with FOR UPDATE on
   // the user row, so a concurrent soft-delete can't slip in between the check
   // and the insert.


### PR DESCRIPTION
## Summary

- `POST /chess` accepts any UUID as `opponentId` and inserts a `chess_games` row with that user as the black player. There's no check that the opponent isn't the caller, so a user can create a game where they're both `whitePlayerId` and `blackPlayerId`.
- Once such a game exists, the caller can accept their own challenge (`/:id/accept` only checks `blackPlayerId === session.user.id`) and play both sides. `POST /:id/move` decides whose turn it is from `chess.turn()` and compares against `whitePlayerId`/`blackPlayerId` — when both are the same user, every move is "their turn." Playing to checkmate awards a win and updates the ELO leaderboard, so this is exploitable to inflate ranking against yourself.
- Adds a single early-return mirroring the existing pattern used by `/users/:handle/follow|block|mute` (`self_follow`, `self_block`, `self_mute`).

## Test plan

- [x] CI typecheck / lint / format / build pass
- [x] `POST /chess` with `opponentId` equal to the caller's user id returns `400 { error: 'self_challenge' }`
- [x] `POST /chess` with a different `opponentId` still creates the game

## Notes

- Validator-level (`createChessGameSchema`) enforcement isn't possible because Zod doesn't have access to the session.
- I noticed the same handler also doesn't validate that the opponent exists (an invalid UUID will hit the `users` foreign-key constraint and surface as a 500). Left that for a separate PR to keep this one focused.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented users from creating chess games by challenging their own account; the system now blocks self-challenges and returns an error message when attempted.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/twitbruv/twitbruv/pull/147?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->