### PR TITLE
mobile: improve new conversation search stability and feedback

### DIFF
--- a/apps/mobile/twitbruv/Features/DMs/NewConversationView.swift
+++ b/apps/mobile/twitbruv/Features/DMs/NewConversationView.swift
@@ -11,7 +11,9 @@ struct NewConversationView: View {
     @State private var groupName = ""
     @State private var users: [UserSummary] = []
     @State private var isCreating = false
+    @State private var isSearching = false
     @State private var errorMessage: String?
+    @State private var searchTask: Task<Void, Never>?
 
     var body: some View {
         NavigationStack {
@@ -40,7 +42,20 @@ struct NewConversationView: View {
                     TextField("Search by handle", text: $query)
                         .textInputAutocapitalization(.never)
                         .autocorrectionDisabled()
-                        .onSubmit { Task { await search() } }
+                        .onSubmit { scheduleSearch(immediate: true) }
+                        .onChange(of: query) { _, _ in
+                            scheduleSearch(immediate: false)
+                        }
+                }
+                if isSearching {
+                    Section {
+                        HStack(spacing: 12) {
+                            ProgressView()
+                            Text("Searching…")
+                                .font(TBTypography.meta)
+                                .foregroundStyle(TBColor.textSecondary)
+                        }
+                    }
                 }
                 if !users.isEmpty {
                     Section("Results") {
@@ -90,15 +105,40 @@ struct NewConversationView: View {
                 }
             }
         }
+        .onDisappear {
+            searchTask?.cancel()
+            searchTask = nil
+        }
+    }
+
+    private func scheduleSearch(immediate: Bool) {
+        searchTask?.cancel()
+        searchTask = Task {
+            if !immediate {
+                try? await Task.sleep(for: .milliseconds(250))
+            }
+            await search()
+        }
     }
 
     private func search() async {
         let q = query.trimmingCharacters(in: .whitespaces)
-        guard q.count >= 2 else { return }
+        guard q.count >= 2 else {
+            isSearching = false
+            users = []
+            errorMessage = nil
+            return
+        }
+        isSearching = true
+        errorMessage = nil
         do {
             let response: SearchResponse = try await env.api.get(API.Search.search(q))
+            guard !Task.isCancelled else { return }
             users = response.users
+            isSearching = false
         } catch {
+            guard !Task.isCancelled else { return }
+            isSearching = false
             errorMessage = error.localizedDescription
         }
     }


### PR DESCRIPTION
### Motivation
- The new-DM flow performed searches only on explicit submit, left stale results while typing, and lacked loading feedback, which made creating conversations feel brittle and unclear.
- Improve responsiveness and stability by debouncing live searches, providing progress UI, and preventing stale/cancelled network results from updating the view.

### Description
- Added `isSearching` and `searchTask` state and a `scheduleSearch(immediate:)` helper to debounce live searches and unify submit/typing behavior.
- Wire `TextField` to call `scheduleSearch(immediate:)` on submit and on change, and show a `ProgressView` section with "Searching…" while a search is in-flight.
- Cancel in-flight search `Task`s when a new query is scheduled or when the view disappears, and clear short-query results/errors immediately.
- Guard against `Task.isCancelled` before applying results and surface network errors in the UI via `errorMessage`.

### Testing
- Ran `bun run typecheck`, which failed in this environment with `/usr/bin/bash: line 1: turbo: command not found`.
- Ran `bun run lint`, which failed in this environment with `/usr/bin/bash: line 1: turbo: command not found`.
- Ran `bun run format:check`, which failed in this environment with `/usr/bin/bash: line 1: turbo: command not found`.
- Ran `bun run build`, which failed in this environment with `/usr/bin/bash: line 1: turbo: command not found`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa176cd074832ebca6cb0837d2a68b)