### PR TITLE
Fix silent logout when duplicate auth cookies stack on cross-subdomain deploys

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,11 +16,15 @@ BETTER_AUTH_URL=http://localhost:3001
 
 # Session cookie config (derived from BETTER_AUTH_URL in code; override per env)
 AUTH_COOKIE_DOMAIN=localhost
-# Set true on the API after migrating to a wildcard AUTH_COOKIE_DOMAIN so stale host-only / old
-# Domain cookies are expired (fixes duplicate session_token + silent logout; Better Auth #9233).
+# If you ever issued cookies under more than one Domain scope (e.g. API host `api.example.com`
+# and later wildcard `.example.com`), the browser can store two `session_token` cookies with the
+# same name. Sign-out only clears cookies matching AUTH_COOKIE_DOMAIN — the other scope stays
+# until you expire it. Enable briefly on the API to attach Max-Age=0 for obsolete scopes (see
+# apps/api/src/middleware/legacy-auth-cookies.ts; background: Better Auth #9233).
 # AUTH_LEGACY_AUTH_COOKIE_CLEANUP=false
-# Optional comma list of extra legacy Domain values to clear, e.g. `api.ak2.dev`.
-# AUTH_LEGACY_COOKIE_DOMAINS=
+# Comma-separated legacy `Domain=` values to clear (add your API hostname if it ever had its
+# own scoped cookies next to the wildcard).
+# AUTH_LEGACY_COOKIE_DOMAINS=api.ak2.dev
 # Comma list; must match the browser tab origin (scheme + host + port). In development the API
 # also merges common localhost/127.0.0.1 ports. Use http://127.0.0.1:3000 not localhost if the URL bar shows 127.0.0.1 — they are different origins to the browser.
 AUTH_TRUSTED_ORIGINS=http://localhost:3000,http://localhost:3001,http://127.0.0.1:3000,http://127.0.0.1:3001

--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,11 @@ BETTER_AUTH_URL=http://localhost:3001
 
 # Session cookie config (derived from BETTER_AUTH_URL in code; override per env)
 AUTH_COOKIE_DOMAIN=localhost
+# Set true on the API after migrating to a wildcard AUTH_COOKIE_DOMAIN so stale host-only / old
+# Domain cookies are expired (fixes duplicate session_token + silent logout; Better Auth #9233).
+# AUTH_LEGACY_AUTH_COOKIE_CLEANUP=false
+# Optional comma list of extra legacy Domain values to clear, e.g. `api.ak2.dev`.
+# AUTH_LEGACY_COOKIE_DOMAINS=
 # Comma list; must match the browser tab origin (scheme + host + port). In development the API
 # also merges common localhost/127.0.0.1 ports. Use http://127.0.0.1:3000 not localhost if the URL bar shows 127.0.0.1 — they are different origins to the browser.
 AUTH_TRUSTED_ORIGINS=http://localhost:3000,http://localhost:3001,http://127.0.0.1:3000,http://127.0.0.1:3001

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,53 +1,64 @@
-import { Hono } from 'hono'
-import { compress } from 'hono/compress'
-import { cors } from 'hono/cors'
-import { etag } from 'hono/etag'
-import { secureHeaders } from 'hono/secure-headers'
-import { sql } from '@workspace/db'
-import { buildContext } from './lib/context.ts'
-import { handleRateLimitError } from '@workspace/rate-limit'
-import { requireSameOrigin, sessionMiddleware, type HonoEnv } from './middleware/session.ts'
-import { meRoute } from './routes/me.ts'
-import { usersRoute } from './routes/users.ts'
-import { postsRoute } from './routes/posts.ts'
-import { feedRoute } from './routes/feed.ts'
-import { hashtagsRoute } from './routes/hashtags.ts'
-import { searchRoute } from './routes/search.ts'
-import { createMediaRoute } from './routes/media.ts'
-import { signedGetUrl } from '@workspace/media/s3'
-import { articlesRoute } from './routes/articles.ts'
-import { notificationsRoute } from './routes/notifications.ts'
-import { analyticsRoute } from './routes/analytics.ts'
-import { dmsRoute } from './routes/dms.ts'
-import { invitesRoute } from './routes/invites.ts'
-import { reportsRoute } from './routes/reports.ts'
-import { federationRoute } from './routes/federation.ts'
-import { adminRoute } from './routes/admin.ts'
-import { pollsRoute } from './routes/polls.ts'
-import { scheduledPostsRoute } from './routes/scheduled-posts.ts'
-import { listsRoute } from './routes/lists.ts'
-import { githubConnectorRoute } from './routes/connectors/github.ts'
-import { chessRoute } from './routes/chess.ts'
-import { unfurlRoute } from './routes/unfurl.ts'
-import { devRoute } from './routes/dev.ts'
+import { Hono } from "hono"
+import { compress } from "hono/compress"
+import { cors } from "hono/cors"
+import { etag } from "hono/etag"
+import { secureHeaders } from "hono/secure-headers"
+import { sql } from "@workspace/db"
+import { buildContext } from "./lib/context.ts"
+import { handleRateLimitError } from "@workspace/rate-limit"
+import { legacyAuthCookieCleanupMiddleware } from "./middleware/legacy-auth-cookies.ts"
+import {
+  requireSameOrigin,
+  sessionMiddleware,
+  type HonoEnv,
+} from "./middleware/session.ts"
+import { meRoute } from "./routes/me.ts"
+import { usersRoute } from "./routes/users.ts"
+import { postsRoute } from "./routes/posts.ts"
+import { feedRoute } from "./routes/feed.ts"
+import { hashtagsRoute } from "./routes/hashtags.ts"
+import { searchRoute } from "./routes/search.ts"
+import { createMediaRoute } from "./routes/media.ts"
+import { signedGetUrl } from "@workspace/media/s3"
+import { articlesRoute } from "./routes/articles.ts"
+import { notificationsRoute } from "./routes/notifications.ts"
+import { analyticsRoute } from "./routes/analytics.ts"
+import { dmsRoute } from "./routes/dms.ts"
+import { invitesRoute } from "./routes/invites.ts"
+import { reportsRoute } from "./routes/reports.ts"
+import { federationRoute } from "./routes/federation.ts"
+import { adminRoute } from "./routes/admin.ts"
+import { pollsRoute } from "./routes/polls.ts"
+import { scheduledPostsRoute } from "./routes/scheduled-posts.ts"
+import { listsRoute } from "./routes/lists.ts"
+import { githubConnectorRoute } from "./routes/connectors/github.ts"
+import { chessRoute } from "./routes/chess.ts"
+import { unfurlRoute } from "./routes/unfurl.ts"
+import { devRoute } from "./routes/dev.ts"
 
 const ctx = await buildContext()
 const app = new Hono<HonoEnv>()
 
 // Structured request log via pino. JSON in production, pretty in dev. Skip the noisy media
 // proxy + healthcheck — every page paint hits those and they'd swamp logs.
-app.use('*', async (c, next) => {
+app.use("*", async (c, next) => {
   const start = Date.now()
   await next()
   const path = c.req.path
-  if (path === '/healthz' || path === '/readyz' || path.startsWith('/api/m/')) return
+  if (path === "/healthz" || path === "/readyz" || path.startsWith("/api/m/"))
+    return
   ctx.log.info(
-    { method: c.req.method, path, status: c.res.status, ms: Date.now() - start },
-    'req',
+    {
+      method: c.req.method,
+      path,
+      status: c.res.status,
+      ms: Date.now() - start,
+    },
+    "req"
   )
 })
 app.use(
-  '*',
+  "*",
   secureHeaders({
     // CORP/COEP block legitimate cross-origin loads (the web app pulling images and JSON from
     // this API). Cross-origin access control is enforced by the CORS middleware below; turning
@@ -57,56 +68,62 @@ app.use(
     // 1y HSTS w/ subdomains + preload, gated by env. Once enabled the browser pins the domain
     // to HTTPS — never flip on without permanent HTTPS.
     strictTransportSecurity: ctx.env.ENABLE_HSTS
-      ? 'max-age=31536000; includeSubDomains; preload'
+      ? "max-age=31536000; includeSubDomains; preload"
       : false,
     // Referrer leakage: we deal in private DMs and mod tools — do not leak full URLs to
     // outbound link clicks.
-    referrerPolicy: 'strict-origin-when-cross-origin',
-  }),
+    referrerPolicy: "strict-origin-when-cross-origin",
+  })
 )
 // Gzip/deflate JSON responses above 1KB. Feed/thread payloads compress ~5-10x.
 // `compress()` skips already-encoded streams (SSE, redirects, images) so DM streaming and
 // the /api/m/* signed-URL redirect pass through untouched.
-app.use('*', compress())
+app.use("*", compress())
 app.use(
-  '*',
+  "*",
   cors({
     origin: ctx.env.AUTH_TRUSTED_ORIGINS,
     credentials: true,
-    allowHeaders: ['Content-Type', 'Authorization', 'X-Db-Anon-Id', 'X-Db-Session-Id'],
-    allowMethods: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'],
-    exposeHeaders: ['Set-Cookie'],
+    allowHeaders: [
+      "Content-Type",
+      "Authorization",
+      "X-Db-Anon-Id",
+      "X-Db-Session-Id",
+    ],
+    allowMethods: ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
+    exposeHeaders: ["Set-Cookie"],
     maxAge: 86400,
-  }),
+  })
 )
 // Hard kill switch. Runs after CORS so the 503 response carries the right CORS headers and
 // the browser can read the body. Health probes bypass so orchestrators don't route the
 // instance out while we're locking the app down.
-app.use('*', async (c, next) => {
+app.use("*", async (c, next) => {
   if (!ctx.env.MAINTENANCE_MODE) return next()
   const path = c.req.path
-  if (path === '/healthz' || path === '/readyz') return next()
-  c.header('Retry-After', '300')
+  if (path === "/healthz" || path === "/readyz") return next()
+  c.header("Retry-After", "300")
   return c.json(
-    { error: 'maintenance', message: ctx.env.MAINTENANCE_MESSAGE },
-    503,
+    { error: "maintenance", message: ctx.env.MAINTENANCE_MESSAGE },
+    503
   )
 })
-app.use('*', sessionMiddleware(ctx))
-app.use('*', requireSameOrigin(ctx.env.AUTH_TRUSTED_ORIGINS))
+app.use("*", legacyAuthCookieCleanupMiddleware(ctx.env))
+app.use("*", sessionMiddleware(ctx))
+app.use("*", requireSameOrigin(ctx.env.AUTH_TRUSTED_ORIGINS))
 
 // Liveness: process is up. Kept cheap so Railway can hammer it.
-app.get('/healthz', (c) => c.json({ ok: true }))
+app.get("/healthz", (c) => c.json({ ok: true }))
 
 // Readiness: DB is reachable. Returns 503 if the ping fails so Railway can route around a
 // half-broken instance instead of serving 500s to users.
-app.get('/readyz', async (c) => {
+app.get("/readyz", async (c) => {
   try {
     await ctx.db.execute(sql`SELECT 1`)
     return c.json({ ok: true })
   } catch (err) {
-    ctx.log.error({ err: errMsg(err) }, 'readyz_db_ping_failed')
-    return c.json({ ok: false, error: 'db_unreachable' }, 503)
+    ctx.log.error({ err: errMsg(err) }, "readyz_db_ping_failed")
+    return c.json({ ok: false, error: "db_unreachable" }, 503)
   }
 })
 
@@ -116,41 +133,53 @@ function errMsg(err: unknown): string {
 
 // Mount better-auth (handles /api/auth/*). Apply rate limits on the abusable flows before
 // delegating to better-auth — it doesn't enforce any.
-app.on(['POST', 'GET'], '/api/auth/*', async (c) => {
+app.on(["POST", "GET"], "/api/auth/*", async (c) => {
   const path = c.req.path
-  if (c.req.method === 'GET') {
-    if (path.endsWith('/passkey/generate-authenticate-options')) {
-      await ctx.rateLimit(c, 'auth.passkey-authenticate')
-    } else if (path.endsWith('/passkey/generate-register-options')) {
-      await ctx.rateLimit(c, 'auth.passkey-register')
+  if (c.req.method === "GET") {
+    if (path.endsWith("/passkey/generate-authenticate-options")) {
+      await ctx.rateLimit(c, "auth.passkey-authenticate")
+    } else if (path.endsWith("/passkey/generate-register-options")) {
+      await ctx.rateLimit(c, "auth.passkey-register")
     }
   }
-  if (c.req.method === 'POST') {
-    if (path.endsWith('/sign-up/email')) await ctx.rateLimit(c, 'auth.signup')
-    else if (path.endsWith('/sign-in/email')) await ctx.rateLimit(c, 'auth.signin')
-    else if (path.endsWith('/sign-in/magic-link')) await ctx.rateLimit(c, 'auth.magic-link')
-    else if (path.endsWith('/verify-password')) await ctx.rateLimit(c, 'auth.signin')
-    else if (path.endsWith('/change-password')) await ctx.rateLimit(c, 'auth.signin')
-    else if (path.endsWith('/request-password-reset')) await ctx.rateLimit(c, 'auth.password-reset')
-    else if (path.includes('/reset-password')) await ctx.rateLimit(c, 'auth.password-reset')
-    else if (path.endsWith('/two-factor/verify-totp')) await ctx.rateLimit(c, 'auth.2fa-verify')
-    else if (path.endsWith('/two-factor/verify-backup-code')) await ctx.rateLimit(c, 'auth.2fa-verify')
-    else if (path.endsWith('/two-factor/verify-otp')) await ctx.rateLimit(c, 'auth.2fa-verify')
-    else if (path.endsWith('/two-factor/send-otp')) await ctx.rateLimit(c, 'auth.email-verify-resend')
-    else if (path.endsWith('/send-verification-email')) await ctx.rateLimit(c, 'auth.email-verify-resend')
-    else if (path.endsWith('/change-email')) await ctx.rateLimit(c, 'auth.email-verify-resend')
-    else if (path.endsWith('/passkey/verify-authentication')) {
-      await ctx.rateLimit(c, 'auth.passkey-authenticate')
-    } else if (path.endsWith('/passkey/verify-registration')) {
-      await ctx.rateLimit(c, 'auth.passkey-register')
+  if (c.req.method === "POST") {
+    if (path.endsWith("/sign-up/email")) await ctx.rateLimit(c, "auth.signup")
+    else if (path.endsWith("/sign-in/email"))
+      await ctx.rateLimit(c, "auth.signin")
+    else if (path.endsWith("/sign-in/magic-link"))
+      await ctx.rateLimit(c, "auth.magic-link")
+    else if (path.endsWith("/verify-password"))
+      await ctx.rateLimit(c, "auth.signin")
+    else if (path.endsWith("/change-password"))
+      await ctx.rateLimit(c, "auth.signin")
+    else if (path.endsWith("/request-password-reset"))
+      await ctx.rateLimit(c, "auth.password-reset")
+    else if (path.includes("/reset-password"))
+      await ctx.rateLimit(c, "auth.password-reset")
+    else if (path.endsWith("/two-factor/verify-totp"))
+      await ctx.rateLimit(c, "auth.2fa-verify")
+    else if (path.endsWith("/two-factor/verify-backup-code"))
+      await ctx.rateLimit(c, "auth.2fa-verify")
+    else if (path.endsWith("/two-factor/verify-otp"))
+      await ctx.rateLimit(c, "auth.2fa-verify")
+    else if (path.endsWith("/two-factor/send-otp"))
+      await ctx.rateLimit(c, "auth.email-verify-resend")
+    else if (path.endsWith("/send-verification-email"))
+      await ctx.rateLimit(c, "auth.email-verify-resend")
+    else if (path.endsWith("/change-email"))
+      await ctx.rateLimit(c, "auth.email-verify-resend")
+    else if (path.endsWith("/passkey/verify-authentication")) {
+      await ctx.rateLimit(c, "auth.passkey-authenticate")
+    } else if (path.endsWith("/passkey/verify-registration")) {
+      await ctx.rateLimit(c, "auth.passkey-register")
     } else if (
-      path.endsWith('/passkey/delete-passkey') ||
-      path.endsWith('/passkey/update-passkey')
+      path.endsWith("/passkey/delete-passkey") ||
+      path.endsWith("/passkey/update-passkey")
     ) {
-      await ctx.rateLimit(c, 'auth.passkey-manage')
+      await ctx.rateLimit(c, "auth.passkey-manage")
     }
   }
-  if (path.includes('/callback/')) await ctx.rateLimit(c, 'auth.oauth-callback')
+  if (path.includes("/callback/")) await ctx.rateLimit(c, "auth.oauth-callback")
   return ctx.auth.handler(c.req.raw)
 })
 
@@ -162,57 +191,57 @@ app.on(['POST', 'GET'], '/api/auth/*', async (c) => {
 // compressed downstream; weak ETags survive representation changes.
 const etagInner = etag({ weak: true })
 const readEtag: typeof etagInner = async (c, next) => {
-  if (c.req.method !== 'GET' && c.req.method !== 'HEAD') return next()
+  if (c.req.method !== "GET" && c.req.method !== "HEAD") return next()
   return etagInner(c, next)
 }
 for (const path of [
-  '/api/feed',
-  '/api/feed/*',
-  '/api/users/*',
-  '/api/posts',
-  '/api/posts/*',
-  '/api/notifications',
-  '/api/notifications/*',
-  '/api/hashtags',
-  '/api/hashtags/*',
-  '/api/articles/*',
-  '/api/search',
+  "/api/feed",
+  "/api/feed/*",
+  "/api/users/*",
+  "/api/posts",
+  "/api/posts/*",
+  "/api/notifications",
+  "/api/notifications/*",
+  "/api/hashtags",
+  "/api/hashtags/*",
+  "/api/articles/*",
+  "/api/search",
 ]) {
   app.use(path, readEtag)
 }
 
-app.route('/api/me', meRoute)
-app.route('/api/users', usersRoute)
-app.route('/api/posts', postsRoute)
-app.route('/api/feed', feedRoute)
-app.route('/api/hashtags', hashtagsRoute)
-app.route('/api/search', searchRoute)
+app.route("/api/me", meRoute)
+app.route("/api/users", usersRoute)
+app.route("/api/posts", postsRoute)
+app.route("/api/feed", feedRoute)
+app.route("/api/hashtags", hashtagsRoute)
+app.route("/api/search", searchRoute)
 app.route(
-  '/api/media',
-  createMediaRoute({ s3: ctx.s3, mediaEnv: ctx.mediaEnv, boss: ctx.boss }),
+  "/api/media",
+  createMediaRoute({ s3: ctx.s3, mediaEnv: ctx.mediaEnv, boss: ctx.boss })
 )
 
 // Signing proxy: takes a stored object key on the path, mints a short-lived signed URL, and
 // 302s the browser to it. The CDN edge caches the redirect briefly (s-maxage) so repeated
 // paints don't thrash signing; browsers are told no-store to avoid disk-caching a redirect
 // whose signed URL expires long before the browser would evict it.
-app.get('/api/m/*', async (c) => {
+app.get("/api/m/*", async (c) => {
   // Recover the object key by stripping every leading occurrence of the route prefix. Belt
   // and suspenders for any path-doubling that happens upstream (proxies, custom domains).
   let key = c.req.path
-  while (key.startsWith('/')) key = key.slice(1)
-  while (key.startsWith('api/m/')) key = key.slice('api/m/'.length)
+  while (key.startsWith("/")) key = key.slice(1)
+  while (key.startsWith("api/m/")) key = key.slice("api/m/".length)
   key = decodeURIComponent(key)
-  if (!key) return c.json({ error: 'missing_key' }, 400)
+  if (!key) return c.json({ error: "missing_key" }, 400)
   // Reject any traversal-style key. Path normalization differs across browsers and S3 SDK
   // implementations, and the bucket layout never legitimately contains "..", "//", or backslashes.
   if (
-    key.includes('..') ||
-    key.includes('//') ||
-    key.includes('\\') ||
-    key.startsWith('/')
+    key.includes("..") ||
+    key.includes("//") ||
+    key.includes("\\") ||
+    key.startsWith("/")
   ) {
-    return c.json({ error: 'bad_key' }, 400)
+    return c.json({ error: "bad_key" }, 400)
   }
 
   const signed = await signedGetUrl({
@@ -225,38 +254,47 @@ app.get('/api/m/*', async (c) => {
   // browser would disk-cache this 302 far past the signed URL's 15-min lifetime → 403.
   // `no-store` is respected even when CF overrides max-age, preventing browser caching.
   // `s-maxage` still lets the CDN edge cache the redirect for a few minutes.
-  const edgeSeconds = Math.max(0, Math.min(300, ctx.env.MEDIA_SIGNED_URL_TTL_SEC - 60))
-  c.header('Cache-Control', `no-store, s-maxage=${edgeSeconds}`)
+  const edgeSeconds = Math.max(
+    0,
+    Math.min(300, ctx.env.MEDIA_SIGNED_URL_TTL_SEC - 60)
+  )
+  c.header("Cache-Control", `no-store, s-maxage=${edgeSeconds}`)
   return c.redirect(signed, 302)
 })
-app.route('/api/articles', articlesRoute)
-app.route('/api/notifications', notificationsRoute)
-app.route('/api/analytics', analyticsRoute)
-app.route('/api/dms', dmsRoute)
-app.route('/api/invites', invitesRoute)
-app.route('/api/reports', reportsRoute)
+app.route("/api/articles", articlesRoute)
+app.route("/api/notifications", notificationsRoute)
+app.route("/api/analytics", analyticsRoute)
+app.route("/api/dms", dmsRoute)
+app.route("/api/invites", invitesRoute)
+app.route("/api/reports", reportsRoute)
 // Federation surfaces are mounted at root, NOT under /api, because spec paths like
 // /.well-known/webfinger and /users/:handle are absolute. This intentionally collides with
 // the public profile URL on the web app; the actor route content-negotiates so browsers get
 // 302'd back to the web profile.
-app.route('/', federationRoute)
-app.route('/api/admin', adminRoute)
-app.route('/api/polls', pollsRoute)
-app.route('/api/scheduled-posts', scheduledPostsRoute)
-app.route('/api/lists', listsRoute)
-app.route('/api/connectors/github', githubConnectorRoute)
-app.route('/api/chess', chessRoute)
-app.route('/api/unfurl', unfurlRoute)
-app.route('/api/dev', devRoute)
+app.route("/", federationRoute)
+app.route("/api/admin", adminRoute)
+app.route("/api/polls", pollsRoute)
+app.route("/api/scheduled-posts", scheduledPostsRoute)
+app.route("/api/lists", listsRoute)
+app.route("/api/connectors/github", githubConnectorRoute)
+app.route("/api/chess", chessRoute)
+app.route("/api/unfurl", unfurlRoute)
+app.route("/api/dev", devRoute)
 
-app.notFound((c) => c.json({ error: 'not_found' }, 404))
+app.notFound((c) => c.json({ error: "not_found" }, 404))
 app.onError((err, c) => {
   const rateLimited = handleRateLimitError(err, c)
   if (rateLimited) return rateLimited
-  ctx.log.error({ err: err instanceof Error ? err.stack ?? err.message : err, path: c.req.path }, 'unhandled_error')
-  return c.json({ error: 'internal_error', message: err.message }, 500)
+  ctx.log.error(
+    {
+      err: err instanceof Error ? (err.stack ?? err.message) : err,
+      path: c.req.path,
+    },
+    "unhandled_error"
+  )
+  return c.json({ error: "internal_error", message: err.message }, 500)
 })
 
 const port = ctx.env.PORT
-ctx.log.info({ port }, 'api_listening')
+ctx.log.info({ port }, "api_listening")
 export default { port, fetch: app.fetch }

--- a/apps/api/src/lib/env.ts
+++ b/apps/api/src/lib/env.ts
@@ -23,173 +23,206 @@ function optionalTrimmedString<T extends z.ZodTypeAny>(schema: T) {
   }, schema.optional())
 }
 
-const envSchema = z.object({
-  DATABASE_URL: z.string().url(),
-  BETTER_AUTH_SECRET: z.string().min(16),
-  BETTER_AUTH_URL: z.string().url().default("http://localhost:3001"),
-  AUTH_TRUSTED_ORIGINS: z
-    .string()
-    .default(DEFAULT_AUTH_TRUSTED_ORIGINS)
-    .transform((s) =>
-      s
-        .split(",")
-        .map((x) => x.trim())
-        .filter(Boolean)
+const envSchema = z
+  .object({
+    DATABASE_URL: z.string().url(),
+    BETTER_AUTH_SECRET: z.string().min(16),
+    BETTER_AUTH_URL: z.string().url().default("http://localhost:3001"),
+    AUTH_TRUSTED_ORIGINS: z
+      .string()
+      .default(DEFAULT_AUTH_TRUSTED_ORIGINS)
+      .transform((s) =>
+        s
+          .split(",")
+          .map((x) => x.trim())
+          .filter(Boolean)
+      ),
+    AUTH_COOKIE_DOMAIN: z.string().optional(),
+    // After switching to a wildcard AUTH_COOKIE_DOMAIN (e.g. `.ak2.dev`), stale host-only or
+    // old Domain=* cookies can duplicate session_token and break get-session when session_data
+    // expires (Better Auth #9233). When true, responses include Set-Cookie lines that expire
+    // those obsolete scopes. See middleware/legacy-auth-cookies.ts.
+    AUTH_LEGACY_AUTH_COOKIE_CLEANUP: z
+      .enum(["true", "false"])
+      .default("false")
+      .transform((v) => v === "true"),
+    // Optional comma list of legacy `Domain=` values to clear (e.g. `api.ak2.dev`) in addition
+    // to host-only cookies on the API host.
+    AUTH_LEGACY_COOKIE_DOMAINS: z
+      .string()
+      .optional()
+      .transform((s) => {
+        if (!s) return [] as string[]
+        return s
+          .split(",")
+          .map((x) => x.trim())
+          .filter(Boolean)
+      }),
+    PASSKEY_RP_ID: z.optional(
+      z.preprocess(
+        (v) => {
+          if (typeof v !== "string") return undefined
+          const t = v.trim()
+          return t.length === 0 ? undefined : t
+        },
+        z.union([z.string(), z.undefined()])
+      )
     ),
-  AUTH_COOKIE_DOMAIN: z.string().optional(),
-  PASSKEY_RP_ID: z.optional(
-    z.preprocess(
-      (v) => {
-        if (typeof v !== "string") return undefined
-        const t = v.trim()
-        return t.length === 0 ? undefined : t
-      },
-      z.union([z.string(), z.undefined()])
-    )
-  ),
 
-  PORT: z.coerce.number().default(3001),
-  NODE_ENV: z
-    .enum(["development", "test", "production"])
-    .default("development"),
-  LOG_LEVEL: z.string().default("info"),
+    PORT: z.coerce.number().default(3001),
+    NODE_ENV: z
+      .enum(["development", "test", "production"])
+      .default("development"),
+    LOG_LEVEL: z.string().default("info"),
 
-  PUBLIC_WEB_URL: z.string().url().default("http://localhost:3000"),
-  APP_NAME: z.string().default("twotter"),
+    PUBLIC_WEB_URL: z.string().url().default("http://localhost:3000"),
+    APP_NAME: z.string().default("twotter"),
 
-  EMAIL_FROM: z.string().default("twotter <noreply@localhost>"),
-  RESEND_API_KEY: z.string().optional(),
+    EMAIL_FROM: z.string().default("twotter <noreply@localhost>"),
+    RESEND_API_KEY: z.string().optional(),
 
-  GITHUB_CLIENT_ID: z.string().optional(),
-  GITHUB_CLIENT_SECRET: z.string().optional(),
-  GITLAB_CLIENT_ID: z.string().optional(),
-  GITLAB_CLIENT_SECRET: z.string().optional(),
-  GOOGLE_CLIENT_ID: z.string().optional(),
-  GOOGLE_CLIENT_SECRET: z.string().optional(),
+    GITHUB_CLIENT_ID: z.string().optional(),
+    GITHUB_CLIENT_SECRET: z.string().optional(),
+    GITLAB_CLIENT_ID: z.string().optional(),
+    GITLAB_CLIENT_SECRET: z.string().optional(),
+    GOOGLE_CLIENT_ID: z.string().optional(),
+    GOOGLE_CLIENT_SECRET: z.string().optional(),
 
-  // "Connect GitHub" OAuth App — separate from the login provider above so that linking your
-  // GitHub for profile display can never overwrite the token better-auth uses to log you in.
-  GITHUB_CONNECT_CLIENT_ID: z.string().optional(),
-  GITHUB_CONNECT_CLIENT_SECRET: z.string().optional(),
+    // "Connect GitHub" OAuth App — separate from the login provider above so that linking your
+    // GitHub for profile display can never overwrite the token better-auth uses to log you in.
+    GITHUB_CONNECT_CLIENT_ID: z.string().optional(),
+    GITHUB_CONNECT_CLIENT_SECRET: z.string().optional(),
 
-  // Shared GitHub PAT (or App installation token) used to enrich post cards for GitHub URLs.
-  // 5000 req/hr authenticated vs 60/hr unauthenticated — required to make the unfurl pipeline
-  // actually work. If unset, posts containing GitHub URLs render fine but without the card.
-  GITHUB_UNFURL_TOKEN: z.string().optional(),
+    // Shared GitHub PAT (or App installation token) used to enrich post cards for GitHub URLs.
+    // 5000 req/hr authenticated vs 60/hr unauthenticated — required to make the unfurl pipeline
+    // actually work. If unset, posts containing GitHub URLs render fine but without the card.
+    GITHUB_UNFURL_TOKEN: z.string().optional(),
 
-  // Comma-separated list of `owner/repo` GitHub repositories whose contributors should
-  // receive the contributor badge. Evaluated when a user connects their GitHub account or
-  // hits Refresh in Settings → Connections. Unset → contributor checks are skipped and the
-  // badge is only granted via admin override.
-  GITHUB_CONTRIBUTOR_REPOS: z
-    .string()
-    .optional()
-    .transform((s) => {
-      if (!s) return [] as string[]
-      return s
-        .split(",")
-        .map((x) => x.trim())
-        .filter((x) => /^[^/\s]+\/[^/\s]+$/.test(x))
-    }),
+    // Comma-separated list of `owner/repo` GitHub repositories whose contributors should
+    // receive the contributor badge. Evaluated when a user connects their GitHub account or
+    // hits Refresh in Settings → Connections. Unset → contributor checks are skipped and the
+    // badge is only granted via admin override.
+    GITHUB_CONTRIBUTOR_REPOS: z
+      .string()
+      .optional()
+      .transform((s) => {
+        if (!s) return [] as string[]
+        return s
+          .split(",")
+          .map((x) => x.trim())
+          .filter((x) => /^[^/\s]+\/[^/\s]+$/.test(x))
+      }),
 
-  YOUTUBE_API_KEY: z.string().optional(),
-  FXTWITTER_API_BASE_URL: z.string().optional(),
+    YOUTUBE_API_KEY: z.string().optional(),
+    FXTWITTER_API_BASE_URL: z.string().optional(),
 
-  // Symmetric key for at-rest encryption of connector OAuth tokens (oauth_connections table).
-  // Must be 32 raw bytes encoded as base64 — anything shorter is rejected at boot. Rotation
-  // story is versioned by the ciphertext prefix `v1:` (see lib/connector-crypto.ts).
-  CONNECTORS_ENCRYPTION_KEY: z
-    .string()
-    .optional()
-    .refine(
-      (v) => {
-        if (!v) return true
-        try {
-          return Buffer.from(v, "base64").length === 32
-        } catch {
-          return false
+    // Symmetric key for at-rest encryption of connector OAuth tokens (oauth_connections table).
+    // Must be 32 raw bytes encoded as base64 — anything shorter is rejected at boot. Rotation
+    // story is versioned by the ciphertext prefix `v1:` (see lib/connector-crypto.ts).
+    CONNECTORS_ENCRYPTION_KEY: z
+      .string()
+      .optional()
+      .refine(
+        (v) => {
+          if (!v) return true
+          try {
+            return Buffer.from(v, "base64").length === 32
+          } catch {
+            return false
+          }
+        },
+        {
+          message: "CONNECTORS_ENCRYPTION_KEY must decode to 32 bytes (base64)",
         }
-      },
-      { message: "CONNECTORS_ENCRYPTION_KEY must decode to 32 bytes (base64)" }
+      ),
+
+    REDIS_URL: z.string(),
+
+    S3_ENDPOINT: z.string().url(),
+    S3_REGION: z.string().default("auto"),
+    S3_ACCESS_KEY_ID: z.string(),
+    S3_SECRET_ACCESS_KEY: z.string(),
+    S3_BUCKET: z.string(),
+    S3_PUBLIC_URL: z.string().url(),
+
+    // How long signed S3 GET URLs minted by the /api/m/* proxy stay valid. Short TTL minimizes
+    // damage if a signed URL leaks (e.g. is accidentally pasted into chat or a referer log).
+    // Default 15min — long enough to survive a slow page load + image decode, short enough that
+    // the URL is dead before most leak vectors find it.
+    MEDIA_SIGNED_URL_TTL_SEC: z.coerce
+      .number()
+      .int()
+      .min(60)
+      .max(3600)
+      .default(900),
+
+    // Add HSTS header in production. Off by default for dev (where requests come over http://localhost).
+    // Enabling in prod opts the browser into HTTPS-only for this origin for 1 year, blocking
+    // downgrade attacks. Only set this once you are sure HTTPS is permanent for the domain.
+    ENABLE_HSTS: z
+      .enum(["true", "false"])
+      .default("false")
+      .transform((v) => v === "true"),
+
+    // Hard kill switch. When true, every request (except /healthz and /readyz) is short-circuited
+    // with a 503 + `{ error: "maintenance" }` so the app can be locked down at runtime without a
+    // redeploy when abuse is in progress. The client detects the 503 and renders a maintenance
+    // screen over the whole UI.
+    MAINTENANCE_MODE: z
+      .enum(["true", "false"])
+      .default("false")
+      .transform((v) => v === "true"),
+    // Human-readable banner shown on the maintenance screen. Kept on the server so it can be
+    // updated without a client redeploy.
+    MAINTENANCE_MESSAGE: z
+      .string()
+      .default("We're temporarily down for maintenance. Check back shortly."),
+
+    // Databuddy server-side analytics API key (format: dbdy_xxx). Optional — if unset,
+    // server-side event tracking is silently disabled.
+    DATABUDDY_API_KEY: z.string().optional(),
+    // Databuddy website/client ID — must match the VITE_PUBLIC_DATABUDDY_CLIENT_ID used
+    // on the frontend so server-side events are scoped to the same website.
+    DATABUDDY_WEBSITE_ID: z.string().optional(),
+
+    // OpenAI API key for the /v1/moderations endpoint used to pre-publish-screen posts.
+    // Optional — when unset, moderation is disabled and every post is accepted (with a
+    // one-time warning at boot). Network errors / timeouts also fail open. Whitespace
+    // is trimmed and empty strings are coerced to undefined so a misformatted env var
+    // (e.g. `OPENAI_API_KEY= `) is treated as unset rather than a bogus key.
+    OPENAI_API_KEY: z.optional(
+      z.preprocess(
+        (v) => {
+          if (typeof v !== "string") return v
+          const trimmed = v.trim()
+          return trimmed.length === 0 ? undefined : trimmed
+        },
+        z.union([z.string(), z.undefined()])
+      )
     ),
 
-  REDIS_URL: z.string(),
-
-  S3_ENDPOINT: z.string().url(),
-  S3_REGION: z.string().default("auto"),
-  S3_ACCESS_KEY_ID: z.string(),
-  S3_SECRET_ACCESS_KEY: z.string(),
-  S3_BUCKET: z.string(),
-  S3_PUBLIC_URL: z.string().url(),
-
-  // How long signed S3 GET URLs minted by the /api/m/* proxy stay valid. Short TTL minimizes
-  // damage if a signed URL leaks (e.g. is accidentally pasted into chat or a referer log).
-  // Default 15min — long enough to survive a slow page load + image decode, short enough that
-  // the URL is dead before most leak vectors find it.
-  MEDIA_SIGNED_URL_TTL_SEC: z.coerce
-    .number()
-    .int()
-    .min(60)
-    .max(3600)
-    .default(900),
-
-  // Add HSTS header in production. Off by default for dev (where requests come over http://localhost).
-  // Enabling in prod opts the browser into HTTPS-only for this origin for 1 year, blocking
-  // downgrade attacks. Only set this once you are sure HTTPS is permanent for the domain.
-  ENABLE_HSTS: z
-    .enum(["true", "false"])
-    .default("false")
-    .transform((v) => v === "true"),
-
-  // Hard kill switch. When true, every request (except /healthz and /readyz) is short-circuited
-  // with a 503 + `{ error: "maintenance" }` so the app can be locked down at runtime without a
-  // redeploy when abuse is in progress. The client detects the 503 and renders a maintenance
-  // screen over the whole UI.
-  MAINTENANCE_MODE: z
-    .enum(["true", "false"])
-    .default("false")
-    .transform((v) => v === "true"),
-  // Human-readable banner shown on the maintenance screen. Kept on the server so it can be
-  // updated without a client redeploy.
-  MAINTENANCE_MESSAGE: z
-    .string()
-    .default("We're temporarily down for maintenance. Check back shortly."),
-
-  // Databuddy server-side analytics API key (format: dbdy_xxx). Optional — if unset,
-  // server-side event tracking is silently disabled.
-  DATABUDDY_API_KEY: z.string().optional(),
-  // Databuddy website/client ID — must match the VITE_PUBLIC_DATABUDDY_CLIENT_ID used
-  // on the frontend so server-side events are scoped to the same website.
-  DATABUDDY_WEBSITE_ID: z.string().optional(),
-
-  // OpenAI API key for the /v1/moderations endpoint used to pre-publish-screen posts.
-  // Optional — when unset, moderation is disabled and every post is accepted (with a
-  // one-time warning at boot). Network errors / timeouts also fail open. Whitespace
-  // is trimmed and empty strings are coerced to undefined so a misformatted env var
-  // (e.g. `OPENAI_API_KEY= `) is treated as unset rather than a bogus key.
-  OPENAI_API_KEY: z.optional(
-    z.preprocess(
-      (v) => {
-        if (typeof v !== "string") return v
-        const trimmed = v.trim()
-        return trimmed.length === 0 ? undefined : trimmed
-      },
-      z.union([z.string(), z.undefined()])
-    )
-  ),
-
-  // Internal ranker service used by the For You feed. All three vars are optional so the API
-  // boots and serves every existing feed even when feed-ranker isn't deployed yet — in that
-  // case /api/feed/for-you transparently falls back to a blended chrono feed on page 1.
-  FEED_RANKER_URL: optionalTrimmedString(z.string().url()),
-  FEED_RANKER_TOKEN: optionalTrimmedString(z.string().min(16)),
-  // Hard ceiling on the ranker call. The product budget is roughly p95 < 120ms; we kill the
-  // request past that and fall back rather than letting a slow ranker drag the API timeline.
-  FEED_RANKER_TIMEOUT_MS: z.coerce.number().int().min(20).max(2000).default(120),
-}).refine((env) => Boolean(env.FEED_RANKER_URL) === Boolean(env.FEED_RANKER_TOKEN), {
-  message: "FEED_RANKER_URL and FEED_RANKER_TOKEN must be provided together",
-  path: ["FEED_RANKER_URL"],
-})
+    // Internal ranker service used by the For You feed. All three vars are optional so the API
+    // boots and serves every existing feed even when feed-ranker isn't deployed yet — in that
+    // case /api/feed/for-you transparently falls back to a blended chrono feed on page 1.
+    FEED_RANKER_URL: optionalTrimmedString(z.string().url()),
+    FEED_RANKER_TOKEN: optionalTrimmedString(z.string().min(16)),
+    // Hard ceiling on the ranker call. The product budget is roughly p95 < 120ms; we kill the
+    // request past that and fall back rather than letting a slow ranker drag the API timeline.
+    FEED_RANKER_TIMEOUT_MS: z.coerce
+      .number()
+      .int()
+      .min(20)
+      .max(2000)
+      .default(120),
+  })
+  .refine(
+    (env) => Boolean(env.FEED_RANKER_URL) === Boolean(env.FEED_RANKER_TOKEN),
+    {
+      message:
+        "FEED_RANKER_URL and FEED_RANKER_TOKEN must be provided together",
+      path: ["FEED_RANKER_URL"],
+    }
+  )
 
 export type Env = z.infer<typeof envSchema>
 

--- a/apps/api/src/middleware/legacy-auth-cookies.ts
+++ b/apps/api/src/middleware/legacy-auth-cookies.ts
@@ -34,6 +34,10 @@ function clearCookieHeader(name: string, domain?: string): string {
   return attrs.join("; ")
 }
 
+function normalizeCookieDomainScope(value: string): string {
+  return value.trim().toLowerCase().replace(/^\./, "")
+}
+
 function requestIsHttps(c: {
   req: { header: (n: string) => string | undefined; url: string }
 }): boolean {
@@ -43,10 +47,9 @@ function requestIsHttps(c: {
       .split(",")
       .map((t) => t.trim().toLowerCase())
       .filter(Boolean)
-    if (tokens.length > 0) {
-      if (tokens.some((t) => t === "https")) return true
-      if (tokens.some((t) => t === "http")) return false
-    }
+    const firstToken = tokens[0]
+    if (firstToken === "https") return true
+    if (firstToken === "http") return false
   }
   try {
     return new URL(c.req.url).protocol === "https:"
@@ -71,11 +74,13 @@ export function legacyAuthCookieCleanupMiddleware(
       c.header("Set-Cookie", clearCookieHeader(name), { append: true })
     }
 
-    const activeCookieDomain = env.AUTH_COOKIE_DOMAIN?.trim().toLowerCase()
+    const activeNormalized = env.AUTH_COOKIE_DOMAIN
+      ? normalizeCookieDomainScope(env.AUTH_COOKIE_DOMAIN)
+      : ""
     for (const domain of env.AUTH_LEGACY_COOKIE_DOMAINS) {
       if (
-        activeCookieDomain &&
-        domain.toLowerCase() === activeCookieDomain
+        activeNormalized &&
+        normalizeCookieDomainScope(domain) === activeNormalized
       ) {
         continue
       }

--- a/apps/api/src/middleware/legacy-auth-cookies.ts
+++ b/apps/api/src/middleware/legacy-auth-cookies.ts
@@ -1,0 +1,76 @@
+import type { MiddlewareHandler } from "hono"
+import { COOKIE_PREFIX } from "@workspace/auth/constants"
+import type { Env } from "../lib/env.ts"
+import type { HonoEnv } from "./session.ts"
+
+/**
+ * Names Better Auth sets under our cookiePrefix (see packages/auth/server.ts).
+ * When duplicate cookies exist (host-only vs Domain=.example.com), the browser sends both;
+ * Better Auth may resolve the wrong one after session_data expires (#9233-style failures).
+ *
+ * Emitting Max-Age=0 for obsolete scopes deletes stale jar entries; cookies scoped with
+ * AUTH_COOKIE_DOMAIN are different records and are not cleared by these lines.
+ */
+const BASE_AUTH_COOKIE_NAMES = [
+  "session_token",
+  "session_data",
+  "better-auth-passkey",
+  "dont_remember",
+] as const
+
+function cookieHeaderName(secureRequest: boolean, suffix: string): string {
+  const base = `${COOKIE_PREFIX}.${suffix}`
+  return secureRequest ? `__Secure-${base}` : base
+}
+
+function clearCookieHeader(name: string, domain?: string): string {
+  const attrs = [`${name}=`, "Path=/", "Max-Age=0", "HttpOnly", "SameSite=Lax"]
+  if (domain) {
+    attrs.push(`Domain=${domain}`)
+    attrs.push("Secure")
+  } else if (name.startsWith("__Secure-")) {
+    attrs.push("Secure")
+  }
+  return attrs.join("; ")
+}
+
+function requestIsHttps(c: {
+  req: { header: (n: string) => string | undefined; url: string }
+}): boolean {
+  const xf = c.req.header("x-forwarded-proto")
+  if (xf === "https") return true
+  if (xf === "http") return false
+  try {
+    return new URL(c.req.url).protocol === "https:"
+  } catch {
+    return false
+  }
+}
+
+export function legacyAuthCookieCleanupMiddleware(
+  env: Env
+): MiddlewareHandler<HonoEnv> {
+  return async (c, next) => {
+    await next()
+    if (!env.AUTH_LEGACY_AUTH_COOKIE_CLEANUP) return
+
+    const secureRequest = requestIsHttps(c)
+    const names = BASE_AUTH_COOKIE_NAMES.map((s) =>
+      cookieHeaderName(secureRequest, s)
+    )
+
+    for (const name of names) {
+      c.header("Set-Cookie", clearCookieHeader(name), { append: true })
+    }
+
+    for (const domain of env.AUTH_LEGACY_COOKIE_DOMAINS) {
+      const trimmed = domain.trim()
+      if (!trimmed) continue
+      for (const name of names) {
+        c.header("Set-Cookie", clearCookieHeader(name, trimmed), {
+          append: true,
+        })
+      }
+    }
+  }
+}

--- a/apps/api/src/middleware/legacy-auth-cookies.ts
+++ b/apps/api/src/middleware/legacy-auth-cookies.ts
@@ -64,10 +64,8 @@ export function legacyAuthCookieCleanupMiddleware(
     }
 
     for (const domain of env.AUTH_LEGACY_COOKIE_DOMAINS) {
-      const trimmed = domain.trim()
-      if (!trimmed) continue
       for (const name of names) {
-        c.header("Set-Cookie", clearCookieHeader(name, trimmed), {
+        c.header("Set-Cookie", clearCookieHeader(name, domain), {
           append: true,
         })
       }

--- a/apps/api/src/middleware/legacy-auth-cookies.ts
+++ b/apps/api/src/middleware/legacy-auth-cookies.ts
@@ -37,9 +37,17 @@ function clearCookieHeader(name: string, domain?: string): string {
 function requestIsHttps(c: {
   req: { header: (n: string) => string | undefined; url: string }
 }): boolean {
-  const xf = c.req.header("x-forwarded-proto")
-  if (xf === "https") return true
-  if (xf === "http") return false
+  const xf = c.req.header("x-forwarded-proto")?.trim()
+  if (xf) {
+    const tokens = xf
+      .split(",")
+      .map((t) => t.trim().toLowerCase())
+      .filter(Boolean)
+    if (tokens.length > 0) {
+      if (tokens.some((t) => t === "https")) return true
+      if (tokens.some((t) => t === "http")) return false
+    }
+  }
   try {
     return new URL(c.req.url).protocol === "https:"
   } catch {
@@ -63,7 +71,14 @@ export function legacyAuthCookieCleanupMiddleware(
       c.header("Set-Cookie", clearCookieHeader(name), { append: true })
     }
 
+    const activeCookieDomain = env.AUTH_COOKIE_DOMAIN?.trim().toLowerCase()
     for (const domain of env.AUTH_LEGACY_COOKIE_DOMAINS) {
+      if (
+        activeCookieDomain &&
+        domain.toLowerCase() === activeCookieDomain
+      ) {
+        continue
+      }
       for (const name of names) {
         c.header("Set-Cookie", clearCookieHeader(name, domain), {
           append: true,

--- a/apps/api/src/middleware/legacy-auth-cookies.ts
+++ b/apps/api/src/middleware/legacy-auth-cookies.ts
@@ -10,6 +10,9 @@ import type { HonoEnv } from "./session.ts"
  *
  * Emitting Max-Age=0 for obsolete scopes deletes stale jar entries; cookies scoped with
  * AUTH_COOKIE_DOMAIN are different records and are not cleared by these lines.
+ *
+ * Host-only expiry runs only when AUTH_COOKIE_DOMAIN is set — otherwise live sessions may be
+ * host-only and clearing them would log everyone out.
  */
 const BASE_AUTH_COOKIE_NAMES = [
   "session_token",
@@ -70,8 +73,10 @@ export function legacyAuthCookieCleanupMiddleware(
       cookieHeaderName(secureRequest, s)
     )
 
-    for (const name of names) {
-      c.header("Set-Cookie", clearCookieHeader(name), { append: true })
+    if (env.AUTH_COOKIE_DOMAIN?.trim()) {
+      for (const name of names) {
+        c.header("Set-Cookie", clearCookieHeader(name), { append: true })
+      }
     }
 
     const activeNormalized = env.AUTH_COOKIE_DOMAIN


### PR DESCRIPTION
## Summary

We debugged a real production foot-gun: **two `__Secure-twotter.session_token` cookies** in the same `Cookie` header, with **different `Domain` values** in Firefox (e.g. one row for **`api.ak2.dev`**, one for **`.ak2.dev`**). They are not duplicates in the “buggy JSON” sense — the browser stores **separate** cookies that happen to share a name when scopes differ over time (same class of issue as [better-auth#9233](https://github.com/better-auth/better-auth/issues/9233)).

**What actually happened in the request chain**

1. User signs in → `POST /api/auth/sign-in/email` responds with `Set-Cookie` using **`Domain=.ak2.dev`** (from `AUTH_COOKIE_DOMAIN`).
2. Later `GET /api/auth/get-session` sends **both** token values: an older **`Domain=api.ak2.dev`** token first, then the current **`.ak2.dev`** token.
3. While **`session_data`** (short cookie cache) is still valid, **`get-session`** can still look fine.
4. After **`session_data` expires** (or tab idle / no refresh), resolution hits the messy **`session_token`** path → **`get-session`** can return **`null`** → **`/api/me`** **401** → forced sign-out.

**Why sign-out didn’t fix it**

Sign-out only emitted clears like **`Domain=.ak2.dev`**. That **does not remove** a cookie stored under **`Domain=api.ak2.dev`**. So the “first” token in the header could survive indefinitely across login/logout cycles.

**What this PR adds**

Optional API middleware (default **off**) that attaches **`Set-Cookie`** lines with **`Max-Age=0`** for obsolete scopes: host-only clears plus whatever you list in **`AUTH_LEGACY_COOKIE_DOMAINS`** (for our case, **`api.ak2.dev`** matters alongside **`.ak2.dev`**).

## Test plan

- [x] `bun run typecheck`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional legacy authentication cookie cleanup to remove old auth cookies when enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->