### PR TITLE
Return 404 in PATCH /media/:id/alt when caller isn't the owner

### DIFF
--- a/apps/api/src/routes/media.ts
+++ b/apps/api/src/routes/media.ts
@@ -123,11 +123,19 @@ export function createMediaRoute(deps: MediaDeps) {
     const body = altSchema.parse(await c.req.json())
 
     // Owner-only — alt text is part of the upload's authored content.
-    const [media] = await db.select().from(schema.media).where(eq(schema.media.id, id)).limit(1)
+    // Fold the ownership check into the WHERE clause so callers can't probe
+    // existence by comparing 404 vs 403 status codes.
+    const [media] = await db
+      .select()
+      .from(schema.media)
+      .where(and(eq(schema.media.id, id), eq(schema.media.ownerId, session.user.id)))
+      .limit(1)
     if (!media) return c.json({ error: 'not_found' }, 404)
-    if (media.ownerId !== session.user.id) return c.json({ error: 'forbidden' }, 403)
 
-    await db.update(schema.media).set({ altText: body.altText }).where(eq(schema.media.id, id))
+    await db
+      .update(schema.media)
+      .set({ altText: body.altText })
+      .where(and(eq(schema.media.id, id), eq(schema.media.ownerId, session.user.id)))
     return c.json({ ok: true })
   })
 


### PR DESCRIPTION
## Summary

- `PATCH /media/:id/alt` returned `404 not_found` for non-existent media but `403 forbidden` for media owned by someone else. The pair lets a caller probe which media IDs exist by sending random UUIDs and watching the status code — an existence oracle.
- Fix: fold the ownership check into the `WHERE` clause of the lookup, mirroring the pattern already used 30 lines above in `POST /media/:id/finalize` (line 91 of the same file). The handler now returns `404 not_found` whether the row doesn't exist or belongs to a different user.

## Test plan

- [x] CI typecheck / lint / format / build pass
- [x] `PATCH /media/:id/alt` on owned media still updates `altText`
- [x] `PATCH /media/:id/alt` on a media ID owned by a different user returns `404 not_found` (was 403 forbidden)
- [x] `PATCH /media/:id/alt` on a non-existent UUID still returns `404 not_found`

## Notes

- No change to the success path or response shape.
- `and` was already imported from `@workspace/db`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Optimized internal ownership verification logic for media alt text updates to improve system efficiency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->