### PR TITLE
Show "now" instead of "0s" or negative seconds for fresh posts

### DIFF
--- a/apps/web/src/components/feed-post-card.tsx
+++ b/apps/web/src/components/feed-post-card.tsx
@@ -56,6 +56,7 @@ function relativeTime(iso: string): string {
   const d = new Date(iso).getTime()
   const diff = Date.now() - d
   const s = Math.floor(diff / 1000)
+  if (s < 1) return "now"
   if (s < 60) return `${s}s`
   const m = Math.floor(s / 60)
   if (m < 60) return `${m}m`

--- a/apps/web/src/components/post-card.tsx
+++ b/apps/web/src/components/post-card.tsx
@@ -46,6 +46,7 @@ function relativeTime(iso: string): string {
   const d = new Date(iso).getTime()
   const diff = Date.now() - d
   const s = Math.floor(diff / 1000)
+  if (s < 1) return "now"
   if (s < 60) return `${s}s`
   const m = Math.floor(s / 60)
   if (m < 60) return `${m}m`


### PR DESCRIPTION
## Summary

- \`relativeTime()\` in \`post-card.tsx\` and \`feed-post-card.tsx\` (identical copies) computed \`Math.floor((Date.now() - postCreatedAt) / 1000)\` and displayed it as \`{n}s\`. For a just-posted item that's \`"0s"\`, and any clock skew between server and client (server's clock slightly ahead) flips the diff negative — the UI then shows \`"-3s"\` or similar, which looks broken.
- Fix: add a \`if (s < 1) return "now"\` guard at the top of each formatter, matching the existing pattern used by \`formatShortTime\` in \`apps/web/src/routes/notifications.tsx:898\`.

## Test plan

- [x] CI typecheck / lint / format / build pass
- [x] Posting an item shows \`"now"\` for the first second
- [x] Counter still ticks normally past 1s (\`1s\`, \`2s\`, ...)

## Notes

- The two copies are duplicates; deduping into a shared util would be a separate refactor PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved relative timestamp display for recent posts. Timestamps now show "now" for posts created within the last second, providing clearer feedback on post recency instead of displaying very small time values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->