### PR TITLE
Validate chess opponent exists before insert

### DIFF
--- a/apps/api/src/routes/chess.ts
+++ b/apps/api/src/routes/chess.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono'
-import { and, desc, eq, or } from '@workspace/db'
+import { and, desc, eq, isNull, or } from '@workspace/db'
 import { schema } from '@workspace/db'
 import { createChessGameSchema, moveChessSchema } from '@workspace/validators'
 import { requireHandle, type HonoEnv } from '../middleware/session.ts'
@@ -135,6 +135,13 @@ chessRoute.post('/', async (c) => {
   const session = c.get('session')!
   const { db } = c.get('ctx')
   const body = createChessGameSchema.parse(await c.req.json())
+
+  const [opponent] = await db
+    .select({ id: schema.users.id })
+    .from(schema.users)
+    .where(and(eq(schema.users.id, body.opponentId), isNull(schema.users.deletedAt)))
+    .limit(1)
+  if (!opponent) return c.json({ error: 'opponent_not_found' }, 404)
 
   // For simplicity, the creator is white, opponent is black
   // In a real app, you might want to randomize this or have a challenge system

--- a/apps/api/src/routes/chess.ts
+++ b/apps/api/src/routes/chess.ts
@@ -136,22 +136,28 @@ chessRoute.post('/', async (c) => {
   const { db } = c.get('ctx')
   const body = createChessGameSchema.parse(await c.req.json())
 
-  const [opponent] = await db
-    .select({ id: schema.users.id })
-    .from(schema.users)
-    .where(and(eq(schema.users.id, body.opponentId), isNull(schema.users.deletedAt)))
-    .limit(1)
-  if (!opponent) return c.json({ error: 'opponent_not_found' }, 404)
+  // Validate opponent and create the game in one transaction with FOR UPDATE on
+  // the user row, so a concurrent soft-delete can't slip in between the check
+  // and the insert.
+  const game = await db.transaction(async (tx) => {
+    const [opponent] = await tx
+      .select({ id: schema.users.id })
+      .from(schema.users)
+      .where(and(eq(schema.users.id, body.opponentId), isNull(schema.users.deletedAt)))
+      .limit(1)
+      .for('update')
+    if (!opponent) return null
 
-  // For simplicity, the creator is white, opponent is black
-  // In a real app, you might want to randomize this or have a challenge system
-  const [game] = await db
-    .insert(schema.chessGames)
-    .values({
-      whitePlayerId: session.user.id,
-      blackPlayerId: body.opponentId,
-    })
-    .returning()
+    const [created] = await tx
+      .insert(schema.chessGames)
+      .values({
+        whitePlayerId: session.user.id,
+        blackPlayerId: body.opponentId,
+      })
+      .returning()
+    return created ?? null
+  })
+  if (!game) return c.json({ error: 'opponent_not_found' }, 404)
 
   c.get('ctx').track('chess_game_created', session.user.id)
   return c.json({ game })


### PR DESCRIPTION
## Summary

- `POST /chess` accepts any UUID-shaped string as `opponentId` and inserts directly into `chess_games`. If that UUID doesn't match a real user, the `chess_games_black_player_id_fkey` foreign-key constraint fires and Postgres returns a 500 to the client. The error is opaque, leaks Postgres internals, and isn't distinguishable from a real server error in logs.
- Fix: look up the opponent first (filtered by `deletedAt IS NULL` so soft-deleted users aren't acceptable challenge targets either) and return `404 opponent_not_found` instead. Mirrors the `resolveHandle` lookup pattern used everywhere in `users.ts`.

## Test plan

- [x] CI typecheck / lint / format / build pass
- [x] `POST /chess` with a real opponent's UUID still creates the game
- [x] `POST /chess` with a random/non-existent UUID returns `404 opponent_not_found` (was 500)
- [x] `POST /chess` with the UUID of a soft-deleted user also returns 404

## Notes

- Independent of PR #147 (self-challenge guard) — both can land in either order; no conflict.
- This adds one extra SELECT per challenge creation, which is negligible.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chess game creation so opponents are validated as active before a game is created; attempts to challenge an unavailable opponent now return a clear error.
  * Made game creation more reliable under concurrent requests to avoid creating games with deleted or unavailable opponents.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->