### PR TITLE
Admin users list: filters (role, verified, contributor, email, bot, status)

### DIFF
--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -244,6 +244,11 @@ adminRoute.get("/online", async (c) => {
   })
 })
 
+const adminUserListBoolParam = z
+  .enum(["true", "false"])
+  .transform((v) => v === "true")
+  .optional()
+
 const listQuery = z.object({
   // Cap admin search input. Without a limit, an admin (or compromised admin session) can
   // ship a massive `q` and force the planner into a wildcard ilike scan. 80 chars matches
@@ -251,12 +256,30 @@ const listQuery = z.object({
   q: z.string().trim().max(80).optional(),
   cursor: z.string().max(40).optional(),
   limit: z.coerce.number().min(1).max(100).default(40),
+  role: z.enum(["user", "admin", "owner"]).optional(),
+  verified: adminUserListBoolParam,
+  contributor: adminUserListBoolParam,
+  emailVerified: adminUserListBoolParam,
+  bot: adminUserListBoolParam,
+  status: z
+    .enum(["active", "banned", "shadowbanned", "deleted"])
+    .optional(),
 })
 
 // List/search users. Cursor is the ISO timestamp of the previous page's last createdAt.
 adminRoute.get("/users", async (c) => {
   const { db, mediaEnv } = c.get("ctx")
-  const { q, cursor, limit } = listQuery.parse(c.req.query())
+  const {
+    q,
+    cursor,
+    limit,
+    role,
+    verified,
+    contributor,
+    emailVerified,
+    bot,
+    status,
+  } = listQuery.parse(c.req.query())
 
   const filters: Array<unknown> = []
   if (q) {
@@ -267,6 +290,29 @@ adminRoute.get("/users", async (c) => {
   }
   const parsedCursor = parseCursor(cursor)
   if (parsedCursor) filters.push(lt(schema.users.createdAt, parsedCursor))
+
+  if (role) filters.push(eq(schema.users.role, role))
+  if (verified !== undefined) filters.push(eq(schema.users.isVerified, verified))
+  if (contributor !== undefined)
+    filters.push(eq(schema.users.isContributor, contributor))
+  if (emailVerified !== undefined)
+    filters.push(eq(schema.users.emailVerified, emailVerified))
+  if (bot !== undefined) filters.push(eq(schema.users.isBot, bot))
+  if (status === "active") {
+    filters.push(
+      and(
+        eq(schema.users.banned, false),
+        isNull(schema.users.shadowBannedAt),
+        isNull(schema.users.deletedAt)
+      )
+    )
+  } else if (status === "banned") {
+    filters.push(eq(schema.users.banned, true))
+  } else if (status === "shadowbanned") {
+    filters.push(isNotNull(schema.users.shadowBannedAt))
+  } else if (status === "deleted") {
+    filters.push(isNotNull(schema.users.deletedAt))
+  }
 
   const rows = await db
     .select()
@@ -339,6 +385,7 @@ adminRoute.get("/users", async (c) => {
   const items = rows.map((u) => ({
     id: u.id,
     email: u.email,
+    emailVerified: u.emailVerified,
     handle: u.handle,
     displayName: u.displayName,
     avatarUrl: assetUrl(mediaEnv, u.avatarUrl),
@@ -348,6 +395,7 @@ adminRoute.get("/users", async (c) => {
     banExpires: u.banExpires?.toISOString() ?? null,
     shadowBannedAt: u.shadowBannedAt?.toISOString() ?? null,
     isVerified: u.isVerified,
+    isBot: u.isBot,
     isContributor: u.isContributor,
     contributorCheckedAt: u.contributorCheckedAt?.toISOString() ?? null,
     deletedAt: u.deletedAt?.toISOString() ?? null,
@@ -453,6 +501,7 @@ adminRoute.get("/users/:id", async (c) => {
     user: {
       id: user.id,
       email: user.email,
+      emailVerified: user.emailVerified,
       handle: user.handle,
       displayName: user.displayName,
       bio: user.bio,
@@ -464,6 +513,7 @@ adminRoute.get("/users/:id", async (c) => {
       banExpires: user.banExpires?.toISOString() ?? null,
       shadowBannedAt: user.shadowBannedAt?.toISOString() ?? null,
       isVerified: user.isVerified,
+      isBot: user.isBot,
       isContributor: user.isContributor,
       contributorCheckedAt: user.contributorCheckedAt?.toISOString() ?? null,
       deletedAt: user.deletedAt?.toISOString() ?? null,

--- a/apps/web/src/components/admin/filter-field.tsx
+++ b/apps/web/src/components/admin/filter-field.tsx
@@ -1,0 +1,18 @@
+import type { ReactNode } from "react"
+
+export function FilterField({
+  label,
+  children,
+}: {
+  label: string
+  children: ReactNode
+}) {
+  return (
+    <div className="flex flex-col gap-1">
+      <span className="text-[10px] font-semibold tracking-wider text-tertiary uppercase">
+        {label}
+      </span>
+      {children}
+    </div>
+  )
+}

--- a/apps/web/src/components/admin/posts.tsx
+++ b/apps/web/src/components/admin/posts.tsx
@@ -46,6 +46,7 @@ import { useInfiniteScrollSentinel } from "../../lib/use-infinite-scroll-sentine
 import { PageError, PageLoading } from "../page-surface"
 import { PageFrame } from "../page-frame"
 import { VerifiedBadge, resolveBadgeTier } from "../verified-badge"
+import { FilterField } from "./filter-field"
 import type { AdminPostFilters } from "../../lib/query-keys"
 import type { ColumnDef } from "@tanstack/react-table"
 import type { AdminPost, AdminPostSort, AdminPostType } from "../../lib/api"
@@ -701,23 +702,6 @@ export default function AdminPosts() {
         }}
       />
     </PageFrame>
-  )
-}
-
-function FilterField({
-  label,
-  children,
-}: {
-  label: string
-  children: React.ReactNode
-}) {
-  return (
-    <div className="flex flex-col gap-1">
-      <span className="text-[10px] font-semibold tracking-wider text-tertiary uppercase">
-        {label}
-      </span>
-      {children}
-    </div>
   )
 }
 

--- a/apps/web/src/components/admin/users.tsx
+++ b/apps/web/src/components/admin/users.tsx
@@ -24,6 +24,13 @@ import { DropdownMenu } from "@workspace/ui/components/dropdown-menu"
 import { Input } from "@workspace/ui/components/input"
 import { Label } from "@workspace/ui/components/label"
 import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@workspace/ui/components/select"
+import {
   Sheet,
   SheetContent,
   SheetDescription,
@@ -51,11 +58,22 @@ import { useMe } from "../../lib/me"
 import { PageError, PageLoading } from "../page-surface"
 import { PageFrame } from "../page-frame"
 import { VerifiedBadge, resolveBadgeTier } from "../verified-badge"
+import { FilterField } from "./filter-field"
 import type { ColumnDef } from "@tanstack/react-table"
 import type { AdminUser } from "../../lib/api"
+import type { AdminUsersFilters } from "../../lib/query-keys"
 
 type Role = "user" | "admin" | "owner"
 const ROLES: Array<Role> = ["user", "admin", "owner"]
+
+type AdminUsersRoleFilter = "any" | Role
+type TriBoolFilter = "any" | "true" | "false"
+type AdminUserStatusFilter =
+  | "any"
+  | "active"
+  | "banned"
+  | "shadowbanned"
+  | "deleted"
 
 type ActionDialogState =
   | { kind: "ban"; user: AdminUser }
@@ -97,9 +115,61 @@ export default function AdminUsers() {
     return () => clearTimeout(t)
   }, [q])
 
+  const [roleFilter, setRoleFilter] = useState<AdminUsersRoleFilter>("any")
+  const [verifiedFilter, setVerifiedFilter] = useState<TriBoolFilter>("any")
+  const [contributorFilter, setContributorFilter] =
+    useState<TriBoolFilter>("any")
+  const [emailVerifiedFilter, setEmailVerifiedFilter] =
+    useState<TriBoolFilter>("any")
+  const [botFilter, setBotFilter] = useState<TriBoolFilter>("any")
+  const [statusFilter, setStatusFilter] = useState<AdminUserStatusFilter>("any")
+
   const filters = useMemo(
-    () => ({ q: debouncedQ.trim() || undefined }),
-    [debouncedQ]
+    (): AdminUsersFilters => ({
+      q: debouncedQ.trim() || undefined,
+      role: roleFilter === "any" ? undefined : roleFilter,
+      verified:
+        verifiedFilter === "any" ? undefined : verifiedFilter === "true",
+      contributor:
+        contributorFilter === "any" ? undefined : contributorFilter === "true",
+      emailVerified:
+        emailVerifiedFilter === "any"
+          ? undefined
+          : emailVerifiedFilter === "true",
+      bot: botFilter === "any" ? undefined : botFilter === "true",
+      status: statusFilter === "any" ? undefined : statusFilter,
+    }),
+    [
+      debouncedQ,
+      roleFilter,
+      verifiedFilter,
+      contributorFilter,
+      emailVerifiedFilter,
+      botFilter,
+      statusFilter,
+    ]
+  )
+
+  const hasActiveFilters = useMemo(
+    () =>
+      Boolean(
+        debouncedQ.trim() ||
+        roleFilter !== "any" ||
+        verifiedFilter !== "any" ||
+        contributorFilter !== "any" ||
+        emailVerifiedFilter !== "any" ||
+        botFilter !== "any" ||
+        statusFilter !== "any"
+      ),
+    [
+      debouncedQ,
+      roleFilter,
+      verifiedFilter,
+      contributorFilter,
+      emailVerifiedFilter,
+      botFilter,
+      statusFilter,
+    ]
   )
 
   const {
@@ -111,7 +181,8 @@ export default function AdminUsers() {
     hasNextPage,
   } = useInfiniteQuery({
     queryKey: qk.admin.users(filters),
-    queryFn: ({ pageParam }) => api.adminUsers(filters.q, pageParam),
+    queryFn: ({ pageParam }) =>
+      api.adminUsers({ ...filters, cursor: pageParam }),
     initialPageParam: undefined as string | undefined,
     getNextPageParam: (last) => last.nextCursor ?? undefined,
   })
@@ -525,16 +596,116 @@ export default function AdminUsers() {
 
   return (
     <PageFrame width="full" className="flex flex-col">
-      <div className="shrink-0 border-b border-neutral p-4">
+      <div className="shrink-0 space-y-3 border-b border-neutral p-4">
         <Input
           value={q}
           onChange={(e) => setQ(e.target.value)}
           placeholder="search by handle or email…"
         />
+        <div className="flex flex-wrap items-end gap-3">
+          <FilterField label="Role">
+            <Select
+              value={roleFilter}
+              onValueChange={(v) => setRoleFilter(v as AdminUsersRoleFilter)}
+            >
+              <SelectTrigger size="sm" className="h-8 w-36">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="any">Any</SelectItem>
+                <SelectItem value="user">User</SelectItem>
+                <SelectItem value="admin">Admin</SelectItem>
+                <SelectItem value="owner">Owner</SelectItem>
+              </SelectContent>
+            </Select>
+          </FilterField>
+          <FilterField label="Verified">
+            <Select
+              value={verifiedFilter}
+              onValueChange={(v) => setVerifiedFilter(v as TriBoolFilter)}
+            >
+              <SelectTrigger size="sm" className="h-8 w-40">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="any">Any</SelectItem>
+                <SelectItem value="true">Verified</SelectItem>
+                <SelectItem value="false">Not verified</SelectItem>
+              </SelectContent>
+            </Select>
+          </FilterField>
+          <FilterField label="Contributor">
+            <Select
+              value={contributorFilter}
+              onValueChange={(v) => setContributorFilter(v as TriBoolFilter)}
+            >
+              <SelectTrigger size="sm" className="h-8 w-44">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="any">Any</SelectItem>
+                <SelectItem value="true">Contributor</SelectItem>
+                <SelectItem value="false">Not contributor</SelectItem>
+              </SelectContent>
+            </Select>
+          </FilterField>
+          <FilterField label="Email">
+            <Select
+              value={emailVerifiedFilter}
+              onValueChange={(v) => setEmailVerifiedFilter(v as TriBoolFilter)}
+            >
+              <SelectTrigger size="sm" className="h-8 w-44">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="any">Any</SelectItem>
+                <SelectItem value="true">Verified</SelectItem>
+                <SelectItem value="false">Not verified</SelectItem>
+              </SelectContent>
+            </Select>
+          </FilterField>
+          <FilterField label="Bot">
+            <Select
+              value={botFilter}
+              onValueChange={(v) => setBotFilter(v as TriBoolFilter)}
+            >
+              <SelectTrigger size="sm" className="h-8 w-32">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="any">Any</SelectItem>
+                <SelectItem value="true">Bot</SelectItem>
+                <SelectItem value="false">Human</SelectItem>
+              </SelectContent>
+            </Select>
+          </FilterField>
+          <FilterField label="Status">
+            <Select
+              value={statusFilter}
+              onValueChange={(v) => setStatusFilter(v as AdminUserStatusFilter)}
+            >
+              <SelectTrigger size="sm" className="h-8 w-40">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="any">Any</SelectItem>
+                <SelectItem value="active">Active</SelectItem>
+                <SelectItem value="banned">Banned</SelectItem>
+                <SelectItem value="shadowbanned">Shadowbanned</SelectItem>
+                <SelectItem value="deleted">Deleted</SelectItem>
+              </SelectContent>
+            </Select>
+          </FilterField>
+        </div>
       </div>
       {loadError && <PageError message={loadError} />}
       {isPending && users.length === 0 && (
         <PageLoading className="py-8" label="Loading…" />
+      )}
+      {!isPending && users.length === 0 && !loadError && (
+        <div className="py-8 text-center text-xs text-tertiary">
+          {hasActiveFilters ? "No users match these filters." : "No users yet."}
+        </div>
       )}
       {users.length > 0 && (
         <div ref={setScrollRoot} className="flex-1">

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -59,6 +59,17 @@ const h = (handle: string) => handle.replace(/^@/, "")
 const qs = (cursor?: string) =>
   cursor ? `?cursor=${encodeURIComponent(cursor)}` : ""
 
+export type AdminUsersListQuery = {
+  q?: string
+  cursor?: string
+  role?: "user" | "admin" | "owner"
+  verified?: boolean
+  contributor?: boolean
+  emailVerified?: boolean
+  bot?: boolean
+  status?: "active" | "banned" | "shadowbanned" | "deleted"
+}
+
 export const api = {
   me: () => request<{ user: SelfUser }>("/api/me"),
   updateMe: (body: Partial<SelfUser>) =>
@@ -447,10 +458,19 @@ export const api = {
 
   adminStats: () => request<AdminStats>(`/api/admin/stats`),
   adminOnline: () => request<AdminOnline>(`/api/admin/online`),
-  adminUsers: (q?: string, cursor?: string) => {
+  adminUsers: (opts: AdminUsersListQuery) => {
     const params = new URLSearchParams()
-    if (q) params.set("q", q)
-    if (cursor) params.set("cursor", cursor)
+    if (opts.q) params.set("q", opts.q)
+    if (opts.cursor) params.set("cursor", opts.cursor)
+    if (opts.role) params.set("role", opts.role)
+    if (opts.verified !== undefined)
+      params.set("verified", opts.verified ? "true" : "false")
+    if (opts.contributor !== undefined)
+      params.set("contributor", opts.contributor ? "true" : "false")
+    if (opts.emailVerified !== undefined)
+      params.set("emailVerified", opts.emailVerified ? "true" : "false")
+    if (opts.bot !== undefined) params.set("bot", opts.bot ? "true" : "false")
+    if (opts.status) params.set("status", opts.status)
     return request<{ users: Array<AdminUser>; nextCursor: string | null }>(
       `/api/admin/users${params.toString() ? `?${params.toString()}` : ""}`
     )
@@ -1264,6 +1284,7 @@ export interface AdminPost {
 export interface AdminUser {
   id: string
   email: string
+  emailVerified: boolean
   handle: string | null
   displayName: string | null
   avatarUrl: string | null
@@ -1273,6 +1294,7 @@ export interface AdminUser {
   banExpires: string | null
   shadowBannedAt: string | null
   isVerified: boolean
+  isBot: boolean
   isContributor: boolean
   contributorCheckedAt: string | null
   deletedAt: string | null

--- a/apps/web/src/lib/query-keys.ts
+++ b/apps/web/src/lib/query-keys.ts
@@ -1,3 +1,5 @@
+import type { AdminUsersListQuery } from "./api"
+
 export type FeedTabKey = "following" | "network" | "all" | "forYou"
 
 export type AdminPostFilters = {
@@ -10,10 +12,7 @@ export type AdminPostFilters = {
   status?: string
 }
 
-export type AdminUsersFilters = {
-  q?: string
-  cursor?: string
-}
+export type AdminUsersFilters = Omit<AdminUsersListQuery, "cursor">
 
 export const qk = {
   me: () => ["me"] as const,


### PR DESCRIPTION
## Summary

- Extend `GET /api/admin/users` with optional query filters (role, verified, contributor, emailVerified, bot, status) that combine with AND, plus expose `emailVerified` and `isBot` on list/detail JSON.
- Add admin Users tab toolbar filters (same `FilterField` + `Select` pattern as posts admin) and shared `filter-field.tsx`.

## Test plan

- [x] `bun run typecheck` passes
- [ ] Manually exercised the affected flow in the browser
- [ ] No new console errors / network errors

## Notes

- Web production build was previously failing on an unrelated `@/components/page-surface` resolve in `invite.$token.tsx`; not introduced here.
- If an older PR used `mobile-app` as the head branch, close it and use this branch instead—the PR diff is `main...head`, so `mobile-app` would show all mobile-app commits, not just this change.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Admin users list now supports advanced filtering by role, verification status, contributor status, email verification, bot status, and account status (active, banned, shadowbanned, deleted).
  * User information displays email verification and bot account indicators.
  * Admin interface includes multi-select filter controls with contextual empty-state messaging.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/twitbruv/twitbruv/pull/161?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->