### PR TITLE
Rate-limit PATCH /media/:id/alt under media.upload

### DIFF
--- a/apps/api/src/routes/media.ts
+++ b/apps/api/src/routes/media.ts
@@ -118,7 +118,8 @@ export function createMediaRoute(deps: MediaDeps) {
   const altSchema = z.object({ altText: z.string().trim().max(1000).nullable() })
   route.patch('/:id/alt', requireHandle(), async (c) => {
     const session = c.get('session')!
-    const { db } = c.get('ctx')
+    const { db, rateLimit } = c.get('ctx')
+    await rateLimit(c, 'media.upload')
     const id = c.req.param('id')
     const body = altSchema.parse(await c.req.json())
 


### PR DESCRIPTION
## Summary

- `PATCH /media/:id/alt` updates the alt-text on an owned media row. It performs a DB select + DB update per call but has no rate limit, while the other media write endpoint (`POST /media/intent`, line 44) is gated by `media.upload`. A caller can spam alt-text PATCHes on their own media indefinitely.
- Fix: add `await rateLimit(c, 'media.upload')` at the top of the handler. Reusing the existing bucket (60/hour) is generous for legitimate alt-text edits and keeps churn-attacks bounded.

## Test plan

- [x] CI typecheck / lint / format / build pass
- [x] Editing alt text on owned media still works
- [x] Sustained alt-text spam past the `media.upload` cap is rejected

## Notes

- No new rate-limit category needed.
- The same handler also has an existence-oracle bug (404 vs 403) — being addressed separately in PR #151 to keep this one focused on the rate-limit gap.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
- The alt-text update endpoint now enforces rate limiting to ensure fair API usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->