### PR TITLE
Rate-limit POST /media/:id/finalize under media.upload

### DIFF
--- a/apps/api/src/routes/media.ts
+++ b/apps/api/src/routes/media.ts
@@ -82,7 +82,8 @@ export function createMediaRoute(deps: MediaDeps) {
 
   route.post('/:id/finalize', requireHandle(), async (c) => {
     const session = c.get('session')!
-    const { db } = c.get('ctx')
+    const { db, rateLimit } = c.get('ctx')
+    await rateLimit(c, 'media.upload')
     const id = c.req.param('id')
 
     const [media] = await db


### PR DESCRIPTION
## Summary

- `POST /media/:id/finalize` is the second step of the upload flow — it confirms the S3 upload happened and enqueues a background `media.process` job. The companion `POST /media/intent` already runs `await rateLimit(c, 'media.upload')` (line 44), but the finalize step does not, so a caller can spam finalize calls and queue arbitrarily many `media.process` jobs without ever hitting the upload rate limit.
- Each finalize call also performs an S3 `HeadObject` and a DB `UPDATE`, plus enqueues a worker job that decodes / resizes / re-uploads images.
- Fix: add `await rateLimit(c, 'media.upload')` to the finalize handler so intent + finalize share one budget. Reusing the existing bucket (`{ HOUR, max: 60 }`) keeps the user's intent-then-finalize round trip on the same counter.

## Test plan

- [x] CI typecheck / lint / format / build pass
- [x] Normal upload flow (intent → S3 PUT → finalize) still works once
- [x] Spamming `POST /media/:id/finalize` past the `media.upload` cap returns the rate-limit error

## Notes

- No new rate-limit category needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Media finalization endpoint now enforces rate limiting to prevent excessive API usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->