### PR TITLE
Rate-limit unfollow/unblock/unmute (DELETE counterparts of follow/block/mute)

### DIFF
--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -574,7 +574,8 @@ usersRoute.post('/:handle/follow', requireHandle(), async (c) => {
 
 usersRoute.delete('/:handle/follow', requireHandle(), async (c) => {
   const session = c.get('session')!
-  const { db, cache } = c.get('ctx')
+  const { db, cache, rateLimit } = c.get('ctx')
+  await rateLimit(c, 'users.follow')
   const user = await resolveHandle(db, c.req.param('handle'))
   if (!user) return c.json({ error: 'not_found' }, 404)
 
@@ -616,7 +617,8 @@ usersRoute.post('/:handle/block', requireHandle(), async (c) => {
 
 usersRoute.delete('/:handle/block', requireHandle(), async (c) => {
   const session = c.get('session')!
-  const { db, cache } = c.get('ctx')
+  const { db, cache, rateLimit } = c.get('ctx')
+  await rateLimit(c, 'users.block')
   const user = await resolveHandle(db, c.req.param('handle'))
   if (!user) return c.json({ error: 'not_found' }, 404)
 
@@ -656,7 +658,8 @@ usersRoute.post('/:handle/mute', requireHandle(), async (c) => {
 
 usersRoute.delete('/:handle/mute', requireHandle(), async (c) => {
   const session = c.get('session')!
-  const { db, cache } = c.get('ctx')
+  const { db, cache, rateLimit } = c.get('ctx')
+  await rateLimit(c, 'users.mute')
   const user = await resolveHandle(db, c.req.param('handle'))
   if (!user) return c.json({ error: 'not_found' }, 404)
 


### PR DESCRIPTION
## Summary

- `POST /users/:handle/follow|block|mute` are each rate-limited (`users.follow`, `users.block`, `users.mute`), but the matching `DELETE` endpoints (unfollow, unblock, unmute) are not. Each one performs a DB delete and a `homeFeedCacheKey` invalidation (block/unblock invalidates two users' caches), so spam is not free.
- The asymmetry also lets a client toggle relationship state in a tight loop without ever hitting the POST limit — e.g., follow → unfollow → follow → unfollow burns half the work the POST limit was meant to bound.
- Fix: add `await rateLimit(c, ...)` to each DELETE using the same bucket as its POST counterpart, so the pair shares one budget.

## Test plan

- [x] CI typecheck / lint / format / build pass
- [x] Normal unfollow / unblock / unmute still work
- [x] Rapid follow→unfollow loop exceeds the `users.follow` limit and is rejected
- [x] Same for block and mute

## Notes

- Reuses existing rate-limit categories — no new entries in `packages/rate-limit/src/limits.ts`.
- POST→DELETE share the same bucket because conceptually they're the same relationship action; counting them under one budget matches the intent of the existing limits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

**Improvements**
* Rate limiting enforcement has been added to unfollow, unblock, and unmute operations to enhance platform stability and service reliability. These endpoints now implement request throttling to maintain consistent performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->