### PR TITLE
Fix prettier-flagged web files (unbreak format CI on main)

### DIFF
--- a/apps/web/src/components/admin/posts.tsx
+++ b/apps/web/src/components/admin/posts.tsx
@@ -190,7 +190,11 @@ export default function AdminPosts() {
 
   const posts = useMemo(() => data?.pages.flatMap((p) => p.posts) ?? [], [data])
 
-  const loadError = error ? (error instanceof Error ? error.message : "failed to load") : null
+  const loadError = error
+    ? error instanceof Error
+      ? error.message
+      : "failed to load"
+    : null
 
   const [busyId, setBusyId] = useState<string | null>(null)
   const [deleteTarget, setDeleteTarget] = useState<AdminPost | null>(null)

--- a/apps/web/src/components/poll-block.tsx
+++ b/apps/web/src/components/poll-block.tsx
@@ -101,9 +101,11 @@ export function PollBlock({
                 <div className="relative flex items-center justify-between gap-3 px-3 py-2.5 text-sm">
                   <span className="flex items-center gap-2 font-medium">
                     {opt.text}
-                    {isViewerChoice && <span className="text-primary font-bold">✓</span>}
+                    {isViewerChoice && (
+                      <span className="font-bold text-primary">✓</span>
+                    )}
                   </span>
-                  <span className="text-primary font-medium text-sm tabular-nums">
+                  <span className="text-sm font-medium text-primary tabular-nums">
                     {pct.toFixed(0)}%
                   </span>
                 </div>
@@ -114,7 +116,7 @@ export function PollBlock({
         return (
           <li key={opt.id}>
             <label
-              className={`hover:bg-base-2 flex cursor-pointer items-center gap-3 rounded-md border border-neutral px-3 py-2.5 text-sm transition font-medium ${
+              className={`flex cursor-pointer items-center gap-3 rounded-md border border-neutral px-3 py-2.5 text-sm font-medium transition hover:bg-base-2 ${
                 isSelected ? "border-primary bg-primary/5 text-primary" : ""
               }`}
             >
@@ -135,10 +137,7 @@ export function PollBlock({
   )
 
   return (
-    <div
-      data-post-card-ignore-open
-      className="mt-3 flex flex-col gap-2"
-    >
+    <div data-post-card-ignore-open className="mt-3 flex flex-col gap-2">
       {!showResults && !poll.allowMultiple ? (
         <RadioGroup
           value={[...selected][0] ?? ""}
@@ -154,7 +153,7 @@ export function PollBlock({
       ) : (
         optionsList
       )}
-      <div className="text-tertiary flex items-center gap-2 text-sm mt-1">
+      <div className="mt-1 flex items-center gap-2 text-sm text-tertiary">
         <span>
           {poll.totalVotes} {poll.totalVotes === 1 ? "vote" : "votes"} ·{" "}
           {formatTimeLeft(closesAt - now)}
@@ -166,7 +165,7 @@ export function PollBlock({
               type="button"
               onClick={() => submit()}
               disabled={busy || selected.size === 0}
-              className="text-primary font-medium hover:underline disabled:opacity-50"
+              className="font-medium text-primary hover:underline disabled:opacity-50"
             >
               {busy ? "Voting…" : "Vote"}
             </button>


### PR DESCRIPTION
## Summary

- The \`format\` CI check is currently failing on every PR opened against \`main\` because two files on \`main\` itself aren't prettier-formatted: \`apps/web/src/components/admin/posts.tsx\` and \`apps/web/src/components/poll-block.tsx\`. \`bun run format:check\` reports them, exits 1, and the GitHub Action turns red on every contribution — mine and anyone else's.
- Fix: ran \`bun run format\` so prettier rewrites only the two flagged files. The diff is entirely Tailwind class re-ordering (the project's \`prettier-plugin-tailwindcss\` orders classes per Tailwind's recommended sort). No logic, props, classes, or JSX structure changed.
- Once this lands, my other open PRs (#148, #149, #151, #152, #153, #154) will get green format checks on their next CI re-run with no change needed on their side.

## Test plan

- [ ] CI typecheck / lint / format / build all pass on this PR
- [ ] Visual diff on poll-block and admin/posts shows only class-reorder / whitespace, no behavior change

## Notes

- This is purely a formatting unblocker — no behavior change, no API change, no schema change. Atomic on purpose so it can land fast and unstick the format gate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved code clarity in admin post error handling logic.
  * Simplified poll block component markup structure and styling formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->