### PR TITLE
Rate-limit list pin/unpin under lists.write

### DIFF
--- a/apps/api/src/routes/lists.ts
+++ b/apps/api/src/routes/lists.ts
@@ -177,7 +177,8 @@ listsRoute.patch('/:id', requireHandle(), async (c) => {
 // pinned lists to the top, so this single boolean controls profile ordering.
 listsRoute.post('/:id/pin', requireHandle(), async (c) => {
   const session = c.get('session')!
-  const { db } = c.get('ctx')
+  const { db, rateLimit } = c.get('ctx')
+  await rateLimit(c, 'lists.write')
   const id = c.req.param('id')
   const [row] = await db
     .update(schema.userLists)
@@ -192,7 +193,8 @@ listsRoute.post('/:id/pin', requireHandle(), async (c) => {
 
 listsRoute.delete('/:id/pin', requireHandle(), async (c) => {
   const session = c.get('session')!
-  const { db } = c.get('ctx')
+  const { db, rateLimit } = c.get('ctx')
+  await rateLimit(c, 'lists.write')
   const id = c.req.param('id')
   const [row] = await db
     .update(schema.userLists)


### PR DESCRIPTION
## Summary

- `POST /lists/:id/pin` and `DELETE /lists/:id/pin` were the only write endpoints in `lists.ts` not gated by `rateLimit()`. Every other list write — create (`POST /`), update (`PATCH /:id`), delete (`DELETE /:id`) — already runs `await rateLimit(c, 'lists.write')`, and member writes use `lists.members`.
- Each pin/unpin is a `UPDATE ... SET pinnedAt = ..., updatedAt = NOW()` on `userLists`, which churns the row's `updatedAt` and any caches keyed on list state. Without a limit, an authenticated owner can spam pin toggles on their own lists.
- Reuses the existing `lists.write` bucket (`packages/rate-limit/src/limits.ts:127`) since pinning is part of "list CRUD" — same category as the other list-row writes.

## Test plan

- [x] CI typecheck / lint / format / build pass
- [x] Pin/unpin still works under normal usage
- [x] Sustained pin spam past `lists.write` thresholds (30/hour, 100/day) gets rejected

## Notes

- Scope kept to the two endpoints; no new rate-limit category needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Added rate limiting to list pin and unpin operations to protect against excessive usage and ensure service stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->